### PR TITLE
feat: Prometheus Block Fullness Metrics

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5009,12 +5009,10 @@ impl StacksChainState {
             None,
         )?;
 
-        let block_limit = clarity_tx
-            .block_limit()
-            .unwrap_or_else(|| {
-                 warn!("Failed to read transaction block limit");
-                 ExecutionCost::max_value()
-            });
+        let block_limit = clarity_tx.block_limit().unwrap_or_else(|| {
+            warn!("Failed to read transaction block limit");
+            ExecutionCost::max_value()
+        });
 
         let (
             scheduled_miner_reward,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5003,6 +5003,10 @@ impl StacksChainState {
             None,
         )?;
 
+        let block_limit = clarity_tx
+            .block_limit()
+            .unwrap_or(ExecutionCost::max_value());
+
         let (
             scheduled_miner_reward,
             block_execution_cost,
@@ -5241,7 +5245,7 @@ impl StacksChainState {
 
         chainstate_tx.log_transactions_processed(&new_tip.index_block_hash(), &tx_receipts);
 
-        set_last_execution_cost_observed(&block_execution_cost);
+        set_last_execution_cost_observed(&block_execution_cost, &block_limit);
 
         let epoch_receipt = StacksEpochReceipt {
             header: new_tip,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -82,6 +82,7 @@ use crate::types::chainstate::{
     StacksAddress, StacksBlockHeader, StacksBlockId, StacksMicroblockHeader,
 };
 use crate::{types, util};
+use monitoring::set_last_execution_cost_observed;
 use types::chainstate::BurnchainHeaderHash;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -5239,6 +5240,8 @@ impl StacksChainState {
         .expect("FATAL: failed to advance chain tip");
 
         chainstate_tx.log_transactions_processed(&new_tip.index_block_hash(), &tx_receipts);
+
+        set_last_execution_cost_observed(&block_execution_cost);
 
         let epoch_receipt = StacksEpochReceipt {
             header: new_tip,

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5005,7 +5005,10 @@ impl StacksChainState {
 
         let block_limit = clarity_tx
             .block_limit()
-            .unwrap_or(ExecutionCost::max_value());
+            .unwrap_or_else(|| {
+                 warn!("Failed to read transaction block limit");
+                 ExecutionCost::max_value()
+            });
 
         let (
             scheduled_miner_reward,

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -35,6 +35,7 @@ use util::db::sqlite_open;
 use util::db::Error as DatabaseError;
 use util::uint::{Uint256, Uint512};
 use vm::costs::ExecutionCost;
+use std::convert::TryInto;
 
 #[cfg(feature = "monitoring_prom")]
 mod prometheus;

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -34,6 +34,7 @@ use std::sync::Mutex;
 use util::db::sqlite_open;
 use util::db::Error as DatabaseError;
 use util::uint::{Uint256, Uint512};
+use vm::costs::ExecutionCost;
 
 #[cfg(feature = "monitoring_prom")]
 mod prometheus;
@@ -102,6 +103,11 @@ pub fn increment_txs_received_counter() {
 pub fn increment_btc_blocks_received_counter() {
     #[cfg(feature = "monitoring_prom")]
     prometheus::BTC_BLOCKS_RECEIVED_COUNTER.inc();
+}
+
+pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count);
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -109,15 +109,15 @@ pub fn increment_btc_blocks_received_counter() {
 #[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count.try_into().unwrap());
+    prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap());
+    prometheus::LAST_BLOCK_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap());
+    prometheus::LAST_BLOCK_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap());
+    prometheus::LAST_BLOCK_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime.try_into().unwrap());
+    prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime.try_into().unwrap());
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -109,15 +109,15 @@ pub fn increment_btc_blocks_received_counter() {
 #[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count.try_into().unwrap());
+    prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap());
+    prometheus::LAST_BLOCK_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap());
+    prometheus::LAST_BLOCK_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap());
+    prometheus::LAST_BLOCK_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime.try_into().unwrap());
+    prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime.try_into().unwrap_or(i64::MAX));
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -108,15 +108,15 @@ pub fn increment_btc_blocks_received_counter() {
 #[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count);
+    prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count);
+    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length);
+    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length);
+    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap());
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime);
+    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime.try_into().unwrap());
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -106,24 +106,25 @@ pub fn increment_btc_blocks_received_counter() {
     prometheus::BTC_BLOCKS_RECEIVED_COUNTER.inc();
 }
 
+/// Log `execution_cost` as a ratio of `block_limit`.
 #[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(
     execution_cost: &ExecutionCost,
     block_limit: &ExecutionCost,
 ) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count.try_into().unwrap_or(i64::MAX));
+    prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count as f64 / block_limit.read_count as f64);
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_BLOCK_WRITE_COUNT
-        .set(execution_cost.write_count.try_into().unwrap_or(i64::MAX));
+        .set(execution_cost.write_count as f64 / block_limit.read_count as f64);
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_BLOCK_READ_LENGTH
-        .set(execution_cost.read_length.try_into().unwrap_or(i64::MAX));
+        .set(execution_cost.read_length as f64 / block_limit.read_length as f64);
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_BLOCK_WRITE_LENGTH
-        .set(execution_cost.write_length.try_into().unwrap_or(i64::MAX));
+        .set(execution_cost.write_length as f64 / block_limit.write_length as f64);
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime.try_into().unwrap_or(i64::MAX));
+    prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime as f64 / block_limit.runtime as f64);
 }
 
 pub fn increment_btc_ops_sent_counter() {
@@ -419,6 +420,7 @@ pub fn set_burnchain_signer(signer: BurnchainSigner) -> Result<(), SetGlobalBurn
     Ok(())
 }
 
+#[allow(unreachable_code)]
 pub fn get_burnchain_signer() -> Option<BurnchainSigner> {
     #[cfg(feature = "monitoring_prom")]
     {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -113,19 +113,18 @@ pub fn set_last_execution_cost_observed(
     block_limit: &ExecutionCost,
 ) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_COUNT
-        .set(execution_cost.read_count as f64 / block_limit.read_count as f64);
-    #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_WRITE_COUNT
-        .set(execution_cost.write_count as f64 / block_limit.read_count as f64);
-    #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_LENGTH
-        .set(execution_cost.read_length as f64 / block_limit.read_length as f64);
-    #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_WRITE_LENGTH
-        .set(execution_cost.write_length as f64 / block_limit.write_length as f64);
-    #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime as f64 / block_limit.runtime as f64);
+    {
+        prometheus::LAST_BLOCK_READ_COUNT
+            .set(execution_cost.read_count as f64 / block_limit.read_count as f64);
+        prometheus::LAST_BLOCK_WRITE_COUNT
+            .set(execution_cost.write_count as f64 / block_limit.read_count as f64);
+        prometheus::LAST_BLOCK_READ_LENGTH
+            .set(execution_cost.read_length as f64 / block_limit.read_length as f64);
+        prometheus::LAST_BLOCK_WRITE_LENGTH
+            .set(execution_cost.write_length as f64 / block_limit.write_length as f64);
+        prometheus::LAST_BLOCK_RUNTIME
+            .set(execution_cost.runtime as f64 / block_limit.runtime as f64);
+    }
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -105,9 +105,18 @@ pub fn increment_btc_blocks_received_counter() {
     prometheus::BTC_BLOCKS_RECEIVED_COUNTER.inc();
 }
 
+#[allow(unused_variables)]
 pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_EXECUTION_READ_COUNT.set(execution_cost.read_count);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_WRITE_COUNT.set(execution_cost.write_count);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_READ_LENGTH.set(execution_cost.read_length);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_WRITE_LENGTH.set(execution_cost.write_length);
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_EXECUTION_RUNTIME.set(execution_cost.runtime);
 }
 
 pub fn increment_btc_ops_sent_counter() {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -113,7 +113,8 @@ pub fn set_last_execution_cost_observed(
     block_limit: &ExecutionCost,
 ) {
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count as f64 / block_limit.read_count as f64);
+    prometheus::LAST_BLOCK_READ_COUNT
+        .set(execution_cost.read_count as f64 / block_limit.read_count as f64);
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_BLOCK_WRITE_COUNT
         .set(execution_cost.write_count as f64 / block_limit.read_count as f64);

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -107,15 +107,21 @@ pub fn increment_btc_blocks_received_counter() {
 }
 
 #[allow(unused_variables)]
-pub fn set_last_execution_cost_observed(execution_cost: &ExecutionCost) {
+pub fn set_last_execution_cost_observed(
+    execution_cost: &ExecutionCost,
+    block_limit: &ExecutionCost,
+) {
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_BLOCK_READ_COUNT.set(execution_cost.read_count.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_WRITE_COUNT.set(execution_cost.write_count.try_into().unwrap_or(i64::MAX));
+    prometheus::LAST_BLOCK_WRITE_COUNT
+        .set(execution_cost.write_count.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_READ_LENGTH.set(execution_cost.read_length.try_into().unwrap_or(i64::MAX));
+    prometheus::LAST_BLOCK_READ_LENGTH
+        .set(execution_cost.read_length.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_WRITE_LENGTH.set(execution_cost.write_length.try_into().unwrap_or(i64::MAX));
+    prometheus::LAST_BLOCK_WRITE_LENGTH
+        .set(execution_cost.write_length.try_into().unwrap_or(i64::MAX));
     #[cfg(feature = "monitoring_prom")]
     prometheus::LAST_BLOCK_RUNTIME.set(execution_cost.runtime.try_into().unwrap_or(i64::MAX));
 }

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -28,6 +28,7 @@ use crate::{
     },
 };
 use burnchains::BurnchainSigner;
+use std::convert::TryInto;
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
@@ -35,7 +36,6 @@ use util::db::sqlite_open;
 use util::db::Error as DatabaseError;
 use util::uint::{Uint256, Uint512};
 use vm::costs::ExecutionCost;
-use std::convert::TryInto;
 
 #[cfg(feature = "monitoring_prom")]
 mod prometheus;

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -92,27 +92,27 @@ lazy_static! {
     )).unwrap();
 
     pub static ref LAST_BLOCK_READ_COUNT: Gauge = register_gauge!(opts!(
-        "execution_cost_read_count",
+        "stacks_node_last_block_read_count",
         "`execution_cost_read_count` for the last block observed."
     )).unwrap();
 
     pub static ref LAST_BLOCK_WRITE_COUNT: Gauge = register_gauge!(opts!(
-        "execution_cost_write_count",
+        "stacks_node_last_block_write_count",
         "`execution_cost_write_count` for the last block observed."
     )).unwrap();
 
     pub static ref LAST_BLOCK_READ_LENGTH: Gauge = register_gauge!(opts!(
-        "execution_cost_read_length",
+        "stacks_node_last_block_read_length",
         "`execution_cost_read_length` for the last block observed."
     )).unwrap();
 
     pub static ref LAST_BLOCK_WRITE_LENGTH: Gauge = register_gauge!(opts!(
-        "execution_cost_write_length",
+        "stacks_node_last_block_write_length",
         "`execution_cost_write_length` for the last block observed."
     )).unwrap();
 
     pub static ref LAST_BLOCK_RUNTIME: Gauge = register_gauge!(opts!(
-        "execution_cost_runtime",
+        "stacks_node_last_block_runtime",
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();
 

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -91,27 +91,27 @@ lazy_static! {
         "Total number of error logs emitted by node"
     )).unwrap();
 
-    pub static ref LAST_EXECUTION_READ_COUNT: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_READ_COUNT: IntGauge = register_int_gauge!(opts!(
         "execution_cost_read_count",
         "`execution_cost_read_count` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_EXECUTION_WRITE_COUNT: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_WRITE_COUNT: IntGauge = register_int_gauge!(opts!(
         "execution_cost_write_count",
         "`execution_cost_write_count` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_EXECUTION_READ_LENGTH: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_READ_LENGTH: IntGauge = register_int_gauge!(opts!(
         "execution_cost_read_length",
         "`execution_cost_read_length` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_EXECUTION_WRITE_LENGTH: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_WRITE_LENGTH: IntGauge = register_int_gauge!(opts!(
         "execution_cost_write_length",
         "`execution_cost_write_length` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_EXECUTION_RUNTIME: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_RUNTIME: IntGauge = register_int_gauge!(opts!(
         "execution_cost_runtime",
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -91,27 +91,27 @@ lazy_static! {
         "Total number of error logs emitted by node"
     )).unwrap();
 
-    pub static ref LAST_BLOCK_READ_COUNT: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_READ_COUNT: Gauge = register_gauge!(opts!(
         "execution_cost_read_count",
         "`execution_cost_read_count` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_BLOCK_WRITE_COUNT: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_WRITE_COUNT: Gauge = register_gauge!(opts!(
         "execution_cost_write_count",
         "`execution_cost_write_count` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_BLOCK_READ_LENGTH: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_READ_LENGTH: Gauge = register_gauge!(opts!(
         "execution_cost_read_length",
         "`execution_cost_read_length` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_BLOCK_WRITE_LENGTH: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_WRITE_LENGTH: Gauge = register_gauge!(opts!(
         "execution_cost_write_length",
         "`execution_cost_write_length` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_BLOCK_RUNTIME: IntGauge = register_int_gauge!(opts!(
+    pub static ref LAST_BLOCK_RUNTIME: Gauge = register_gauge!(opts!(
         "execution_cost_runtime",
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -91,6 +91,11 @@ lazy_static! {
         "Total number of error logs emitted by node"
     )).unwrap();
 
+    pub static ref LAST_EXECUTION_READ_COUNT: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_runtime",
+        "`execution_cost_runtime` for the last block observed."
+    )).unwrap();
+
     pub static ref ACTIVE_MINERS_COUNT_GAUGE: IntGauge = register_int_gauge!(opts!(
         "stacks_node_active_miners_total",
         "Total number of active miners"

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -92,6 +92,26 @@ lazy_static! {
     )).unwrap();
 
     pub static ref LAST_EXECUTION_READ_COUNT: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_read_count",
+        "`execution_cost_read_count` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_WRITE_COUNT: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_write_count",
+        "`execution_cost_write_count` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_READ_LENGTH: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_read_length",
+        "`execution_cost_read_length` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_WRITE_LENGTH: IntGauge = register_int_gauge!(opts!(
+        "execution_cost_write_length",
+        "`execution_cost_write_length` for the last block observed."
+    )).unwrap();
+
+    pub static ref LAST_EXECUTION_RUNTIME: IntGauge = register_int_gauge!(opts!(
         "execution_cost_runtime",
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();


### PR DESCRIPTION
## Motivation
We want to log a bunch of new metrics (#3024). This one adds "block fullness", which we have been talking about lately. 

This supports ingestion of this data into prometheus without needing to launch a custom server.

## Change
This PR logs the 5-dimensional `ExecutionCost` for the just seen block in the `append_block` function run by the followers and miners.

## Testing
No testing yet! Since this is for diagnostics, we can hook it up to the prometheus monitoring system and see if it looks right.