### PR TITLE
Feat/add stacks height http header

### DIFF
--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -742,8 +742,10 @@ impl<
                                                 &event_data.value,
                                                 &contract_id,
                                                 block_receipt.header.index_block_hash(),
-                                                block_receipt.header.block_height,
+                                                block_receipt.header.stacks_block_height,
                                                 receipt.transaction.txid(),
+                                                new_canonical_block_snapshot
+                                                    .canonical_stacks_tip_height,
                                             );
                                             if let Some(attachment_instance) = res {
                                                 attachments_instances.insert(attachment_instance);
@@ -791,7 +793,7 @@ impl<
                         {
                             warn!("FeeEstimator failed to process block receipt";
                                   "stacks_block" => %block_hash,
-                                  "stacks_height" => %block_receipt.header.block_height,
+                                  "stacks_height" => %block_receipt.header.stacks_block_height,
                                   "error" => %e);
                         }
                     }

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -744,8 +744,10 @@ impl<
                                                 block_receipt.header.index_block_hash(),
                                                 block_receipt.header.stacks_block_height,
                                                 receipt.transaction.txid(),
-                                                new_canonical_block_snapshot
-                                                    .canonical_stacks_tip_height,
+                                                Some(
+                                                    new_canonical_block_snapshot
+                                                        .canonical_stacks_tip_height,
+                                                ),
                                             );
                                             if let Some(attachment_instance) = res {
                                                 attachments_instances.insert(attachment_instance);

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -472,11 +472,11 @@ impl StacksChainState {
         tx: &mut StacksDBTx<'a>,
         tip: &StacksHeaderInfo,
     ) -> Result<Vec<MinerPaymentSchedule>, Error> {
-        if tip.block_height < MINER_REWARD_MATURITY {
+        if tip.stacks_block_height < MINER_REWARD_MATURITY {
             return Ok(vec![]);
         }
 
-        let block_height = tip.block_height - MINER_REWARD_MATURITY;
+        let block_height = tip.stacks_block_height - MINER_REWARD_MATURITY;
         StacksChainState::get_scheduled_block_rewards_in_fork_at_height(tx, tip, block_height)
     }
 
@@ -669,12 +669,12 @@ impl StacksChainState {
         parent_miner: MinerPaymentSchedule,
     ) -> Result<Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>, Error> {
         let mainnet = clarity_tx.config.mainnet;
-        if tip.block_height <= MINER_REWARD_MATURITY {
+        if tip.stacks_block_height <= MINER_REWARD_MATURITY {
             // no mature rewards exist
             return Ok(None);
         }
 
-        let reward_height = tip.block_height - MINER_REWARD_MATURITY;
+        let reward_height = tip.stacks_block_height - MINER_REWARD_MATURITY;
 
         assert!(latest_matured_miners.len() > 0);
         assert!(latest_matured_miners[0].vtxindex == 0);
@@ -829,7 +829,7 @@ mod test {
         new_tip.anchored_header.total_work.work =
             parent_header_info.anchored_header.total_work.work + 1;
         new_tip.microblock_tail = None;
-        new_tip.block_height = parent_header_info.block_height + 1;
+        new_tip.stacks_block_height = parent_header_info.stacks_block_height + 1;
         new_tip.consensus_hash = ConsensusHash(
             Hash160::from_data(
                 &Sha512Trunc256Sum::from_data(&parent_header_info.consensus_hash.0).0,
@@ -926,8 +926,8 @@ mod test {
 
             assert!(ancestor_1.is_some());
             assert!(ancestor_0.is_some());
-            assert_eq!(ancestor_0.unwrap().block_height, 0); // block 0 is the boot block
-            assert_eq!(ancestor_1.unwrap().block_height, 1);
+            assert_eq!(ancestor_0.unwrap().stacks_block_height, 0); // block 0 is the boot block
+            assert_eq!(ancestor_1.unwrap().stacks_block_height, 1);
         }
 
         let tip = advance_tip(&mut chainstate, &parent_tip, &mut tip_reward, &mut vec![]);
@@ -939,11 +939,11 @@ mod test {
             let ancestor_0 = StacksChainState::get_tip_ancestor(&mut tx, &tip, 0).unwrap();
 
             assert!(ancestor_2.is_some());
-            assert_eq!(ancestor_2.unwrap().block_height, 2);
+            assert_eq!(ancestor_2.unwrap().stacks_block_height, 2);
             assert!(ancestor_1.is_some());
-            assert_eq!(ancestor_1.unwrap().block_height, 1);
+            assert_eq!(ancestor_1.unwrap().stacks_block_height, 1);
             assert!(ancestor_0.is_some());
-            assert_eq!(ancestor_0.unwrap().block_height, 0); // block 0 is the boot block
+            assert_eq!(ancestor_0.unwrap().stacks_block_height, 0); // block 0 is the boot block
         }
     }
 

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -120,7 +120,7 @@ impl StacksChainState {
         anchored_block_cost: &ExecutionCost,
     ) -> Result<(), Error> {
         assert_eq!(
-            tip_info.block_height,
+            tip_info.stacks_block_height,
             tip_info.anchored_header.total_work.work
         );
         assert!(tip_info.burn_header_timestamp < i64::MAX as u64);
@@ -129,7 +129,7 @@ impl StacksChainState {
         let index_root = &tip_info.index_root;
         let consensus_hash = &tip_info.consensus_hash;
         let burn_header_hash = &tip_info.burn_header_hash;
-        let block_height = tip_info.block_height;
+        let block_height = tip_info.stacks_block_height;
         let burn_header_height = tip_info.burn_header_height;
         let burn_header_timestamp = tip_info.burn_header_timestamp;
 
@@ -254,7 +254,7 @@ impl StacksChainState {
         tip: &StacksHeaderInfo,
         height: u64,
     ) -> Result<Option<StacksHeaderInfo>, Error> {
-        assert!(tip.block_height >= height);
+        assert!(tip.stacks_block_height >= height);
         StacksChainState::get_index_tip_ancestor(tx, &tip.index_block_hash(), height)
     }
 
@@ -284,7 +284,7 @@ impl StacksChainState {
         let mut ancestors = vec![];
         let mut ancestry_cursor = Some(upper_bound_header);
         while let Some(cursor) = ancestry_cursor.take() {
-            if cursor.block_height < lower_bound_height {
+            if cursor.stacks_block_height < lower_bound_height {
                 break;
             }
             let block_id = cursor.index_block_hash();

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -139,7 +139,7 @@ pub struct MinerPaymentSchedule {
 pub struct StacksHeaderInfo {
     pub anchored_header: StacksBlockHeader,
     pub microblock_tail: Option<StacksMicroblockHeader>,
-    pub block_height: u64, // block height on Stacks chain
+    pub stacks_block_height: u64,
     pub index_root: TrieHash,
     pub consensus_hash: ConsensusHash,
     pub burn_header_hash: BurnchainHeaderHash,
@@ -199,7 +199,7 @@ impl StacksHeaderInfo {
         StacksHeaderInfo {
             anchored_header: StacksBlockHeader::genesis_block_header(),
             microblock_tail: None,
-            block_height: 0,
+            stacks_block_height: 0,
             index_root: TrieHash([0u8; 32]),
             burn_header_hash: burnchain_params.first_block_hash.clone(),
             burn_header_height: burnchain_params.first_block_height as u32,
@@ -218,7 +218,7 @@ impl StacksHeaderInfo {
         StacksHeaderInfo {
             anchored_header: StacksBlockHeader::genesis_block_header(),
             microblock_tail: None,
-            block_height: 0,
+            stacks_block_height: 0,
             index_root: root_hash,
             burn_header_hash: first_burnchain_block_hash.clone(),
             burn_header_height: first_burnchain_block_height,
@@ -271,7 +271,7 @@ impl FromRow<StacksHeaderInfo> for StacksHeaderInfo {
         Ok(StacksHeaderInfo {
             anchored_header: stacks_header,
             microblock_tail: None,
-            block_height,
+            stacks_block_height: block_height,
             index_root,
             consensus_hash,
             burn_header_hash,
@@ -2138,7 +2138,7 @@ impl StacksChainState {
             anchored_header: new_tip.clone(),
             microblock_tail: microblock_tail_opt,
             index_root: root_hash,
-            block_height: new_tip.total_work.work,
+            stacks_block_height: new_tip.total_work.work,
             consensus_hash: new_consensus_hash.clone(),
             burn_header_hash: new_burn_header_hash.clone(),
             burn_header_height: new_burnchain_height,

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -139,7 +139,7 @@ pub struct MinerPaymentSchedule {
 pub struct StacksHeaderInfo {
     pub anchored_header: StacksBlockHeader,
     pub microblock_tail: Option<StacksMicroblockHeader>,
-    pub block_height: u64,
+    pub block_height: u64, // block height on Stacks chain
     pub index_root: TrieHash,
     pub consensus_hash: ConsensusHash,
     pub burn_header_hash: BurnchainHeaderHash,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -420,7 +420,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
             );
             Error::NoSuchBlockError
         })?
-        .block_height;
+        .stacks_block_height;
 
         // when we drop the miner, the underlying clarity instance will be rolled back
         chainstate.set_unconfirmed_dirty(true);
@@ -495,7 +495,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                 (
                     header_info.consensus_hash,
                     header_info.anchored_header.block_hash(),
-                    header_info.block_height,
+                    header_info.stacks_block_height,
                 )
             } else {
                 // unconfirmed state needs to be initialized
@@ -1120,7 +1120,7 @@ impl StacksBlockBuilder {
         let genesis_chain_tip = StacksHeaderInfo {
             anchored_header: StacksBlockHeader::genesis_block_header(),
             microblock_tail: None,
-            block_height: 0,
+            stacks_block_height: 0,
             index_root: TrieHash([0u8; 32]),
             consensus_hash: genesis_consensus_hash.clone(),
             burn_header_hash: genesis_burn_header_hash.clone(),
@@ -1828,7 +1828,7 @@ impl StacksBlockBuilder {
             let new_work = StacksWorkScore {
                 burn: total_burn,
                 work: stacks_parent_header
-                    .block_height
+                    .stacks_block_height
                     .checked_add(1)
                     .expect("FATAL: block height overflow"),
             };
@@ -1869,7 +1869,7 @@ impl StacksBlockBuilder {
             let new_work = StacksWorkScore {
                 burn: total_burn,
                 work: stacks_parent_header
-                    .block_height
+                    .stacks_block_height
                     .checked_add(1)
                     .expect("FATAL: block height overflow"),
             };
@@ -1912,7 +1912,7 @@ impl StacksBlockBuilder {
         let (tip_consensus_hash, tip_block_hash, tip_height) = (
             parent_stacks_header.consensus_hash.clone(),
             parent_stacks_header.anchored_header.block_hash(),
-            parent_stacks_header.block_height,
+            parent_stacks_header.stacks_block_height,
         );
 
         debug!(
@@ -3219,7 +3219,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -3241,7 +3241,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -3403,7 +3403,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -3425,7 +3425,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -3546,7 +3546,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -3568,7 +3568,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -3594,7 +3594,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -3616,7 +3616,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -3884,7 +3884,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -3906,7 +3906,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -3932,7 +3932,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -3954,7 +3954,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -4145,7 +4145,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -4167,7 +4167,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -4195,7 +4195,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -4217,7 +4217,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -4483,7 +4483,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -4505,7 +4505,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -4528,7 +4528,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -4550,7 +4550,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -4726,7 +4726,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -4748,7 +4748,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -4774,7 +4774,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -4796,7 +4796,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -5032,7 +5032,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -5054,7 +5054,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -5077,7 +5077,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -5099,7 +5099,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -5275,7 +5275,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -5297,7 +5297,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -5323,7 +5323,7 @@ pub mod test {
                     let all_prev_mining_rewards = get_all_mining_rewards(
                         &mut miner_chainstate,
                         &builder.chain_tip,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                     );
 
                     let sort_iconn = sortdb.index_conn();
@@ -5345,7 +5345,7 @@ pub mod test {
                     assert!(check_mining_reward(
                         &mut epoch,
                         miner,
-                        builder.chain_tip.block_height,
+                        builder.chain_tip.stacks_block_height,
                         &all_prev_mining_rewards
                     ));
 
@@ -10096,7 +10096,7 @@ pub mod test {
                 // check descendant blocks for their poison-microblock commissions
                 test_debug!(
                     "new tip at height {}: {}",
-                    next_tip.block_height,
+                    next_tip.stacks_block_height,
                     &new_tip_hash
                 );
                 reporters.push((reporter, new_tip_hash, seq));

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -134,7 +134,7 @@ fn make_block(
         anchored_header,
         microblock_tail: None,
         index_root: TrieHash::from_empty_data(),
-        block_height,
+        stacks_block_height: block_height,
         consensus_hash: block_consensus.clone(),
         burn_header_hash: BurnchainHeaderHash([0; 32]),
         burn_header_height: burn_height as u32,

--- a/src/cost_estimates/tests/common.rs
+++ b/src/cost_estimates/tests/common.rs
@@ -30,7 +30,7 @@ pub fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksE
                 microblock_pubkey_hash: Hash160([0; 20]),
             },
             microblock_tail: None,
-            block_height: 1,
+            stacks_block_height: 1,
             index_root: TrieHash([0; 32]),
             consensus_hash: ConsensusHash([2; 20]),
             burn_header_hash: BurnchainHeaderHash([1; 32]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,7 +516,7 @@ simulating a miner.
             } else {
                 "Failed to"
             },
-            parent_header.block_height + 1,
+            parent_header.stacks_block_height + 1,
             StacksBlockHeader::make_index_block_hash(
                 &parent_header.consensus_hash,
                 &parent_header.anchored_header.block_hash()

--- a/src/net/atlas/db.rs
+++ b/src/net/atlas/db.rs
@@ -98,10 +98,11 @@ impl FromRow<AttachmentInstance> for AttachmentInstance {
             content_hash,
             attachment_index,
             index_block_hash,
-            block_height,
+            stacks_block_height: block_height,
             metadata,
             contract_id,
             tx_id,
+            canonical_stacks_tip_height: None,
         })
     }
 }
@@ -475,7 +476,7 @@ impl AtlasDB {
                 &now as &dyn ToSql,
                 &attachment.index_block_hash as &dyn ToSql,
                 &attachment.attachment_index as &dyn ToSql,
-                &u64_to_sql(attachment.block_height)?,
+                &u64_to_sql(attachment.stacks_block_height)?,
                 &is_available as &dyn ToSql,
                 &attachment.metadata as &dyn ToSql,
                 &attachment.contract_id.to_string() as &dyn ToSql,

--- a/src/net/atlas/download.rs
+++ b/src/net/atlas/download.rs
@@ -361,8 +361,11 @@ impl AttachmentsBatchStateContext {
                         reliability_report: reliability_report.clone(),
                         contract_id: contract_id.clone(),
                         pages: pages.clone(),
-                        block_height: self.attachments_batch.block_height,
+                        stacks_block_height: self.attachments_batch.stacks_block_height,
                         index_block_hash: self.attachments_batch.index_block_hash,
+                        canonical_stacks_tip_height: self
+                            .attachments_batch
+                            .canonical_stacks_tip_height,
                     };
                     queue.push(request);
                 }
@@ -446,7 +449,8 @@ impl AttachmentsBatchStateContext {
                 let request = AttachmentRequest {
                     sources,
                     content_hash: content_hash.clone(),
-                    block_height: self.attachments_batch.block_height,
+                    stacks_block_height: self.attachments_batch.stacks_block_height,
+                    canonical_stacks_tip_height: self.attachments_batch.canonical_stacks_tip_height,
                 };
                 enqueued.insert(content_hash);
                 queue.push(request);
@@ -955,9 +959,10 @@ pub struct AttachmentsInventoryRequest {
     pub url: UrlString,
     pub contract_id: QualifiedContractIdentifier,
     pub pages: Vec<u32>,
-    pub block_height: u64, // block height on Stacks chain
+    pub stacks_block_height: u64,
     pub index_block_hash: StacksBlockId,
     pub reliability_report: ReliabilityReport,
+    pub canonical_stacks_tip_height: Option<u64>,
 }
 
 impl Hash for AttachmentsInventoryRequest {
@@ -965,7 +970,7 @@ impl Hash for AttachmentsInventoryRequest {
         self.contract_id.hash(state);
         self.pages.hash(state);
         self.index_block_hash.hash(state);
-        self.block_height.hash(state);
+        self.stacks_block_height.hash(state);
     }
 }
 
@@ -1002,7 +1007,7 @@ impl Requestable for AttachmentsInventoryRequest {
             pages_indexes.insert(*page);
         }
         HttpRequestType::GetAttachmentsInv(
-            HttpRequestMetadata::from_host(peer_host, Some(self.block_height)),
+            HttpRequestMetadata::from_host(peer_host, self.canonical_stacks_tip_height),
             self.index_block_hash,
             pages_indexes,
         )
@@ -1020,7 +1025,8 @@ impl std::fmt::Display for AttachmentsInventoryRequest {
 pub struct AttachmentRequest {
     pub content_hash: Hash160,
     pub sources: HashMap<UrlString, ReliabilityReport>,
-    pub block_height: u64, // block height of Stacks chain
+    pub stacks_block_height: u64,
+    pub canonical_stacks_tip_height: Option<u64>,
 }
 
 impl AttachmentRequest {
@@ -1062,7 +1068,7 @@ impl Requestable for AttachmentRequest {
 
     fn make_request_type(&self, peer_host: PeerHost) -> HttpRequestType {
         HttpRequestType::GetAttachment(
-            HttpRequestMetadata::from_host(peer_host, Some(self.block_height)),
+            HttpRequestMetadata::from_host(peer_host, self.canonical_stacks_tip_height),
             self.content_hash,
         )
     }
@@ -1077,7 +1083,8 @@ impl std::fmt::Display for AttachmentRequest {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttachmentsBatch {
-    pub block_height: u64, // block height on Stacks chain
+    pub stacks_block_height: u64,
+    pub canonical_stacks_tip_height: Option<u64>,
     pub index_block_hash: StacksBlockId,
     pub attachments_instances: HashMap<QualifiedContractIdentifier, HashMap<u32, Hash160>>,
     pub retry_count: u64,
@@ -1087,7 +1094,8 @@ pub struct AttachmentsBatch {
 impl AttachmentsBatch {
     pub fn new() -> AttachmentsBatch {
         AttachmentsBatch {
-            block_height: 0,
+            stacks_block_height: 0,
+            canonical_stacks_tip_height: None,
             index_block_hash: StacksBlockId([0u8; 32]),
             attachments_instances: HashMap::new(),
             retry_count: 0,
@@ -1097,10 +1105,11 @@ impl AttachmentsBatch {
 
     pub fn track_attachment(&mut self, attachment: &AttachmentInstance) {
         if self.attachments_instances.is_empty() {
-            self.block_height = attachment.block_height.clone();
+            self.stacks_block_height = attachment.stacks_block_height.clone();
             self.index_block_hash = attachment.index_block_hash.clone();
+            self.canonical_stacks_tip_height = attachment.canonical_stacks_tip_height;
         } else {
-            if self.block_height != attachment.block_height
+            if self.stacks_block_height != attachment.stacks_block_height
                 || self.index_block_hash != attachment.index_block_hash
             {
                 warn!("Atlas: attempt to add unrelated AttachmentInstance ({}, {}) to AttachmentsBatch", attachment.attachment_index, attachment.index_block_hash);
@@ -1200,7 +1209,7 @@ impl Ord for AttachmentsBatch {
                 self.attachments_instances_count()
                     .cmp(&other.attachments_instances_count())
             })
-            .then_with(|| other.block_height.cmp(&self.block_height))
+            .then_with(|| other.stacks_block_height.cmp(&self.stacks_block_height))
     }
 }
 

--- a/src/net/atlas/mod.rs
+++ b/src/net/atlas/mod.rs
@@ -92,7 +92,7 @@ impl Attachment {
 pub struct AttachmentInstance {
     pub content_hash: Hash160,
     pub attachment_index: u32,
-    pub block_height: u64,
+    pub block_height: u64, // block height on Stacks chain
     pub index_block_hash: StacksBlockId,
     pub metadata: String,
     pub contract_id: QualifiedContractIdentifier,

--- a/src/net/atlas/mod.rs
+++ b/src/net/atlas/mod.rs
@@ -109,7 +109,7 @@ impl AttachmentInstance {
         index_block_hash: StacksBlockId,
         stacks_block_height: u64,
         tx_id: Txid,
-        canonical_stacks_tip_height: u64,
+        canonical_stacks_tip_height: Option<u64>,
     ) -> Option<AttachmentInstance> {
         if let Value::Tuple(ref attachment) = value {
             if let Ok(Value::Tuple(ref attachment_data)) = attachment.get("attachment") {
@@ -147,7 +147,7 @@ impl AttachmentInstance {
                             metadata,
                             contract_id: contract_id.clone(),
                             tx_id,
-                            canonical_stacks_tip_height: Some(canonical_stacks_tip_height),
+                            canonical_stacks_tip_height: canonical_stacks_tip_height,
                         };
                         return Some(instance);
                     }

--- a/src/net/atlas/mod.rs
+++ b/src/net/atlas/mod.rs
@@ -92,11 +92,12 @@ impl Attachment {
 pub struct AttachmentInstance {
     pub content_hash: Hash160,
     pub attachment_index: u32,
-    pub block_height: u64, // block height on Stacks chain
+    pub stacks_block_height: u64,
     pub index_block_hash: StacksBlockId,
     pub metadata: String,
     pub contract_id: QualifiedContractIdentifier,
     pub tx_id: Txid,
+    pub canonical_stacks_tip_height: Option<u64>,
 }
 
 impl AttachmentInstance {
@@ -106,8 +107,9 @@ impl AttachmentInstance {
         value: &Value,
         contract_id: &QualifiedContractIdentifier,
         index_block_hash: StacksBlockId,
-        block_height: u64,
+        stacks_block_height: u64,
         tx_id: Txid,
+        canonical_stacks_tip_height: u64,
     ) -> Option<AttachmentInstance> {
         if let Value::Tuple(ref attachment) = value {
             if let Ok(Value::Tuple(ref attachment_data)) = attachment.get("attachment") {
@@ -141,10 +143,11 @@ impl AttachmentInstance {
                             index_block_hash,
                             content_hash,
                             attachment_index: *attachment_index as u32,
-                            block_height,
+                            stacks_block_height,
                             metadata,
                             contract_id: contract_id.clone(),
                             tx_id,
+                            canonical_stacks_tip_height: Some(canonical_stacks_tip_height),
                         };
                         return Some(instance);
                     }

--- a/src/net/atlas/tests.rs
+++ b/src/net/atlas/tests.rs
@@ -174,7 +174,7 @@ fn test_attachment_instance_parsing() {
         index_block_hash.clone(),
         stacks_block_height,
         Txid([0; 32]),
-        stacks_block_height,
+        Some(stacks_block_height),
     )
     .unwrap();
     assert_eq!(attachment_instance_1.attachment_index, 1);
@@ -201,7 +201,7 @@ fn test_attachment_instance_parsing() {
         index_block_hash.clone(),
         stacks_block_height,
         Txid([0; 32]),
-        stacks_block_height,
+        Some(stacks_block_height),
     )
     .unwrap();
     assert_eq!(attachment_instance_2.attachment_index, 2);
@@ -228,7 +228,7 @@ fn test_attachment_instance_parsing() {
         index_block_hash.clone(),
         stacks_block_height,
         Txid([0; 32]),
-        stacks_block_height,
+        Some(stacks_block_height),
     )
     .unwrap();
     assert_eq!(attachment_instance_3.attachment_index, 3);
@@ -286,7 +286,7 @@ fn test_attachment_instance_parsing() {
             index_block_hash.clone(),
             stacks_block_height,
             Txid([0; 32]),
-            stacks_block_height
+            Some(stacks_block_height)
         )
         .is_none());
     }

--- a/src/net/atlas/tests.rs
+++ b/src/net/atlas/tests.rs
@@ -47,6 +47,7 @@ fn new_attachment_from(content: &str) -> Attachment {
     }
 }
 
+#[cfg(test)]
 fn new_attachment_instance_from(
     attachment: &Attachment,
     attachment_index: u32,
@@ -55,11 +56,12 @@ fn new_attachment_instance_from(
     AttachmentInstance {
         content_hash: attachment.hash().clone(),
         attachment_index,
-        block_height,
+        stacks_block_height: block_height,
         index_block_hash: StacksBlockId([block_height as u8; 32]),
         metadata: "".to_string(),
         contract_id: QualifiedContractIdentifier::transient(),
         tx_id: Txid([0; 32]),
+        canonical_stacks_tip_height: Some(block_height),
     }
 }
 
@@ -86,6 +88,7 @@ fn new_peers(peers: Vec<(&str, u32, u32)>) -> HashMap<UrlString, ReliabilityRepo
     new_peers
 }
 
+#[cfg(test)]
 fn new_attachment_request(
     sources: Vec<(&str, u32, u32)>,
     content_hash: &Hash160,
@@ -102,10 +105,12 @@ fn new_attachment_request(
     AttachmentRequest {
         sources,
         content_hash: content_hash.clone(),
-        block_height,
+        stacks_block_height: block_height,
+        canonical_stacks_tip_height: Some(block_height),
     }
 }
 
+#[cfg(test)]
 fn new_attachments_inventory_request(
     url: &str,
     pages: Vec<u32>,
@@ -117,11 +122,12 @@ fn new_attachments_inventory_request(
 
     AttachmentsInventoryRequest {
         url,
-        block_height,
+        stacks_block_height: block_height,
         pages,
         contract_id: QualifiedContractIdentifier::transient(),
         index_block_hash: StacksBlockId([0x00; 32]),
         reliability_report: ReliabilityReport::new(req_sent, req_success),
+        canonical_stacks_tip_height: Some(block_height),
     }
 }
 
@@ -144,7 +150,7 @@ fn test_attachment_instance_parsing() {
     use vm;
 
     let contract_id = QualifiedContractIdentifier::transient();
-    let block_height = 0;
+    let stacks_block_height = 0;
     let index_block_hash = StacksBlockId([0x00; 32]);
 
     let value_1 = vm::execute(
@@ -166,8 +172,9 @@ fn test_attachment_instance_parsing() {
         &value_1,
         &contract_id,
         index_block_hash.clone(),
-        block_height,
+        stacks_block_height,
         Txid([0; 32]),
+        stacks_block_height,
     )
     .unwrap();
     assert_eq!(attachment_instance_1.attachment_index, 1);
@@ -192,8 +199,9 @@ fn test_attachment_instance_parsing() {
         &value_2,
         &contract_id,
         index_block_hash.clone(),
-        block_height,
+        stacks_block_height,
         Txid([0; 32]),
+        stacks_block_height,
     )
     .unwrap();
     assert_eq!(attachment_instance_2.attachment_index, 2);
@@ -218,8 +226,9 @@ fn test_attachment_instance_parsing() {
         &value_3,
         &contract_id,
         index_block_hash.clone(),
-        block_height,
+        stacks_block_height,
         Txid([0; 32]),
+        stacks_block_height,
     )
     .unwrap();
     assert_eq!(attachment_instance_3.attachment_index, 3);
@@ -275,8 +284,9 @@ fn test_attachment_instance_parsing() {
             &value,
             &contract_id,
             index_block_hash.clone(),
-            block_height,
+            stacks_block_height,
             Txid([0; 32]),
+            stacks_block_height
         )
         .is_none());
     }

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -157,12 +157,12 @@ impl Requestable for BlockRequestKey {
     fn make_request_type(&self, peer_host: PeerHost) -> HttpRequestType {
         match self.kind {
             BlockRequestKeyKind::Block => HttpRequestType::GetBlock(
-                HttpRequestMetadata::from_host(peer_host),
+                HttpRequestMetadata::from_host(peer_host, Some(self.sortition_height)),
                 self.index_block_hash,
             ),
             BlockRequestKeyKind::ConfirmedMicroblockStream => {
                 HttpRequestType::GetMicroblocksConfirmed(
-                    HttpRequestMetadata::from_host(peer_host),
+                    HttpRequestMetadata::from_host(peer_host, Some(self.sortition_height)),
                     self.index_block_hash,
                 )
             }

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -256,7 +256,7 @@ impl HttpReservedHeader {
             | "content-type"
             | "x-request-id"
             | "host"
-            | "canonical-stacks-tip-height" => true,
+            | "x-canonical-stacks-tip-height" => true,
             _ => false,
         }
     }
@@ -280,7 +280,7 @@ impl HttpReservedHeader {
                 Ok(ph) => Some(HttpReservedHeader::Host(ph)),
                 Err(_) => None,
             },
-            "canonical-stacks-tip-height" => match value.parse::<u64>() {
+            "x-canonical-stacks-tip-height" => match value.parse::<u64>() {
                 Ok(h) => Some(HttpReservedHeader::CanonicalStacksTipHeight(h)),
                 Err(_) => None,
             },
@@ -878,7 +878,7 @@ fn stacks_height_headers<W: Write>(
 ) -> Result<(), codec_error> {
     match md.canonical_stacks_tip_height {
         Some(height) => {
-            fd.write_all(format!("Canonical-Stacks-Tip-Height: {}\r\n", height).as_bytes())
+            fd.write_all(format!("X-Canonical-Stacks-Tip-Height: {}\r\n", height).as_bytes())
                 .map_err(codec_error::WriteError)?;
         }
         _ => {}
@@ -908,7 +908,7 @@ fn keep_alive_headers<W: Write>(fd: &mut W, md: &HttpResponseMetadata) -> Result
     }
     match md.canonical_stacks_tip_height {
         Some(height) => {
-            fd.write_all(format!("Canonical-Stacks-Tip-Height: {}\r\n", height).as_bytes())
+            fd.write_all(format!("X-Canonical-Stacks-Tip-Height: {}\r\n", height).as_bytes())
                 .map_err(codec_error::WriteError)?;
         }
         _ => {}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1531,18 +1531,6 @@ impl HttpResponseMetadata {
     }
 }
 
-// impl From<&HttpRequestType> for HttpResponseMetadata {
-//     fn from(req: &HttpRequestType) -> HttpResponseMetadata {
-//         let metadata = req.metadata();
-//         HttpResponseMetadata::new(
-//             metadata.version,
-//             HttpResponseMetadata::make_request_id(),
-//             None,
-//             metadata.keep_alive,
-//         )
-//     }
-// }
-
 /// All data-plane message types a peer can reply with.
 #[derive(Debug, Clone, PartialEq)]
 pub enum HttpResponseType {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2155,7 +2155,6 @@ impl PeerNetwork {
     fn do_network_mempool_sync(
         &mut self,
         dns_client_opt: &mut Option<&mut DNSClient>,
-        sortdb: &SortitionDB,
         mempool: &MemPoolDB,
         chainstate: &mut StacksChainState,
         ibd: bool,
@@ -2164,7 +2163,7 @@ impl PeerNetwork {
             return Ok(None);
         }
 
-        match self.do_mempool_sync(dns_client_opt, sortdb, mempool, chainstate)? {
+        match self.do_mempool_sync(dns_client_opt, mempool, chainstate)? {
             (true, txs_opt) => {
                 // did we run to completion?
                 if let Some(txs) = txs_opt {
@@ -3414,7 +3413,6 @@ impl PeerNetwork {
     fn do_mempool_sync(
         &mut self,
         dns_client_opt: &mut Option<&mut DNSClient>,
-        sortdb: &SortitionDB,
         mempool: &MemPoolDB,
         chainstate: &mut StacksChainState,
     ) -> Result<(bool, Option<Vec<StacksTransaction>>), net_error> {
@@ -5046,7 +5044,7 @@ impl PeerNetwork {
         // In parallel, do a mempool sync.
         // Remember any txs we get, so we can feed them to the relayer thread.
         if let Some(mut txs) =
-            self.do_network_mempool_sync(&mut dns_client_opt, sortdb, mempool, chainstate, ibd)?
+            self.do_network_mempool_sync(&mut dns_client_opt, mempool, chainstate, ibd)?
         {
             network_result.synced_transactions.append(&mut txs);
         }

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -3332,17 +3332,15 @@ impl PeerNetwork {
         &mut self,
         url: &UrlString,
         addr: &SocketAddr,
-        sortdb: &SortitionDB,
         mempool: &MemPoolDB,
         chainstate: &mut StacksChainState,
         page_id: Txid,
     ) -> Result<(bool, Option<usize>), net_error> {
-        let burn_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())?;
         let sync_data = mempool.make_mempool_sync_data()?;
         let request = HttpRequestType::MemPoolQuery(
             HttpRequestMetadata::from_host(
                 PeerHost::from_socketaddr(addr),
-                Some(burn_tip.canonical_stacks_tip_height),
+                Some(self.burnchain_tip.canonical_stacks_tip_height),
             ),
             sync_data,
             Some(page_id),
@@ -3497,7 +3495,6 @@ impl PeerNetwork {
                     match self.mempool_sync_send_query(
                         url,
                         addr,
-                        sortdb,
                         mempool,
                         chainstate,
                         page_id.clone(),

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -2399,7 +2399,7 @@ mod test {
     }
 
     fn http_get_info(http_port: u16) -> RPCPeerInfoData {
-        let mut request = HttpRequestMetadata::new("127.0.0.1".to_string(), http_port);
+        let mut request = HttpRequestMetadata::new("127.0.0.1".to_string(), http_port, None);
         request.keep_alive = false;
         let getinfo = HttpRequestType::GetInfo(request);
         let response = http_rpc(http_port, getinfo).unwrap();
@@ -2421,7 +2421,7 @@ mod test {
             block.block_hash(),
             http_port
         );
-        let mut request = HttpRequestMetadata::new("127.0.0.1".to_string(), http_port);
+        let mut request = HttpRequestMetadata::new("127.0.0.1".to_string(), http_port, None);
         request.keep_alive = false;
         let post_block = HttpRequestType::PostBlock(request, consensus_hash.clone(), block.clone());
         let response = http_rpc(http_port, post_block).unwrap();
@@ -2445,7 +2445,7 @@ mod test {
             mblock.block_hash(),
             http_port
         );
-        let mut request = HttpRequestMetadata::new("127.0.0.1".to_string(), http_port);
+        let mut request = HttpRequestMetadata::new("127.0.0.1".to_string(), http_port, None);
         request.keep_alive = false;
         let tip = StacksBlockHeader::make_index_block_hash(consensus_hash, block_hash);
         let post_microblock =

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -148,6 +148,8 @@ pub struct ConversationHttp {
     last_response_timestamp: u64, // absolute timestamp of the last time we sent at least 1 byte in a response
     connection_time: u64,         // when this converation was instantiated
 
+    canonical_stacks_tip_height: Option<u64>, // chain tip height of the Stacks blockchain
+
     // ongoing block streams
     reply_streams: VecDeque<(
         ReplyHandleHttp,
@@ -496,6 +498,7 @@ impl ConversationHttp {
             peer_addr: peer_addr,
             outbound_url: outbound_url,
             peer_host: peer_host,
+            canonical_stacks_tip_height: None,
             pending_request: None,
             pending_response: None,
             pending_error_response: None,
@@ -613,8 +616,10 @@ impl ConversationHttp {
         network: &PeerNetwork,
         chainstate: &StacksChainState,
         handler_args: &RPCHandlerArgs,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let pi = RPCPeerInfoData::from_network(
             network,
             chainstate,
@@ -635,8 +640,10 @@ impl ConversationHttp {
         chainstate: &mut StacksChainState,
         tip: &StacksBlockId,
         burnchain: &Burnchain,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         match RPCPoxInfoData::from_db(sortdb, chainstate, tip, burnchain) {
             Ok(pi) => {
@@ -670,6 +677,7 @@ impl ConversationHttp {
         index_block_hash: &StacksBlockId,
         pages_indexes: &HashSet<u32>,
         _options: &ConnectionOptions,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
         // We are receiving a list of page indexes with a chain tip hash.
         // The amount of pages_indexes is capped by MAX_ATTACHMENT_INV_PAGES_PER_REQUEST (8)
@@ -680,7 +688,8 @@ impl ConversationHttp {
         // we will be handling each page index separately.
         // We could also add the notion of "budget" so that a client could only get a limited number
         // of pages when they are spanning over many blocks.
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         if pages_indexes.len() > MAX_ATTACHMENT_INV_PAGES_PER_REQUEST {
             let msg = format!(
                 "Number of attachment inv pages is limited by {} per request",
@@ -735,8 +744,10 @@ impl ConversationHttp {
         req: &HttpRequestType,
         atlasdb: &mut AtlasDB,
         content_hash: Hash160,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         match atlasdb.find_attachment(&content_hash) {
             Ok(Some(attachment)) => {
                 let content = GetAttachmentResponse { attachment };
@@ -759,10 +770,12 @@ impl ConversationHttp {
         fd: &mut W,
         req: &HttpRequestType,
         network: &PeerNetwork,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
         let epoch = network.get_current_epoch();
 
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let neighbor_data = RPCNeighborsInfo::from_p2p(
             network.local_peer.network_id,
             epoch.network_epoch,
@@ -810,8 +823,10 @@ impl ConversationHttp {
         tip: &StacksBlockId,
         quantity: u64,
         chainstate: &StacksChainState,
+        canonical_stacks_tip_height: u64,
     ) -> Result<Option<StreamCursor>, net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         if quantity > (MAX_HEADERS as u64) {
             // bad request
             let response = HttpResponseType::BadRequestJSON(
@@ -859,9 +874,11 @@ impl ConversationHttp {
         req: &HttpRequestType,
         index_block_hash: &StacksBlockId,
         chainstate: &StacksChainState,
+        canonical_stacks_tip_height: u64,
     ) -> Result<Option<StreamCursor>, net_error> {
         monitoring::increment_stx_blocks_served_counter();
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         // do we have this block?
         match StacksChainState::has_block_indexed(&chainstate.blocks_path, index_block_hash) {
@@ -902,9 +919,11 @@ impl ConversationHttp {
         req: &HttpRequestType,
         index_anchor_block_hash: &StacksBlockId,
         chainstate: &StacksChainState,
+        canonical_stacks_tip_height: u64,
     ) -> Result<Option<StreamCursor>, net_error> {
         monitoring::increment_stx_confirmed_micro_blocks_served_counter();
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         match chainstate.has_processed_microblocks(index_anchor_block_hash) {
             Ok(true) => {}
@@ -1007,9 +1026,11 @@ impl ConversationHttp {
         req: &HttpRequestType,
         tail_index_microblock_hash: &StacksBlockId,
         chainstate: &StacksChainState,
+        canonical_stacks_tip_height: u64,
     ) -> Result<Option<StreamCursor>, net_error> {
         monitoring::increment_stx_micro_blocks_served_counter();
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         // do we have this processed microblock stream?
         match StacksChainState::has_processed_microblocks_indexed(
@@ -1089,8 +1110,10 @@ impl ConversationHttp {
         http: &mut StacksHttp,
         fd: &mut W,
         req: &HttpRequestType,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         // todo -- need to actually estimate the cost / length for token transfers
         //   right now, it just uses the minimum.
@@ -1110,9 +1133,10 @@ impl ConversationHttp {
         tip: &StacksBlockId,
         account: &PrincipalData,
         with_proof: bool,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
-
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let response =
             match chainstate.maybe_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
                 clarity_tx.with_clarity_db_readonly(|clarity_db| {
@@ -1182,8 +1206,10 @@ impl ConversationHttp {
         contract_name: &ContractName,
         var_name: &ClarityName,
         with_proof: bool,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let contract_identifier =
             QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
 
@@ -1234,8 +1260,10 @@ impl ConversationHttp {
         map_name: &ClarityName,
         key: &Value,
         with_proof: bool,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let contract_identifier =
             QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
 
@@ -1293,8 +1321,10 @@ impl ConversationHttp {
         sender: &PrincipalData,
         args: &[Value],
         options: &ConnectionOptions,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let contract_identifier =
             QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
 
@@ -1379,8 +1409,10 @@ impl ConversationHttp {
         contract_addr: &StacksAddress,
         contract_name: &ContractName,
         with_proof: bool,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let contract_identifier =
             QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
 
@@ -1431,8 +1463,10 @@ impl ConversationHttp {
         contract_addr: &StacksAddress,
         contract_name: &ContractName,
         trait_id: &TraitIdentifier,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let contract_identifier =
             QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
 
@@ -1485,8 +1519,10 @@ impl ConversationHttp {
         tip: &StacksBlockId,
         contract_addr: &StacksAddress,
         contract_name: &ContractName,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let contract_identifier =
             QualifiedContractIdentifier::new(contract_addr.clone().into(), contract_name.clone());
 
@@ -1522,8 +1558,10 @@ impl ConversationHttp {
         index_anchor_block_hash: &StacksBlockId,
         min_seq: u16,
         chainstate: &StacksChainState,
+        canonical_stacks_tip_height: u64,
     ) -> Result<Option<StreamCursor>, net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         // do we have this unconfirmed microblock stream?
         match chainstate.has_any_staging_microblock_indexed(index_anchor_block_hash, min_seq) {
@@ -1607,8 +1645,10 @@ impl ConversationHttp {
         chainstate: &StacksChainState,
         mempool: &MemPoolDB,
         txid: &Txid,
+        canonical_stacks_tip_height: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
 
         // present in the unconfirmed state?
         if let Some(ref unconfirmed) = chainstate.unconfirmed_state.as_ref() {
@@ -1715,7 +1755,10 @@ impl ConversationHttp {
                     &tip.anchored_block_hash,
                 ))),
                 None => {
-                    let response_metadata = HttpResponseMetadata::from(req);
+                    let response_metadata = HttpResponseMetadata::from_http_request_type(
+                        req,
+                        Some(canonical_stacks_tip_height),
+                    );
                     warn!("Failed to load Stacks chain tip");
                     let response = HttpResponseType::ServerError(
                         response_metadata,
@@ -1733,6 +1776,7 @@ impl ConversationHttp {
         req: &HttpRequestType,
         tip: StacksBlockId,
         chainstate: &StacksChainState,
+        canonical_stacks_tip_height: u64,
     ) -> Result<Option<(ConsensusHash, BlockHeaderHash)>, net_error> {
         match chainstate.get_block_header_hashes(&tip)? {
             Some((ch, bl)) => {
@@ -1740,8 +1784,8 @@ impl ConversationHttp {
             }
             None => {}
         }
-
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         warn!("Failed to load Stacks chain tip");
         let response = HttpResponseType::ServerError(
             response_metadata,
@@ -1759,7 +1803,8 @@ impl ConversationHttp {
         tx: &TransactionPayload,
         estimated_len: u64,
     ) -> Result<(), net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())?;
         let stacks_epoch = SortitionDB::get_stacks_epoch(sortdb.conn(), tip.block_height)?
                 .ok_or_else(|| {
@@ -1846,9 +1891,11 @@ impl ConversationHttp {
         atlasdb: &mut AtlasDB,
         attachment: Option<Attachment>,
         event_observer: Option<&dyn MemPoolEventDispatcher>,
+        canonical_stacks_tip_height: u64,
     ) -> Result<bool, net_error> {
         let txid = tx.txid();
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let (response, accepted) = if mempool.has_tx(&txid) {
             debug!("Mempool already has POSTed transaction {}", &txid);
             (
@@ -1856,7 +1903,6 @@ impl ConversationHttp {
                 false,
             )
         } else {
-            let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())?;
             let stacks_epoch = sortdb
                 .index_conn()
                 .get_stacks_epoch(tip.block_height as u32)
@@ -1919,8 +1965,10 @@ impl ConversationHttp {
         chainstate: &mut StacksChainState,
         consensus_hash: &ConsensusHash,
         block: &StacksBlock,
+        canonical_stacks_tip_height: u64,
     ) -> Result<bool, net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         // is this a consensus hash we recognize?
         let (response, accepted) =
             match SortitionDB::get_sortition_id_by_consensus(&sortdb.conn(), consensus_hash) {
@@ -2023,7 +2071,6 @@ impl ConversationHttp {
                     )
                 }
             };
-
         response.send(http, fd).and_then(|_| Ok(accepted))
     }
 
@@ -2039,8 +2086,10 @@ impl ConversationHttp {
         block_hash: &BlockHeaderHash,
         chainstate: &mut StacksChainState,
         microblock: &StacksMicroblock,
+        canonical_stacks_tip_height: u64,
     ) -> Result<bool, net_error> {
-        let response_metadata = HttpResponseMetadata::from(req);
+        let response_metadata =
+            HttpResponseMetadata::from_http_request_type(req, Some(canonical_stacks_tip_height));
         let (response, accepted) =
             match chainstate.preprocess_streamed_microblock(consensus_hash, block_hash, microblock)
             {
@@ -2113,11 +2162,13 @@ impl ConversationHttp {
         handler_opts: &RPCHandlerArgs,
     ) -> Result<Option<StacksMessageType>, net_error> {
         let mut reply = self.connection.make_relay_handle(self.conn_id)?;
+        let burn_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())?;
         let keep_alive = req.metadata().keep_alive;
         let mut ret = None;
 
         let stream_opt = match req {
             HttpRequestType::GetInfo(ref _md) => {
+                // self.canonical_stacks_tip_height = _md.
                 ConversationHttp::handle_getinfo(
                     &mut self.connection.protocol,
                     &mut reply,
@@ -2125,6 +2176,7 @@ impl ConversationHttp {
                     network,
                     chainstate,
                     handler_opts,
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2145,6 +2197,7 @@ impl ConversationHttp {
                         chainstate,
                         &tip,
                         &network.burnchain,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2155,6 +2208,7 @@ impl ConversationHttp {
                     &mut reply,
                     &req,
                     network,
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2174,6 +2228,7 @@ impl ConversationHttp {
                         &tip,
                         *quantity,
                         chainstate,
+                        burn_tip.canonical_stacks_tip_height,
                     )?
                 } else {
                     None
@@ -2186,6 +2241,7 @@ impl ConversationHttp {
                     &req,
                     index_block_hash,
                     chainstate,
+                    burn_tip.canonical_stacks_tip_height,
                 )?
             }
             HttpRequestType::GetMicroblocksIndexed(ref _md, ref index_head_hash) => {
@@ -2195,6 +2251,7 @@ impl ConversationHttp {
                     &req,
                     index_head_hash,
                     chainstate,
+                    burn_tip.canonical_stacks_tip_height,
                 )?
             }
             HttpRequestType::GetMicroblocksConfirmed(ref _md, ref anchor_index_block_hash) => {
@@ -2204,6 +2261,7 @@ impl ConversationHttp {
                     &req,
                     anchor_index_block_hash,
                     chainstate,
+                    burn_tip.canonical_stacks_tip_height,
                 )?
             }
             HttpRequestType::GetMicroblocksUnconfirmed(
@@ -2217,6 +2275,7 @@ impl ConversationHttp {
                 index_anchor_block_hash,
                 *min_seq,
                 chainstate,
+                burn_tip.canonical_stacks_tip_height,
             )?,
             HttpRequestType::GetTransactionUnconfirmed(ref _md, ref txid) => {
                 ConversationHttp::handle_gettransaction_unconfirmed(
@@ -2226,6 +2285,7 @@ impl ConversationHttp {
                     chainstate,
                     mempool,
                     txid,
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2247,6 +2307,7 @@ impl ConversationHttp {
                         &tip,
                         principal,
                         *with_proof,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2278,6 +2339,7 @@ impl ConversationHttp {
                         contract_name,
                         var_name,
                         *with_proof,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2311,6 +2373,7 @@ impl ConversationHttp {
                         map_name,
                         key,
                         *with_proof,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2320,6 +2383,7 @@ impl ConversationHttp {
                     &mut self.connection.protocol,
                     &mut reply,
                     &req,
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2346,6 +2410,7 @@ impl ConversationHttp {
                         &tip,
                         contract_addr,
                         contract_name,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2392,6 +2457,7 @@ impl ConversationHttp {
                         as_sender,
                         args,
                         &self.connection.options,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2421,6 +2487,7 @@ impl ConversationHttp {
                         contract_addr,
                         contract_name,
                         *with_proof,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2441,6 +2508,7 @@ impl ConversationHttp {
                             &mut network.atlasdb,
                             attachment.clone(),
                             handler_opts.event_observer.as_deref(),
+                            burn_tip.canonical_stacks_tip_height,
                         )?;
                         if accepted {
                             // forward to peer network
@@ -2448,7 +2516,10 @@ impl ConversationHttp {
                         }
                     }
                     None => {
-                        let response_metadata = HttpResponseMetadata::from(&req);
+                        let response_metadata = HttpResponseMetadata::from_http_request_type(
+                            &req,
+                            Some(burn_tip.canonical_stacks_tip_height),
+                        );
                         warn!("Failed to load Stacks chain tip");
                         let response = HttpResponseType::ServerError(
                             response_metadata,
@@ -2466,6 +2537,7 @@ impl ConversationHttp {
                     &req,
                     &mut network.atlasdb,
                     content_hash.clone(),
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2482,6 +2554,7 @@ impl ConversationHttp {
                     &index_block_hash,
                     pages_indexes,
                     &self.connection.options,
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2494,6 +2567,7 @@ impl ConversationHttp {
                     chainstate,
                     consensus_hash,
                     block,
+                    burn_tip.canonical_stacks_tip_height,
                 )?;
                 if accepted {
                     // inform the peer network so it can announce its presence
@@ -2519,6 +2593,7 @@ impl ConversationHttp {
                             &req,
                             tip,
                             chainstate,
+                            burn_tip.canonical_stacks_tip_height,
                         )?
                     {
                         let accepted = ConversationHttp::handle_post_microblock(
@@ -2529,6 +2604,7 @@ impl ConversationHttp {
                             &block_hash,
                             chainstate,
                             mblock,
+                            burn_tip.canonical_stacks_tip_height,
                         )?;
                         if accepted {
                             // forward to peer network
@@ -2557,7 +2633,10 @@ impl ConversationHttp {
                 )?
             }
             HttpRequestType::OptionsPreflight(ref _md, ref _path) => {
-                let response_metadata = HttpResponseMetadata::from(&req);
+                let response_metadata = HttpResponseMetadata::from_http_request_type(
+                    &req,
+                    Some(burn_tip.canonical_stacks_tip_height),
+                );
                 let response = HttpResponseType::OptionsPreflight(response_metadata);
                 response
                     .send(&mut self.connection.protocol, &mut reply)
@@ -2589,12 +2668,16 @@ impl ConversationHttp {
                         contract_addr,
                         contract_name,
                         trait_id,
+                        burn_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
             }
             HttpRequestType::ClientError(ref _md, ref err) => {
-                let response_metadata = HttpResponseMetadata::from(&req);
+                let response_metadata = HttpResponseMetadata::from_http_request_type(
+                    &req,
+                    Some(burn_tip.canonical_stacks_tip_height),
+                );
                 let response = match err {
                     ClientError::Message(s) => HttpResponseType::BadRequestJSON(
                         response_metadata,
@@ -2903,6 +2986,7 @@ impl ConversationHttp {
                 StacksHttpMessage::Response(resp) => {
                     // Is there someone else waiting for this message?  If so, pass it along.
                     // (this _should_ be our pending_request handle)
+                    self.canonical_stacks_tip_height = resp.metadata().canonical_stacks_tip_height;
                     match self
                         .connection
                         .fulfill_request(StacksHttpMessage::Response(resp))

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -2185,7 +2185,6 @@ impl ConversationHttp {
         handler_opts: &RPCHandlerArgs,
     ) -> Result<Option<StacksMessageType>, net_error> {
         let mut reply = self.connection.make_relay_handle(self.conn_id)?;
-        let burn_tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())?;
         let keep_alive = req.metadata().keep_alive;
         let mut ret = None;
 
@@ -2198,7 +2197,7 @@ impl ConversationHttp {
                     network,
                     chainstate,
                     handler_opts,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2210,7 +2209,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_getpoxinfo(
                         &mut self.connection.protocol,
@@ -2220,7 +2219,7 @@ impl ConversationHttp {
                         chainstate,
                         &tip,
                         &network.burnchain,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2231,7 +2230,7 @@ impl ConversationHttp {
                     &mut reply,
                     &req,
                     network,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2243,7 +2242,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_getheaders(
                         &mut self.connection.protocol,
@@ -2252,7 +2251,7 @@ impl ConversationHttp {
                         &tip,
                         *quantity,
                         chainstate,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?
                 } else {
                     None
@@ -2265,7 +2264,7 @@ impl ConversationHttp {
                     &req,
                     index_block_hash,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?
             }
             HttpRequestType::GetMicroblocksIndexed(ref _md, ref index_head_hash) => {
@@ -2275,7 +2274,7 @@ impl ConversationHttp {
                     &req,
                     index_head_hash,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?
             }
             HttpRequestType::GetMicroblocksConfirmed(ref _md, ref anchor_index_block_hash) => {
@@ -2285,7 +2284,7 @@ impl ConversationHttp {
                     &req,
                     anchor_index_block_hash,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?
             }
             HttpRequestType::GetMicroblocksUnconfirmed(
@@ -2299,7 +2298,7 @@ impl ConversationHttp {
                 index_anchor_block_hash,
                 *min_seq,
                 chainstate,
-                burn_tip.canonical_stacks_tip_height,
+                network.burnchain_tip.canonical_stacks_tip_height,
             )?,
             HttpRequestType::GetTransactionUnconfirmed(ref _md, ref txid) => {
                 ConversationHttp::handle_gettransaction_unconfirmed(
@@ -2309,7 +2308,7 @@ impl ConversationHttp {
                     chainstate,
                     mempool,
                     txid,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2321,7 +2320,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_get_account_entry(
                         &mut self.connection.protocol,
@@ -2332,7 +2331,7 @@ impl ConversationHttp {
                         &tip,
                         principal,
                         *with_proof,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2352,7 +2351,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_get_data_var(
                         &mut self.connection.protocol,
@@ -2365,7 +2364,7 @@ impl ConversationHttp {
                         contract_name,
                         var_name,
                         *with_proof,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2386,7 +2385,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_get_map_entry(
                         &mut self.connection.protocol,
@@ -2400,7 +2399,7 @@ impl ConversationHttp {
                         map_name,
                         key,
                         *with_proof,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2410,7 +2409,7 @@ impl ConversationHttp {
                     &mut self.connection.protocol,
                     &mut reply,
                     &req,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2427,7 +2426,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_get_contract_abi(
                         &mut self.connection.protocol,
@@ -2438,7 +2437,7 @@ impl ConversationHttp {
                         &tip,
                         contract_addr,
                         contract_name,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2452,7 +2451,7 @@ impl ConversationHttp {
                     sortdb,
                     tx,
                     estimated_len,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2472,7 +2471,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_readonly_function_call(
                         &mut self.connection.protocol,
@@ -2487,7 +2486,7 @@ impl ConversationHttp {
                         as_sender,
                         args,
                         &self.connection.options,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2506,7 +2505,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_get_contract_src(
                         &mut self.connection.protocol,
@@ -2518,7 +2517,7 @@ impl ConversationHttp {
                         contract_addr,
                         contract_name,
                         *with_proof,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2539,7 +2538,7 @@ impl ConversationHttp {
                             &mut network.atlasdb,
                             attachment.clone(),
                             handler_opts.event_observer.as_deref(),
-                            burn_tip.canonical_stacks_tip_height,
+                            network.burnchain_tip.canonical_stacks_tip_height,
                         )?;
                         if accepted {
                             // forward to peer network
@@ -2549,7 +2548,7 @@ impl ConversationHttp {
                     None => {
                         let response_metadata = HttpResponseMetadata::from_http_request_type(
                             &req,
-                            Some(burn_tip.canonical_stacks_tip_height),
+                            Some(network.burnchain_tip.canonical_stacks_tip_height),
                         );
                         warn!("Failed to load Stacks chain tip");
                         let response = HttpResponseType::ServerError(
@@ -2568,7 +2567,7 @@ impl ConversationHttp {
                     &req,
                     &mut network.atlasdb,
                     content_hash.clone(),
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2585,7 +2584,7 @@ impl ConversationHttp {
                     &index_block_hash,
                     pages_indexes,
                     &self.connection.options,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 None
             }
@@ -2598,7 +2597,7 @@ impl ConversationHttp {
                     chainstate,
                     consensus_hash,
                     block,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )?;
                 if accepted {
                     // inform the peer network so it can announce its presence
@@ -2616,7 +2615,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     if let Some((consensus_hash, block_hash)) =
                         ConversationHttp::handle_load_stacks_chain_tip_hashes(
@@ -2625,7 +2624,7 @@ impl ConversationHttp {
                             &req,
                             tip,
                             chainstate,
-                            burn_tip.canonical_stacks_tip_height,
+                            network.burnchain_tip.canonical_stacks_tip_height,
                         )?
                     {
                         let accepted = ConversationHttp::handle_post_microblock(
@@ -2636,7 +2635,7 @@ impl ConversationHttp {
                             &block_hash,
                             chainstate,
                             mblock,
-                            burn_tip.canonical_stacks_tip_height,
+                            network.burnchain_tip.canonical_stacks_tip_height,
                         )?;
                         if accepted {
                             // forward to peer network
@@ -2662,14 +2661,14 @@ impl ConversationHttp {
                     chainstate,
                     query.clone(),
                     network.connection_opts.mempool_max_tx_query,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                     page_id_opt.clone(),
                 )?)
             }
             HttpRequestType::OptionsPreflight(ref _md, ref _path) => {
                 let response_metadata = HttpResponseMetadata::from_http_request_type(
                     &req,
-                    Some(burn_tip.canonical_stacks_tip_height),
+                    Some(network.burnchain_tip.canonical_stacks_tip_height),
                 );
                 let response = HttpResponseType::OptionsPreflight(response_metadata);
                 response
@@ -2691,7 +2690,7 @@ impl ConversationHttp {
                     tip_req,
                     sortdb,
                     chainstate,
-                    burn_tip.canonical_stacks_tip_height,
+                    network.burnchain_tip.canonical_stacks_tip_height,
                 )? {
                     ConversationHttp::handle_get_is_trait_implemented(
                         &mut self.connection.protocol,
@@ -2703,7 +2702,7 @@ impl ConversationHttp {
                         contract_addr,
                         contract_name,
                         trait_id,
-                        burn_tip.canonical_stacks_tip_height,
+                        network.burnchain_tip.canonical_stacks_tip_height,
                     )?;
                 }
                 None
@@ -2711,7 +2710,7 @@ impl ConversationHttp {
             HttpRequestType::ClientError(ref _md, ref err) => {
                 let response_metadata = HttpResponseMetadata::from_http_request_type(
                     &req,
-                    Some(burn_tip.canonical_stacks_tip_height),
+                    Some(network.burnchain_tip.canonical_stacks_tip_height),
                 );
                 let response = match err {
                     ClientError::Message(s) => HttpResponseType::BadRequestJSON(

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -893,6 +893,7 @@ mod test {
             |client_id, _| {
                 let mut request = HttpRequestType::GetInfo(HttpRequestMetadata::from_host(
                     PeerHost::from_host_port("127.0.0.1".to_string(), 51001),
+                    None,
                 ));
                 request.metadata_mut().keep_alive = false;
 
@@ -922,6 +923,7 @@ mod test {
             |client_id, _| {
                 let mut request = HttpRequestType::GetInfo(HttpRequestMetadata::from_host(
                     PeerHost::from_host_port("127.0.0.1".to_string(), 51011),
+                    None,
                 ));
                 request.metadata_mut().keep_alive = false;
 
@@ -966,10 +968,10 @@ mod test {
                 );
 
                 let mut request = HttpRequestType::GetBlock(
-                    HttpRequestMetadata::from_host(PeerHost::from_host_port(
-                        "127.0.0.1".to_string(),
-                        51021,
-                    )),
+                    HttpRequestMetadata::from_host(
+                        PeerHost::from_host_port("127.0.0.1".to_string(), 51021),
+                        None,
+                    ),
                     index_block_hash,
                 );
                 request.metadata_mut().keep_alive = false;
@@ -1030,10 +1032,10 @@ mod test {
                 );
 
                 let mut request = HttpRequestType::GetBlock(
-                    HttpRequestMetadata::from_host(PeerHost::from_host_port(
-                        "127.0.0.1".to_string(),
-                        51031,
-                    )),
+                    HttpRequestMetadata::from_host(
+                        PeerHost::from_host_port("127.0.0.1".to_string(), 51031),
+                        None,
+                    ),
                     index_block_hash,
                 );
                 request.metadata_mut().keep_alive = false;
@@ -1085,6 +1087,7 @@ mod test {
             |client_id, _| {
                 let mut request = HttpRequestType::GetInfo(HttpRequestMetadata::from_host(
                     PeerHost::from_host_port("127.0.0.1".to_string(), 51041),
+                    None,
                 ));
                 request.metadata_mut().keep_alive = false;
 
@@ -1140,6 +1143,7 @@ mod test {
             |client_id, _| {
                 let mut request = HttpRequestType::GetInfo(HttpRequestMetadata::from_host(
                     PeerHost::from_host_port("127.0.0.1".to_string(), 51051),
+                    None,
                 ));
                 request.metadata_mut().keep_alive = false;
 
@@ -1209,10 +1213,10 @@ mod test {
                 let signed_contract_tx = signer.get_tx().unwrap();
 
                 let mut request = HttpRequestType::PostTransaction(
-                    HttpRequestMetadata::from_host(PeerHost::from_host_port(
-                        "127.0.0.1".to_string(),
-                        51061,
-                    )),
+                    HttpRequestMetadata::from_host(
+                        PeerHost::from_host_port("127.0.0.1".to_string(), 51061),
+                        None,
+                    ),
                     signed_contract_tx,
                     None,
                 );
@@ -1312,6 +1316,7 @@ mod test {
                 // send a different request
                 let mut request = HttpRequestType::GetInfo(HttpRequestMetadata::from_host(
                     PeerHost::from_host_port("127.0.0.1".to_string(), 51083),
+                    None,
                 ));
                 request.metadata_mut().keep_alive = false;
 
@@ -1360,10 +1365,10 @@ mod test {
                 );
 
                 let mut request = HttpRequestType::GetBlock(
-                    HttpRequestMetadata::from_host(PeerHost::from_host_port(
-                        "127.0.0.1".to_string(),
-                        51071,
-                    )),
+                    HttpRequestMetadata::from_host(
+                        PeerHost::from_host_port("127.0.0.1".to_string(), 51071),
+                        None,
+                    ),
                     index_block_hash,
                 );
                 request.metadata_mut().keep_alive = false;

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -270,7 +270,7 @@ impl EventObserver {
         json!({
             "attachment_index": attachment.0.attachment_index,
             "index_block_hash": format!("0x{}", attachment.0.index_block_hash),
-            "block_height": attachment.0.block_height,
+            "block_height": attachment.0.stacks_block_height,
             "content_hash": format!("0x{}", attachment.0.content_hash),
             "contract_id": format!("{}", attachment.0.contract_id),
             "metadata": format!("0x{}", attachment.0.metadata),
@@ -367,7 +367,7 @@ impl EventObserver {
         // Wrap events
         let payload = json!({
             "block_hash": format!("0x{}", chain_tip.block.block_hash()),
-            "block_height": chain_tip.metadata.block_height,
+            "block_height": chain_tip.metadata.stacks_block_height,
             "burn_block_hash": format!("0x{}", chain_tip.metadata.burn_header_hash),
             "burn_block_height": chain_tip.metadata.burn_header_height,
             "miner_txid": format!("0x{}", winner_txid),
@@ -670,7 +670,7 @@ impl EventDispatcher {
         anchored_consumed: &ExecutionCost,
         mblock_confirmed_consumed: &ExecutionCost,
     ) {
-        let boot_receipts = if chain_tip.metadata.block_height == 1 {
+        let boot_receipts = if chain_tip.metadata.stacks_block_height == 1 {
             let mut boot_receipts_result = self
                 .boot_receipts
                 .lock()

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -970,7 +970,7 @@ impl Node {
                                     &event_data.value,
                                     &contract_id,
                                     epoch_receipt.header.index_block_hash(),
-                                    epoch_receipt.header.block_height,
+                                    epoch_receipt.header.stacks_block_height,
                                     receipt.transaction.txid(),
                                 );
                                 if let Some(attachment_instance) = res {

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -899,7 +899,7 @@ impl Node {
             if let Err(e) = estimator.notify_block(&processed_block, &stacks_epoch.block_limit) {
                 warn!("FeeEstimator failed to process block receipt";
                       "stacks_block" => %processed_block.header.anchored_header.block_hash(),
-                      "stacks_height" => %processed_block.header.block_height,
+                      "stacks_height" => %processed_block.header.stacks_block_height,
                       "error" => %e);
             }
         }
@@ -972,6 +972,9 @@ impl Node {
                                     epoch_receipt.header.index_block_hash(),
                                     epoch_receipt.header.stacks_block_height,
                                     receipt.transaction.txid(),
+                                    self.chain_tip
+                                        .as_ref()
+                                        .map(|t| t.metadata.stacks_block_height),
                                 );
                                 if let Some(attachment_instance) = res {
                                     attachments_instances.insert(attachment_instance);

--- a/testnet/stacks-node/src/run_loop/mod.rs
+++ b/testnet/stacks-node/src/run_loop/mod.rs
@@ -101,7 +101,7 @@ impl RunLoopCallbacks {
     ) {
         info_green!(
             "Stacks block #{} ({}) successfully produced, including {} transactions",
-            chain_tip.metadata.block_height,
+            chain_tip.metadata.stacks_block_height,
             chain_tip.metadata.index_block_hash(),
             chain_tip.block.txs.len()
         );

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -381,7 +381,7 @@ fn bitcoind_integration_test() {
                 0 => {
                     // Inspecting the chain at round 0.
                     // - Chain length should be 1.
-                    assert!(chain_tip.metadata.block_height == 1);
+                    assert!(chain_tip.metadata.stacks_block_height == 1);
 
                     // Block #1 should only have 0 txs
                     assert!(chain_tip.block.txs.len() == 1);
@@ -394,7 +394,7 @@ fn bitcoind_integration_test() {
                 1 => {
                     // Inspecting the chain at round 1.
                     // - Chain length should be 2.
-                    assert!(chain_tip.metadata.block_height == 2);
+                    assert!(chain_tip.metadata.stacks_block_height == 2);
 
                     // Block #2 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -407,7 +407,7 @@ fn bitcoind_integration_test() {
                 2 => {
                     // Inspecting the chain at round 2.
                     // - Chain length should be 3.
-                    assert!(chain_tip.metadata.block_height == 3);
+                    assert!(chain_tip.metadata.stacks_block_height == 3);
 
                     // Block #3 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -420,7 +420,7 @@ fn bitcoind_integration_test() {
                 3 => {
                     // Inspecting the chain at round 3.
                     // - Chain length should be 4.
-                    assert!(chain_tip.metadata.block_height == 4);
+                    assert!(chain_tip.metadata.stacks_block_height == 4);
 
                     // Block #4 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -433,7 +433,7 @@ fn bitcoind_integration_test() {
                 4 => {
                     // Inspecting the chain at round 4.
                     // - Chain length should be 5.
-                    assert!(chain_tip.metadata.block_height == 5);
+                    assert!(chain_tip.metadata.stacks_block_height == 5);
 
                     // Block #5 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -446,7 +446,7 @@ fn bitcoind_integration_test() {
                 5 => {
                     // Inspecting the chain at round 5.
                     // - Chain length should be 6.
-                    assert!(chain_tip.metadata.block_height == 6);
+                    assert!(chain_tip.metadata.stacks_block_height == 6);
 
                     // Block #6 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -333,7 +333,7 @@ fn integration_test_get_info() {
             1 => {
                 // - Chain length should be 2.
                 let blocks = StacksChainState::list_blocks(&chain_state.db()).unwrap();
-                assert!(chain_tip.metadata.block_height == 2);
+                assert!(chain_tip.metadata.stacks_block_height == 2);
 
                 // Block #1 should have 5 txs
                 assert_eq!(chain_tip.block.txs.len(), 5);
@@ -1206,7 +1206,7 @@ fn contract_stx_transfer() {
 
             match round {
                 1 => {
-                    assert!(chain_tip.metadata.block_height == 2);
+                    assert!(chain_tip.metadata.stacks_block_height == 2);
                     // Block #1 should have 2 txs -- coinbase + transfer
                     assert_eq!(chain_tip.block.txs.len(), 2);
 
@@ -1251,12 +1251,12 @@ fn contract_stx_transfer() {
                     );
                 }
                 2 => {
-                    assert!(chain_tip.metadata.block_height == 3);
+                    assert!(chain_tip.metadata.stacks_block_height == 3);
                     // Block #2 should have 2 txs -- coinbase + publish
                     assert_eq!(chain_tip.block.txs.len(), 2);
                 }
                 3 => {
-                    assert!(chain_tip.metadata.block_height == 4);
+                    assert!(chain_tip.metadata.stacks_block_height == 4);
                     // Block #3 should have 2 txs -- coinbase + contract-call,
                     //   the second publish _should have been rejected_
                     assert_eq!(chain_tip.block.txs.len(), 2);
@@ -1303,7 +1303,7 @@ fn contract_stx_transfer() {
                     );
                 }
                 4 => {
-                    assert!(chain_tip.metadata.block_height == 5);
+                    assert!(chain_tip.metadata.stacks_block_height == 5);
                     assert_eq!(
                         chain_tip.block.txs.len() as u64,
                         MAXIMUM_MEMPOOL_TX_CHAINING + 1,
@@ -1461,19 +1461,19 @@ fn mine_transactions_out_of_order() {
 
             match round {
                 1 => {
-                    assert_eq!(chain_tip.metadata.block_height, 2);
+                    assert_eq!(chain_tip.metadata.stacks_block_height, 2);
                     assert_eq!(chain_tip.block.txs.len(), 1);
                 }
                 2 => {
-                    assert_eq!(chain_tip.metadata.block_height, 3);
+                    assert_eq!(chain_tip.metadata.stacks_block_height, 3);
                     assert_eq!(chain_tip.block.txs.len(), 1);
                 }
                 3 => {
-                    assert_eq!(chain_tip.metadata.block_height, 4);
+                    assert_eq!(chain_tip.metadata.stacks_block_height, 4);
                     assert_eq!(chain_tip.block.txs.len(), 1);
                 }
                 4 => {
-                    assert_eq!(chain_tip.metadata.block_height, 5);
+                    assert_eq!(chain_tip.metadata.stacks_block_height, 5);
                     assert_eq!(chain_tip.block.txs.len(), 5);
 
                     // check that 1000 stx _was_ transfered to the contract principal
@@ -1720,7 +1720,7 @@ fn bad_contract_tx_rollback() {
 
             match round {
                 1 => {
-                    assert!(chain_tip.metadata.block_height == 2);
+                    assert!(chain_tip.metadata.stacks_block_height == 2);
                     // Block #1 should have 2 txs -- coinbase + transfer
                     assert_eq!(chain_tip.block.txs.len(), 2);
 
@@ -1765,12 +1765,12 @@ fn bad_contract_tx_rollback() {
                     );
                 }
                 2 => {
-                    assert_eq!(chain_tip.metadata.block_height, 3);
+                    assert_eq!(chain_tip.metadata.stacks_block_height, 3);
                     // Block #2 should have 4 txs -- coinbase + 2 transfer + 1 publish
                     assert_eq!(chain_tip.block.txs.len(), 4);
                 }
                 3 => {
-                    assert_eq!(chain_tip.metadata.block_height, 4);
+                    assert_eq!(chain_tip.metadata.stacks_block_height, 4);
                     // Block #2 should have 1 txs -- coinbase
                     assert_eq!(chain_tip.block.txs.len(), 1);
                 }

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -522,7 +522,7 @@ fn should_succeed_mining_valid_txs() {
                 0 => {
                     // Inspecting the chain at round 0.
                     // - Chain length should be 1.
-                    assert!(chain_tip.metadata.block_height == 1);
+                    assert!(chain_tip.metadata.stacks_block_height == 1);
 
                     // Block #1 should only have 0 txs
                     assert!(chain_tip.block.txs.len() == 1);
@@ -539,7 +539,7 @@ fn should_succeed_mining_valid_txs() {
                 1 => {
                     // Inspecting the chain at round 1.
                     // - Chain length should be 2.
-                    assert!(chain_tip.metadata.block_height == 2);
+                    assert!(chain_tip.metadata.stacks_block_height == 2);
 
                     // Block #2 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -571,7 +571,7 @@ fn should_succeed_mining_valid_txs() {
                 2 => {
                     // Inspecting the chain at round 2.
                     // - Chain length should be 3.
-                    assert!(chain_tip.metadata.block_height == 3);
+                    assert!(chain_tip.metadata.stacks_block_height == 3);
 
                     // Block #3 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -603,7 +603,7 @@ fn should_succeed_mining_valid_txs() {
                 3 => {
                     // Inspecting the chain at round 3.
                     // - Chain length should be 4.
-                    assert!(chain_tip.metadata.block_height == 4);
+                    assert!(chain_tip.metadata.stacks_block_height == 4);
 
                     // Block #4 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -644,7 +644,7 @@ fn should_succeed_mining_valid_txs() {
                 4 => {
                     // Inspecting the chain at round 4.
                     // - Chain length should be 5.
-                    assert!(chain_tip.metadata.block_height == 5);
+                    assert!(chain_tip.metadata.stacks_block_height == 5);
 
                     // Block #5 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -685,7 +685,7 @@ fn should_succeed_mining_valid_txs() {
                 5 => {
                     // Inspecting the chain at round 5.
                     // - Chain length should be 6.
-                    assert!(chain_tip.metadata.block_height == 6);
+                    assert!(chain_tip.metadata.stacks_block_height == 6);
 
                     // Block #6 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);
@@ -809,7 +809,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 0 => {
                     // Inspecting the chain at round 0.
                     // - Chain length should be 1.
-                    assert!(chain_tip.metadata.block_height == 1);
+                    assert!(chain_tip.metadata.stacks_block_height == 1);
 
                     // Block #1 should only have 1 txs
                     assert!(chain_tip.block.txs.len() == 1);
@@ -825,7 +825,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 1 => {
                     // Inspecting the chain at round 1.
                     // - Chain length should be 2.
-                    assert!(chain_tip.metadata.block_height == 2);
+                    assert!(chain_tip.metadata.stacks_block_height == 2);
 
                     // Block #2 should only have 2 txs
                     assert_eq!(chain_tip.block.txs.len(), 2);
@@ -849,7 +849,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 2 => {
                     // Inspecting the chain at round 2.
                     // - Chain length should be 3.
-                    assert!(chain_tip.metadata.block_height == 3);
+                    assert!(chain_tip.metadata.stacks_block_height == 3);
 
                     // Block #3 should only have 1 tx (the other being invalid)
                     assert!(chain_tip.block.txs.len() == 1);
@@ -865,7 +865,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 3 => {
                     // Inspecting the chain at round 3.
                     // - Chain length should be 4.
-                    assert!(chain_tip.metadata.block_height == 4);
+                    assert!(chain_tip.metadata.stacks_block_height == 4);
 
                     // Block #4 should only have 1 tx (the other being invalid)
                     assert!(chain_tip.block.txs.len() == 1);
@@ -881,7 +881,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 4 => {
                     // Inspecting the chain at round 4.
                     // - Chain length should be 5.
-                    assert!(chain_tip.metadata.block_height == 5);
+                    assert!(chain_tip.metadata.stacks_block_height == 5);
 
                     // Block #5 should only have 2 txs
                     assert!(chain_tip.block.txs.len() == 2);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -4131,7 +4131,7 @@ fn block_limit_hit_integration_test() {
     // included in first block
     let tx_4 = make_stacks_transfer(&third_spender_sk, 0, 180, &PrincipalData::from(addr), 100);
 
-    let (mut conf, miner_account) = neon_integration_test_conf();
+    let (mut conf, _miner_account) = neon_integration_test_conf();
 
     conf.initial_balances.push(InitialBalance {
         address: addr.clone().into(),
@@ -4718,7 +4718,7 @@ fn microblock_large_tx_integration_test() {
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
     // Check that the microblock contains the first tx.
-    let mut microblock_events = test_observer::get_microblocks();
+    let microblock_events = test_observer::get_microblocks();
     assert!(microblock_events.len() >= 1);
 
     let microblock = microblock_events[0].clone();


### PR DESCRIPTION
This PR adds information about a node's canonical stacks tip height to its http headers. This way, nodes will have visibility of their peers' heights. 
This work will be used in #2768, to implement a health check endpoint. Part of the notion of health of a node is being caught up to their peers.  

## Testing 
Added test in `rpc.rs`