### PR TITLE
feat: Prometheus Block Fullness Metrics

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -82,6 +82,7 @@ use crate::types::chainstate::{
     StacksAddress, StacksBlockHeader, StacksBlockId, StacksMicroblockHeader,
 };
 use crate::{types, util};
+use monitoring::set_last_execution_cost_observed;
 use types::chainstate::BurnchainHeaderHash;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -5239,6 +5240,8 @@ impl StacksChainState {
         .expect("FATAL: failed to advance chain tip");
 
         chainstate_tx.log_transactions_processed(&new_tip.index_block_hash(), &tx_receipts);
+
+        set_last_execution_cost_observed(&block_execution_cost);
 
         let epoch_receipt = StacksEpochReceipt {
             header: new_tip,

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -34,6 +34,7 @@ use std::sync::Mutex;
 use util::db::sqlite_open;
 use util::db::Error as DatabaseError;
 use util::uint::{Uint256, Uint512};
+use vm::costs::ExecutionCost;
 
 #[cfg(feature = "monitoring_prom")]
 mod prometheus;
@@ -102,6 +103,11 @@ pub fn increment_txs_received_counter() {
 pub fn increment_btc_blocks_received_counter() {
     #[cfg(feature = "monitoring_prom")]
     prometheus::BTC_BLOCKS_RECEIVED_COUNTER.inc();
+}
+
+pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count);
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -108,15 +108,15 @@ pub fn increment_btc_blocks_received_counter() {
 #[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count);
+    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count);
+    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length);
+    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length);
+    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime);
+    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime.try_into().unwrap());
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -105,9 +105,18 @@ pub fn increment_btc_blocks_received_counter() {
     prometheus::BTC_BLOCKS_RECEIVED_COUNTER.inc();
 }
 
+#[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime);
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -91,6 +91,11 @@ lazy_static! {
         "Total number of error logs emitted by node"
     )).unwrap();
 
+    pub static ref LAST_EXECUTION_READ_COUNT: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_runtime",
+        "`execution_cost_runtime` for the last block observed."
+    )).unwrap();
+
     pub static ref ACTIVE_MINERS_COUNT_GAUGE: IntGauge = register_int_gauge!(opts!(
         "stacks_node_active_miners_total",
         "Total number of active miners"

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -92,6 +92,26 @@ lazy_static! {
     )).unwrap();
 
     pub static ref LAST_EXECUTION_READ_COUNT: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_read_count",
+        "`execution_cost_read_count` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_WRITE_COUNT: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_write_count",
+        "`execution_cost_write_count` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_READ_LENGTH: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_read_length",
+        "`execution_cost_read_length` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_WRITE_LENGTH: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_write_length",
+        "`execution_cost_write_length` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_RUNTIME: IntGauge = register_int_gauge!(opts!(
         "execution_cost_runtime",
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();


### PR DESCRIPTION
## Motivation
We want to log a bunch of new metrics.

## Change
This PR logs the 5-dimensional `ExecutionCost` for just seen block in `append_block`.

This supports ingestion of this data into prometheus without needing to launch a custom server.

## Testing
No testing yet! Since this is for diagnostics, we can hook it up to the prometheus monitoring system and see if it looks right.