### PR TITLE
Fix: address #2358

### DIFF
--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -49,6 +49,8 @@ use util::vrf::{VRFPrivateKey, VRFPublicKey, VRF};
 
 use chainstate::stacks::index::storage::TrieFileStorage;
 
+use core::*;
+
 // return type from parse_data below
 struct ParsedData {
     block_header_hash: BlockHeaderHash,
@@ -685,7 +687,10 @@ impl LeaderBlockCommitOp {
                 return Err(op_error::BlockCommitBadModulus);
             }
             let intended_sortition = tx
-                .get_ancestor_block_hash(self.block_height - miss_distance, &tx_tip)?
+                .get_ancestor_block_hash(
+                    self.block_height - BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT,
+                    &tx_tip,
+                )?
                 .ok_or_else(|| op_error::BlockCommitNoParent)?;
             let missed_data = MissedBlockCommit {
                 input: self.input.clone(),
@@ -1423,7 +1428,7 @@ mod tests {
 
     #[test]
     fn test_check() {
-        let first_block_height = 121;
+        let first_block_height = BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 121;
         let first_burn_hash = BurnchainHeaderHash::from_hex(
             "0000000000000000000000000000000000000000000000000000000000000123",
         )
@@ -1674,7 +1679,7 @@ mod tests {
             prev_snapshot.index_root.clone()
         };
 
-        let block_height = 124;
+        let block_height = BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124;
 
         let fixtures = vec![
             CheckFixture {
@@ -1771,8 +1776,10 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 444,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125)
+                        % BURN_BLOCK_MINED_AT_MODULUS)
+                        as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Err(op_error::BlockCommitNoLeaderKey),
@@ -1821,8 +1828,10 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 445,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125)
+                        % BURN_BLOCK_MINED_AT_MODULUS)
+                        as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Err(op_error::BlockCommitNoParent),
@@ -1845,9 +1854,9 @@ mod tests {
                         .unwrap(),
                     )
                     .unwrap(),
-                    parent_block_ptr: 126,
+                    parent_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
                     parent_vtxindex: 444,
-                    key_block_ptr: 124,
+                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124,
                     key_vtxindex: 457,
                     memo: vec![0x80],
                     commit_outs: vec![],
@@ -1871,8 +1880,10 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 445,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125)
+                        % BURN_BLOCK_MINED_AT_MODULUS)
+                        as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Err(op_error::BlockCommitNoParent),
@@ -1895,9 +1906,9 @@ mod tests {
                         .unwrap(),
                     )
                     .unwrap(),
-                    parent_block_ptr: 125,
+                    parent_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125,
                     parent_vtxindex: 444,
-                    key_block_ptr: 124,
+                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124,
                     key_vtxindex: 457,
                     memo: vec![0x80],
                     commit_outs: vec![],
@@ -1921,8 +1932,10 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 445,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125)
+                        % BURN_BLOCK_MINED_AT_MODULUS)
+                        as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Ok(()),
@@ -1945,9 +1958,9 @@ mod tests {
                         .unwrap(),
                     )
                     .unwrap(),
-                    parent_block_ptr: 125,
+                    parent_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125,
                     parent_vtxindex: 444,
-                    key_block_ptr: 124,
+                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124,
                     key_vtxindex: 457,
                     memo: vec![0x80],
                     commit_outs: vec![],
@@ -1971,8 +1984,8 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 445,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Err(op_error::BlockCommitBadInput),
@@ -1995,9 +2008,9 @@ mod tests {
                         .unwrap(),
                     )
                     .unwrap(),
-                    parent_block_ptr: 125,
+                    parent_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125,
                     parent_vtxindex: 444,
-                    key_block_ptr: 124,
+                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124,
                     key_vtxindex: 457,
                     memo: vec![0x80],
                     commit_outs: vec![],
@@ -2021,8 +2034,8 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 445,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Ok(()),
@@ -2047,7 +2060,7 @@ mod tests {
                     .unwrap(),
                     parent_block_ptr: 0,
                     parent_vtxindex: 0,
-                    key_block_ptr: 124,
+                    key_block_ptr: (BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124) as u32,
                     key_vtxindex: 457,
                     memo: vec![0x80],
                     commit_outs: vec![],
@@ -2071,8 +2084,8 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 445,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Ok(()),
@@ -2097,7 +2110,7 @@ mod tests {
                     .unwrap(),
                     parent_block_ptr: 0,
                     parent_vtxindex: 0,
-                    key_block_ptr: 124,
+                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 124,
                     key_vtxindex: 456,
                     memo: vec![0x80],
                     commit_outs: vec![],
@@ -2121,8 +2134,8 @@ mod tests {
                     )
                     .unwrap(),
                     vtxindex: 444,
-                    block_height: 126,
-                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 126,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125) % BURN_BLOCK_MINED_AT_MODULUS) as u8,
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Ok(()),

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1469,7 +1469,15 @@ mod tests {
         ];
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 5000, BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 10000),
+            pox_constants: PoxConstants::new(
+                6,
+                2,
+                2,
+                25,
+                5,
+                BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 5000,
+                BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 10000,
+            ),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -2044,66 +2052,6 @@ mod tests {
                 res: Err(op_error::BlockCommitBadInput),
             },
             CheckFixture {
-                // reject -- missed block commit
-                op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
-                    block_header_hash: BlockHeaderHash::from_bytes(
-                        &hex_bytes(
-                            "2222222222222222222222222222222222222222222222222222222222222222",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
-                    new_seed: VRFSeed::from_bytes(
-                        &hex_bytes(
-                            "3333333333333333333333333333333333333333333333333333333333333333",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
-                    parent_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT as u32 + 125,
-                    parent_vtxindex: 444,
-                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT as u32 + 124,
-                    key_vtxindex: 457,
-                    memo: vec![0x80],
-                    commit_outs: vec![],
-
-                    burn_fee: 12345,
-                    input: (Txid([0; 32]), 0),
-                    apparent_sender: BurnchainSigner {
-                        public_keys: vec![StacksPublicKey::from_hex(
-                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
-                        )
-                        .unwrap()],
-                        num_sigs: 1,
-                        hash_mode: AddressHashMode::SerializeP2PKH,
-                    },
-
-                    txid: Txid::from_bytes_be(
-                        &hex_bytes(
-                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
-                    vtxindex: 445,
-                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 127,
-                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125)
-                        % BURN_BLOCK_MINED_AT_MODULUS)
-                        as u8,
-                    burn_header_hash: block_126_hash.clone(),
-                },
-                res: Err(op_error::MissedBlockCommit(MissedBlockCommit{input: (Txid([0; 32]), 0),
-                     intended_sortition: SortitionId([0; 32]),
-                      txid:Txid::from_bytes_be(
-                        &hex_bytes(
-                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap() })),
-            },
-            CheckFixture {
                 // accept -- consumes leader_key_2
                 op: LeaderBlockCommitOp {
                     sunset_burn: 0,
@@ -2258,6 +2206,58 @@ mod tests {
                     burn_header_hash: block_126_hash.clone(),
                 },
                 res: Ok(()),
+            },
+            CheckFixture {
+                // reject -- missed block commit
+                op: LeaderBlockCommitOp {
+                    sunset_burn: 0,
+                    block_header_hash: BlockHeaderHash::from_bytes(
+                        &hex_bytes(
+                            "2222222222222222222222222222222222222222222222222222222222222222",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    new_seed: VRFSeed::from_bytes(
+                        &hex_bytes(
+                            "3333333333333333333333333333333333333333333333333333333333333333",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    parent_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT as u32 + 125,
+                    parent_vtxindex: 444,
+                    key_block_ptr: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT as u32 + 122,
+                    key_vtxindex: 457,
+                    memo: vec![0x80],
+                    commit_outs: vec![],
+
+                    burn_fee: 12345,
+                    input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
+
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    vtxindex: 445,
+                    block_height: BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 127,
+                    burn_parent_modulus: ((BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + 125)
+                        % BURN_BLOCK_MINED_AT_MODULUS)
+                        as u8,
+                    burn_header_hash: block_127_hash.clone(),
+                },
+                res: Err(op_error::BlockCommitNoParent), // because of missing sortition db
             },
         ];
 


### PR DESCRIPTION
## Description

SIP-007 describes that the smoothing function takes the previous 6 bitcoin commits as burn samples.
However, the current implementation tries to use a block that in most cases is in the future.

This PR fixes this by using the block as described in SIP-007
For details refer to issue #2358 

TODOs:
* Integration test to cover the error `MissedBlockCommit` needs to be added
* Does this require a new SIP?
* ~~Should be rebased to `blockstack:next` after #2373 merged~~

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Consensus breaking

## Are documentation updates required?
No

## Testing information
* Run unit tests (only covering parts of the changed code)

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kantai 
