### PR TITLE
Fix: MinedBlock event txid

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -2,7 +2,7 @@ FROM rust:bullseye AS test
 
 WORKDIR /build
 
-RUN rustup override set nightly && \
+RUN rustup override set nightly-2022-01-14 && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -6,7 +6,7 @@ COPY . .
 
 WORKDIR /src/testnet/stacks-node
 
-RUN rustup override set nightly && \
+RUN rustup override set nightly-2022-01-14 && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -9,7 +9,7 @@ RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
-RUN rustup override set nightly && \
+RUN rustup override set nightly-2022-01-14 && \
     rustup component add llvm-tools-preview && \
     cargo install grcov
 

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -40,6 +40,7 @@ use clarity_vm::clarity::{ClarityConnection, ClarityInstance};
 use core::mempool::*;
 use core::*;
 use net::Error as net_error;
+use serde::Deserialize;
 use util::get_epoch_time_ms;
 use util::hash::MerkleTree;
 use util::hash::Sha512Trunc256Sum;
@@ -159,6 +160,7 @@ pub struct TransactionSkipped {
 /// Represents an event for a successful transaction. This transaction should be added to the block.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransactionSuccessEvent {
+    #[serde(deserialize_with = "hex_deserialize", serialize_with = "hex_serialize")]
     pub txid: Txid,
     pub fee: u64,
     pub execution_cost: ExecutionCost,
@@ -168,6 +170,7 @@ pub struct TransactionSuccessEvent {
 /// Represents an event for a failed transaction. Something went wrong when processing this transaction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionErrorEvent {
+    #[serde(deserialize_with = "hex_deserialize", serialize_with = "hex_serialize")]
     pub txid: Txid,
     pub error: String,
 }
@@ -175,8 +178,19 @@ pub struct TransactionErrorEvent {
 /// Represents an event for a transaction that was skipped, but might succeed later.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TransactionSkippedEvent {
+    #[serde(deserialize_with = "hex_deserialize", serialize_with = "hex_serialize")]
     pub txid: Txid,
     pub error: String,
+}
+
+fn hex_serialize<S: serde::Serializer>(txid: &Txid, s: S) -> Result<S::Ok, S::Error> {
+    let inst = txid.to_hex();
+    s.serialize_str(inst.as_str())
+}
+
+fn hex_deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Txid, D::Error> {
+    let inst_str = String::deserialize(d)?;
+    Txid::from_hex(&inst_str).map_err(serde::de::Error::custom)
 }
 
 /// `TransactionResult` represents the outcome of transaction processing.

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -165,6 +165,35 @@ pub mod test_observer {
 
     async fn handle_mined_block(block: serde_json::Value) -> Result<impl warp::Reply, Infallible> {
         let mut mined_blocks = MINED_BLOCKS.lock().unwrap();
+        // assert that the mined transaction events have string-y txids
+        block
+            .as_object()
+            .expect("Expected JSON object for mined block event")
+            .get("tx_events")
+            .expect("Expected tx_events key in mined block event")
+            .as_array()
+            .expect("Expected tx_events key to be an array in mined block event")
+            .iter()
+            .for_each(|txevent| {
+                let txevent_obj = txevent.as_object().expect("TransactionEvent should be object");
+                let inner_obj = if let Some(inner_obj) = txevent_obj.get("Success") {
+                    inner_obj
+                } else if let Some(inner_obj) = txevent_obj.get("ProcessingError") {
+                    inner_obj
+                } else if let Some(inner_obj) = txevent_obj.get("Skipped") {
+                    inner_obj
+                } else {
+                    panic!("TransactionEvent object should have one of Success, ProcessingError, or Skipped")
+                };
+                inner_obj
+                    .as_object()
+                    .expect("TransactionEvent should be an object")
+                    .get("txid")
+                    .expect("Should have txid key")
+                    .as_str()
+                    .expect("Expected txid to be a string");
+            });
+
         mined_blocks.push(serde_json::from_value(block).unwrap());
         Ok(warp::http::StatusCode::OK)
     }


### PR DESCRIPTION
This updates the MinedBlock event's serde serialization to do hex serialization of the txid. Previously, the txid would be serialized like a number array.