### PR TITLE
Fix arg count checks for map functions

### DIFF
--- a/src/vm/analysis/type_checker/natives/maps.rs
+++ b/src/vm/analysis/type_checker/natives/maps.rs
@@ -21,8 +21,7 @@ use vm::functions::tuples;
 
 use super::check_special_tuple_cons;
 use vm::analysis::type_checker::{
-    check_arguments_at_least, no_type, CheckError, CheckErrors, TypeChecker, TypeResult,
-    TypingContext,
+    check_argument_count, no_type, CheckError, CheckErrors, TypeChecker, TypeResult, TypingContext,
 };
 
 use vm::costs::cost_functions::ClarityCostFunction;
@@ -33,7 +32,7 @@ pub fn check_special_fetch_entry(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(2, args)?;
+    check_argument_count(2, args)?;
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 
@@ -73,7 +72,7 @@ pub fn check_special_delete_entry(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(2, args)?;
+    check_argument_count(2, args)?;
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 
@@ -106,7 +105,7 @@ fn check_set_or_insert_entry(
     args: &[SymbolicExpression],
     context: &TypingContext,
 ) -> TypeResult {
-    check_arguments_at_least(3, args)?;
+    check_argument_count(3, args)?;
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::BadMapName)?;
 

--- a/src/vm/analysis/type_checker/tests/mod.rs
+++ b/src/vm/analysis/type_checker/tests/mod.rs
@@ -1862,6 +1862,29 @@ fn test_fetch_entry_mismatching_type_signatures() {
 }
 
 #[test]
+fn test_fetch_entry_mismatching_arg_counts() {
+    let cases = [
+        "map-get? kv-store",
+        "map-get? kv-store { key: key } { key: 0 }",
+    ];
+
+    for case in cases.iter() {
+        let contract_src = format!(
+            "(define-map kv-store {{ key: int }} {{ value: int }})
+             (define-private (incompatible-tuple) (tuple (k 1)))
+             (define-private (kv-get (key int))
+                ({}))",
+            case
+        );
+        let res = mem_type_check(&contract_src).unwrap_err();
+        assert!(match &res.err {
+            &CheckErrors::IncorrectArgumentCount(_, _) => true,
+            _ => false,
+        });
+    }
+}
+
+#[test]
 fn test_fetch_entry_unbound_variables() {
     let cases = ["map-get? kv-store { key: unknown-value }"];
 
@@ -1922,6 +1945,29 @@ fn test_insert_entry_mismatching_type_signatures() {
         let res = mem_type_check(&contract_src).unwrap_err();
         assert!(match &res.err {
             &CheckErrors::TypeError(_, _) => true,
+            _ => false,
+        });
+    }
+}
+
+#[test]
+fn test_insert_entry_mismatching_arg_counts() {
+    let cases = [
+        "map-insert kv-store { key: key }",
+        "map-insert kv-store { key: key } { value: value } { value: 0}",
+    ];
+
+    for case in cases.iter() {
+        let contract_src = format!(
+            "(define-map kv-store {{ key: int }} {{ value: int }})
+             (define-private (incompatible-tuple) (tuple (k 1)))
+             (define-private (kv-add (key int) (value int))
+                ({}))",
+            case
+        );
+        let res = mem_type_check(&contract_src).unwrap_err();
+        assert!(match &res.err {
+            &CheckErrors::IncorrectArgumentCount(_, _) => true,
             _ => false,
         });
     }
@@ -1995,6 +2041,29 @@ fn test_delete_entry_mismatching_type_signatures() {
 }
 
 #[test]
+fn test_delete_entry_mismatching_arg_count() {
+    let cases = [
+        "map-delete kv-store",
+        "map-delete kv-store { key: 1 } false",
+    ];
+
+    for case in cases.iter() {
+        let contract_src = format!(
+            "(define-map kv-store {{ key: int }} {{ value: int }})
+             (define-private (incompatible-tuple) (tuple (k 1)))
+             (define-private (kv-del (key int))
+                ({}))",
+            case
+        );
+        let res = mem_type_check(&contract_src).unwrap_err();
+        assert!(match &res.err {
+            &CheckErrors::IncorrectArgumentCount(_, _) => true,
+            _ => false,
+        });
+    }
+}
+
+#[test]
 fn test_delete_entry_unbound_variables() {
     let cases = ["map-delete kv-store { key: unknown-value }"];
 
@@ -2057,6 +2126,29 @@ fn test_set_entry_mismatching_type_signatures() {
         let res = mem_type_check(&&contract_src).unwrap_err();
         assert!(match &res.err {
             &CheckErrors::TypeError(_, _) => true,
+            _ => false,
+        });
+    }
+}
+
+#[test]
+fn test_set_entry_mismatching_arg_counts() {
+    let cases = [
+        "map-set kv-store",
+        "map-set kv-store { key: key } { value: value } {value: 0}",
+    ];
+
+    for case in cases.iter() {
+        let contract_src = format!(
+            "(define-map kv-store {{ key: int }} {{ value: int }})
+             (define-private (incompatible-tuple) (tuple (k 1)))
+             (define-private (kv-set (key int) (value int))
+                ({}))",
+            case
+        );
+        let res = mem_type_check(&&contract_src).unwrap_err();
+        assert!(match &res.err {
+            &CheckErrors::IncorrectArgumentCount(_, _) => true,
             _ => false,
         });
     }


### PR DESCRIPTION
## Description

The checks in the type checker for the map functions use `check_arguments_at_least` when they should use `check_argument_count`, since passing too many arguments should be reported as an error.

1. Motivation for change
hirosystems/clarinet#228 (@friedger)

2. What was changed
I modified those checks to look for the exact argument count.

3. How does this impact application developers
If existing contracts were passing too many arguments to these functions, they will now get errors.

4. Link to relevant issues and documentation
hirosystems/clarinet#228

5. Provide examples of use cases with code samples and applicable acceptance criteria

This program should report an error for passing too many arguments to `map-delete`:
```clarity
(define-map user-profile principal principal)
(define-public (delete)
  (ok (map-delete user-profile tx-sender contract-caller)))
```

## Type of Change
- Bug fix - this is reporting an error where it was previously ignored

## Does this introduce a breaking change?

Technically, yes. If any existing contracts passed too many arguments to these functions, they would now report an error.

## Are documentation updates required?
No, the documentation already describes the appropriate arguments.

## Testing information

I added cases to check for wrong numbers of arguments to these functions.