### PR TITLE
feat: Mempool Analyzer

### DIFF
--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -84,6 +84,8 @@ use crate::types::chainstate::{
 };
 use crate::types::proof::{ClarityMarfTrieId, TrieHash};
 use crate::util::boot::{boot_code_acc, boot_code_addr, boot_code_id, boot_code_tx_auth};
+use clarity_vm::clarity::BlockLimitsFunctions;
+use clarity_vm::clarity::ProductionBlockLimitFns;
 use vm::Value;
 
 pub mod accounts;
@@ -1552,6 +1554,22 @@ impl StacksChainState {
         path_str: &str,
         boot_data: Option<&mut ChainStateBootData>,
     ) -> Result<(StacksChainState, Vec<StacksTransactionReceipt>), Error> {
+        StacksChainState::open_and_exec_with_limits(
+            mainnet,
+            chain_id,
+            path_str,
+            boot_data,
+            ProductionBlockLimitFns(),
+        )
+    }
+
+    pub fn open_and_exec_with_limits(
+        mainnet: bool,
+        chain_id: u32,
+        path_str: &str,
+        boot_data: Option<&mut ChainStateBootData>,
+        block_limit_fns: BlockLimitsFunctions,
+    ) -> Result<(StacksChainState, Vec<StacksTransactionReceipt>), Error> {
         StacksChainState::make_chainstate_dirs(path_str)?;
         let path = PathBuf::from(path_str);
         let blocks_path = StacksChainState::blocks_path(path.clone());
@@ -1596,7 +1614,8 @@ impl StacksChainState {
         )
         .map_err(|e| Error::ClarityError(e.into()))?;
 
-        let clarity_state = ClarityInstance::new(mainnet, vm_state);
+        let clarity_state =
+            ClarityInstance::new_with_limits_fns(mainnet, vm_state, block_limit_fns);
 
         let mut chainstate = StacksChainState {
             mainnet: mainnet,

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -878,7 +878,7 @@ pub struct StacksBlockBuilder {
     parent_header_hash: BlockHeaderHash,
     parent_microblock_hash: Option<BlockHeaderHash>,
     miner_id: usize,
-    block_limits_fns:BlockLimitsFunctions,
+    block_limits_fns: BlockLimitsFunctions,
 }
 
 // maximum microblock size is 64KB, but note that the current leader has a space budget of

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -60,6 +60,7 @@ use crate::types::chainstate::{
 };
 use crate::types::chainstate::{StacksBlockHeader, StacksBlockId, StacksMicroblockHeader};
 use crate::types::proof::{TrieHash, TRIEHASH_ENCODED_SIZE};
+use clarity_vm::clarity::BlockLimitsFunctions;
 
 pub mod address;
 pub mod auth;
@@ -877,10 +878,8 @@ pub struct StacksBlockBuilder {
     parent_header_hash: BlockHeaderHash,
     parent_microblock_hash: Option<BlockHeaderHash>,
     miner_id: usize,
+    block_limits_fns:BlockLimitsFunctions,
 }
-
-// maximum amount of data a leader can send during its epoch (2MB)
-pub const MAX_EPOCH_SIZE: u32 = 2 * 1024 * 1024;
 
 // maximum microblock size is 64KB, but note that the current leader has a space budget of
 // $MAX_EPOCH_SIZE bytes (so the average microblock size needs to be 4kb if there are 256 of them)

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -74,7 +74,7 @@ use types::chainstate::BurnchainHeaderHash;
 
 /// This struct is used to map the context at a point in time to concrete limits on block
 /// length and execution run-time. This allows the user to either:
-///   1) use default production settings, e.g., read the block limits from the StacksEpoch
+///   1) use default production settings, i.e., read the block limits from the StacksEpoch
 ///   2) override defaults with special settings to make a tool, e.g., the mempool analyzer
 ///   3) override defaults with special settings for test.
 /// Note: We use a simple interface that can be expanded over time if necessary.

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -70,7 +70,6 @@ use crate::types::proof::TrieHash;
 use crate::util::boot::{boot_code_acc, boot_code_addr, boot_code_id, boot_code_tx_auth};
 use crate::util::db::Error as db_error;
 use crate::util::secp256k1::MessageSignature;
-use chainstate::stacks::MAX_EPOCH_SIZE;
 use types::chainstate::BurnchainHeaderHash;
 
 /// This struct is used to map the context at a point in time to concrete limits on block
@@ -79,6 +78,7 @@ use types::chainstate::BurnchainHeaderHash;
 ///   2) override defaults with special settings to make a tool, e.g., the mempool analyzer
 ///   3) override defaults with special settings for test.
 /// Note: We use a simple interface that can be expanded over time if necessary.
+#[derive(Clone)]
 pub struct BlockLimitsFunctions {
     /// The length limit of a block.
     pub output_length_limit: u32,
@@ -285,6 +285,9 @@ impl ClarityBlockConnection<'_> {
         }
     }
 }
+
+// Maximum amount of data a leader can send during its epoch (2MB).
+pub const MAX_EPOCH_SIZE: u32 = 2 * 1024 * 1024;
 
 /// `BlockLimitsFunctions` for production. Use `MAX_EPOCH_SIZE` for length limit and get block
 /// limits from `StacksEpoch`.

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -287,7 +287,7 @@ impl ClarityBlockConnection<'_> {
 }
 
 // Maximum amount of data a leader can send during its epoch (2MB).
-pub const MAX_EPOCH_SIZE: u32 = 2 * 1024 * 1024;
+const MAX_EPOCH_SIZE: u32 = 2 * 1024 * 1024;
 
 /// `BlockLimitsFunctions` for production. Use `MAX_EPOCH_SIZE` for length limit and get block
 /// limits from `StacksEpoch`.

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -70,7 +70,23 @@ use crate::types::proof::TrieHash;
 use crate::util::boot::{boot_code_acc, boot_code_addr, boot_code_id, boot_code_tx_auth};
 use crate::util::db::Error as db_error;
 use crate::util::secp256k1::MessageSignature;
+use chainstate::stacks::MAX_EPOCH_SIZE;
 use types::chainstate::BurnchainHeaderHash;
+
+/// This struct is used to map the context at a point in time to concrete limits on block
+/// length and execution run-time. This allows the user to either:
+///   1) use default production settings, e.g., read the block limits from the StacksEpoch
+///   2) override defaults with special settings to make a tool, e.g., the mempool analyzer
+///   3) override defaults with special settings for test.
+/// Note: We use a simple interface that can be expanded over time if necessary.
+pub struct BlockLimitsFunctions {
+    /// The length limit of a block.
+    pub output_length_limit: u32,
+    /// Function mapping the StacksEpoch to an execution cost.
+    /// Note: We have to look up the StacksEpoch at run-time anyway, so we avoid an interface
+    /// that would require looking it up again.
+    pub execution_block_limit_fn: fn(&StacksEpoch) -> ExecutionCost,
+}
 
 ///
 /// A high-level interface for interacting with the Clarity VM.
@@ -88,6 +104,8 @@ use types::chainstate::BurnchainHeaderHash;
 pub struct ClarityInstance {
     datastore: MarfedKV,
     mainnet: bool,
+    /// Derive block limits from the given context. Used to use or override production defaults.
+    pub block_limits_fns: BlockLimitsFunctions,
 }
 
 ///
@@ -268,9 +286,49 @@ impl ClarityBlockConnection<'_> {
     }
 }
 
+/// `BlockLimitsFunctions` for production. Use `MAX_EPOCH_SIZE` for length limit and get block
+/// limits from `StacksEpoch`.
+pub fn ProductionBlockLimitFns() -> BlockLimitsFunctions {
+    BlockLimitsFunctions {
+        output_length_limit: MAX_EPOCH_SIZE,
+        execution_block_limit_fn: |epoch: &StacksEpoch| epoch.block_limit.clone(),
+    }
+}
+
+/// Creates an "unlimited" block size. This can be used for analyzing the mempool.
+pub fn UnlimitedBlockLimitFns() -> BlockLimitsFunctions {
+    BlockLimitsFunctions {
+        output_length_limit: u32::MAX,
+        execution_block_limit_fn: |_epoch: &StacksEpoch| ExecutionCost {
+            write_length: u64::MAX,
+            write_count: u64::MAX,
+            read_length: u64::MAX,
+            read_count: u64::MAX,
+            runtime: u64::MAX,
+        },
+    }
+}
+
 impl ClarityInstance {
+    /// Uses production block limits.
     pub fn new(mainnet: bool, datastore: MarfedKV) -> ClarityInstance {
-        ClarityInstance { datastore, mainnet }
+        ClarityInstance {
+            datastore,
+            mainnet,
+            block_limits_fns: ProductionBlockLimitFns(),
+        }
+    }
+
+    pub fn new_with_limits_fns(
+        mainnet: bool,
+        datastore: MarfedKV,
+        block_limits_fns: BlockLimitsFunctions,
+    ) -> ClarityInstance {
+        ClarityInstance {
+            datastore,
+            mainnet,
+            block_limits_fns,
+        }
     }
 
     pub fn with_marf<F, R>(&mut self, f: F) -> R
@@ -320,16 +378,12 @@ impl ClarityInstance {
         let mut datastore = self.datastore.begin(current, next);
 
         let epoch = Self::get_epoch_of(current, header_db, burn_state_db);
+        let block_limit = (self.block_limits_fns.execution_block_limit_fn)(&epoch).clone();
         let cost_track = {
             let mut clarity_db = datastore.as_clarity_db(&NULL_HEADER_DB, &NULL_BURN_STATE_DB);
             Some(
-                LimitedCostTracker::new(
-                    self.mainnet,
-                    epoch.block_limit.clone(),
-                    &mut clarity_db,
-                    epoch.epoch_id,
-                )
-                .expect("FAIL: problem instantiating cost tracking"),
+                LimitedCostTracker::new(self.mainnet, block_limit, &mut clarity_db, epoch.epoch_id)
+                    .expect("FAIL: problem instantiating cost tracking"),
             )
         };
 

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -33,6 +33,11 @@ version = "=0.24.2"
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [[bin]]
+name = "mempool-analyzer"
+path = "src/mempool_analyzer.rs"
+
+
+[[bin]]
 name = "stacks-node"
 path = "src/main.rs"
 

--- a/testnet/stacks-node/src/mempool_analyzer.rs
+++ b/testnet/stacks-node/src/mempool_analyzer.rs
@@ -1,0 +1,184 @@
+/// Usage: {} <working-dir> [max-time]
+///
+/// This program can be used to "analyze the mempool".
+///
+/// In particular, it can be used to mine an "unlimited block". That is, it will attempt
+/// to build a block from the transactions in the mempool, but will never run out of
+/// space in the block. Thus, each transaction in the mempool will be tried once.
+///
+/// Note that nonces which are too high initially can become appropriate as blocks are processed.
+///
+/// <working-dir> specifies the `working_dir` from the miner's config file.
+/// [max-time] optionally gives an amount of time to stop mining after, useful for debugging.
+extern crate stacks;
+
+#[macro_use(slog_warn)]
+extern crate slog;
+use std::env;
+use std::process;
+
+use cost_estimates::metrics::UnitMetric;
+use stacks::cost_estimates::UnitEstimator;
+
+use clarity_vm::clarity::UnlimitedBlockLimitFns;
+use stacks::burnchains::Txid;
+use stacks::chainstate::burn::ConsensusHash;
+use stacks::chainstate::stacks::miner::*;
+use stacks::chainstate::stacks::*;
+use stacks::core::mempool::*;
+use stacks::types::chainstate::BlockHeaderHash;
+use stacks::*;
+use stacks::{
+    chainstate::{burn::db::sortdb::SortitionDB, stacks::db::StacksChainState},
+    core::MemPoolDB,
+    util::{hash::Hash160, vrf::VRFProof},
+    vm::costs::ExecutionCost,
+};
+
+/// Prints transaction events to the standard output.
+struct PrintDebugEventDispatcher {}
+
+impl PrintDebugEventDispatcher {
+    fn new() -> PrintDebugEventDispatcher {
+        return PrintDebugEventDispatcher {};
+    }
+}
+
+impl MemPoolEventDispatcher for PrintDebugEventDispatcher {
+    fn mempool_txs_dropped(&self, _txids: Vec<Txid>, _reason: MemPoolDropReason) {
+        warn!("`mempool_txs_dropped` was called.");
+    }
+    fn mined_block_event(
+        &self,
+        _target_burn_height: u64,
+        _block: &StacksBlock,
+        _block_size_bytes: u64,
+        _consumed: &ExecutionCost,
+        _confirmed_microblock_cost: &ExecutionCost,
+        tx_results: Vec<TransactionEvent>,
+    ) {
+        for tx_event in tx_results {
+            println!("tx_event {:?}", &tx_event);
+        }
+    }
+    fn mined_microblock_event(
+        &self,
+        _microblock: &StacksMicroblock,
+        _tx_results: Vec<TransactionEvent>,
+        _anchor_block_consensus_hash: ConsensusHash,
+        _anchor_block: BlockHeaderHash,
+    ) {
+        panic!("`mined_microblock_event` was not expected in this workflow.");
+    }
+}
+
+fn main() {
+    let argv: Vec<String> = env::args().collect();
+    if argv.len() < 2 {
+        eprintln!(
+            "Usage: {} <working-dir> [max-time]
+
+ This program can be used to \"analyze the mempool\".
+
+ In particular, it can be used to mine an \"unlimited block\". That is, it will attempt
+ to build a block from the transactions in the mempool, but will never run out of
+ space in the block. Thus, each transaction in the mempool will be tried once.
+
+ Note that nonces which are too high initially can become appropriate as blocks are processed.
+
+ <working-dir> specifies the `working_dir` from the miner's config file.
+ [max-time] optionally gives an amount of time to stop mining after, useful for debugging.
+ ",
+            argv[0]
+        );
+        process::exit(1);
+    }
+
+    let sort_db_path = format!("{}/mainnet/burnchain/sortition", &argv[1]);
+    let chain_state_path = format!("{}/mainnet/chainstate/", &argv[1]);
+
+    let min_fee = u64::max_value();
+    let mut max_time = u64::max_value();
+
+    if argv.len() >= 3 {
+        max_time = argv[2].parse().expect("Could not parse max_time");
+    }
+    eprintln!("mempool_analyzer: max_time {}", max_time);
+
+    let sort_db = SortitionDB::open(&sort_db_path, false)
+        .expect(&format!("Failed to open {}", &sort_db_path));
+    let chain_id = core::CHAIN_ID_MAINNET;
+    let (chain_state, _) = StacksChainState::open_and_exec_with_limits(
+        true,
+        chain_id,
+        &chain_state_path,
+        None,
+        UnlimitedBlockLimitFns(),
+    )
+    .expect("Failed to open stacks chain state");
+    let chain_tip = SortitionDB::get_canonical_burn_chain_tip(sort_db.conn())
+        .expect("Failed to get sortition chain tip");
+
+    let estimator = Box::new(UnitEstimator);
+    let metric = Box::new(UnitMetric);
+
+    let mut mempool_db = MemPoolDB::open(true, chain_id, &chain_state_path, estimator, metric)
+        .expect("Failed to open mempool db");
+
+    let stacks_block = chain_state.get_stacks_chain_tip(&sort_db).unwrap().unwrap();
+    let parent_header = StacksChainState::get_anchored_block_header_info(
+        chain_state.db(),
+        &stacks_block.consensus_hash,
+        &stacks_block.anchored_block_hash,
+    )
+    .expect("Failed to load chain tip header info")
+    .expect("Failed to load chain tip header info");
+
+    let sk = StacksPrivateKey::new();
+    let mut tx_auth = TransactionAuth::from_p2pkh(&sk).unwrap();
+    tx_auth.set_origin_nonce(0);
+
+    let mut coinbase_tx = StacksTransaction::new(
+        TransactionVersion::Mainnet,
+        tx_auth,
+        TransactionPayload::Coinbase(CoinbasePayload([0u8; 32])),
+    );
+
+    coinbase_tx.chain_id = chain_id;
+    coinbase_tx.anchor_mode = TransactionAnchorMode::OnChainOnly;
+    let mut tx_signer = StacksTransactionSigner::new(&coinbase_tx);
+    tx_signer.sign_origin(&sk).unwrap();
+    let coinbase_tx = tx_signer.get_tx().unwrap();
+
+    let mut settings = BlockBuilderSettings::limited();
+    settings.max_miner_time_ms = max_time;
+    settings.mempool_settings.min_tx_fee = min_fee;
+
+    let dispatcher = PrintDebugEventDispatcher::new();
+    let result = StacksBlockBuilder::build_anchored_block(
+        &chain_state,
+        &sort_db.index_conn(),
+        &mut mempool_db,
+        &parent_header,
+        chain_tip.total_burn,
+        VRFProof::empty(),
+        Hash160([0; 20]),
+        &coinbase_tx,
+        settings,
+        Some(&dispatcher),
+    );
+
+    if let Ok((block, execution_cost, size)) = result {
+        let mut total_fees = 0;
+        for tx in block.txs.iter() {
+            total_fees += tx.get_tx_fee();
+        }
+        println!(
+            "Block {}: {} uSTX fees, {} bytes, cost {:?}",
+            block.block_hash(),
+            total_fees,
+            size,
+            &execution_cost
+        );
+    }
+}

--- a/testnet/stacks-node/src/mempool_analyzer.rs
+++ b/testnet/stacks-node/src/mempool_analyzer.rs
@@ -98,11 +98,11 @@ fn main() {
     let chain_state_path = format!("{}/mainnet/chainstate/", &argv[1]);
 
     let min_fee = u64::max_value();
-    let mut max_time = u64::max_value();
-
-    if argv.len() >= 3 {
-        max_time = argv[2].parse().expect("Could not parse max_time");
-    }
+    let max_time = if argv.len() >= 3 {
+        argv[2].parse().expect("Could not parse max_time")
+    } else {
+        u64::max_value()
+    };
     eprintln!("mempool_analyzer: max_time {}", max_time);
 
     let sort_db = SortitionDB::open(&sort_db_path, false)

--- a/testnet/stacks-node/src/mempool_analyzer.rs
+++ b/testnet/stacks-node/src/mempool_analyzer.rs
@@ -58,7 +58,7 @@ impl MemPoolEventDispatcher for PrintDebugEventDispatcher {
         tx_results: Vec<TransactionEvent>,
     ) {
         for tx_event in tx_results {
-            println!("tx_event {:?}", &tx_event);
+            println!("{:?}", &tx_event);
         }
     }
     fn mined_microblock_event(


### PR DESCRIPTION
## Motivation
Towards #3002 

## New Code
This program can be used to "analyze the mempool". This can be used to compute statistics, especially:
* how big is the mempool?
* what percentage of mempool transactions are mineable?
* what is the cost to clear the mempool?

More specifically, this tool can be used to mine an "unlimited block". That is, it will attempt to build a block from the transactions in the mempool, but will never run out of space in the block.

Each transaction in the mempool will be tried once.

## Changed Code

To support this change, we introduce `BlockLimitsFunctions`, which allows the user to specify custom block limits. Currently, there is no choice but to take the limits from the `StacksEpoch`. Now, users writing custom tools or tests will be able to override these values.

## Testing
The new memory analyzer tool is just tested by running it. It's not currently in production.

The changes to introduce `BlockLimitsFunctions` are tested by the existing tests.