### PR TITLE
Fix: add macos-arm64 builds to releases

### DIFF
--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -249,7 +249,7 @@ jobs:
       - create-release
     strategy:
       matrix:
-        platform: [ windows-x64, macos-x64, linux-x64, linux-musl-x64, linux-armv7, linux-arm64 ]
+        platform: [ windows-x64, macos-x64, macos-arm64, linux-x64, linux-musl-x64, linux-armv7, linux-arm64 ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI already builds and uploads a `macos-arm64` target, but it's not included as an asset in releases. This adds the macos-arm64 build in the `create-release` job.