### PR TITLE
Feat/add all indexes

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -483,13 +483,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
 
         PRIMARY KEY(sortition_id)
     );"#,
-    "CREATE INDEX snapshots_block_hashes ON snapshots(block_height,index_root,winning_stacks_block_hash);",
-    "CREATE INDEX snapshots_block_stacks_hashes ON snapshots(num_sortitions,index_root,winning_stacks_block_hash);",
-    "CREATE INDEX snapshots_block_heights ON snapshots(burn_header_hash,block_height);",
-    "CREATE INDEX snapshots_block_winning_hash ON snapshots(winning_stacks_block_hash);",
-    "CREATE INDEX snapshots_canonical_chain_tip ON snapshots(pox_valid,block_height DESC,burn_header_hash ASC);",
-    "CREATE INDEX block_arrivals ON snapshots(arrival_index,burn_header_hash);",
-    "CREATE INDEX arrival_indexes ON snapshots(arrival_index);",
     r#"
     CREATE TABLE snapshot_transition_ops(
       sortition_id TEXT PRIMARY KEY,
@@ -514,9 +507,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         PRIMARY KEY(txid,sortition_id),
         FOREIGN KEY(sortition_id) REFERENCES snapshots(sortition_id)
     );"#,
-    r#"
-    CREATE INDEX index_leader_keys_sortition_id_block_height_vtxindex ON leader_keys(sortition_id,block_height,vtxindex);
-    "#,
     r#"
     CREATE TABLE block_commits(
         txid TEXT NOT NULL,
@@ -543,10 +533,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         FOREIGN KEY(sortition_id) REFERENCES snapshots(sortition_id)
     );"#,
     r#"
-    CREATE INDEX index_block_commits_sortition_id_vtxindex ON block_commits(sortition_id,vtxindex);
-    CREATE INDEX index_block_commits_sortition_id_block_height_vtxindex ON block_commits(sortition_id,block_height,vtxindex);
-    "#,
-    r#"
     CREATE TABLE user_burn_support(
         txid TEXT NOT NULL,
         vtxindex INTEGER NOT NULL,
@@ -567,11 +553,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         FOREIGN KEY(sortition_id) REFERENCES snapshots(sortition_id)
     );"#,
     r#"
-    CREATE INDEX index_user_burn_support_txid ON user_burn_support(txid);
-    CREATE INDEX index_user_burn_support_sortition_id_vtxindex ON user_burn_support(sortition_id,vtxindex);
-    CREATE INDEX index_user_burn_support_sortition_id_hash_160_key_vtxindex_key_block_ptr_vtxindex ON user_burn_support(sortition_id,block_header_hash_160,key_vtxindex,key_block_ptr,vtxindex ASC);
-    "#,
-    r#"
     CREATE TABLE stack_stx (
         txid TEXT NOT NULL,
         vtxindex INTEGER NOT NULL,
@@ -585,9 +566,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
 
         PRIMARY KEY(txid)
     );"#,
-    r#"
-    CREATE INDEX index_stack_stx_burn_header_hash ON stack_stx(burn_header_hash);
-    "#,
     r#"
     CREATE TABLE transfer_stx (
         txid TEXT NOT NULL,
@@ -603,9 +581,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         PRIMARY KEY(txid)
     );"#,
     r#"
-    CREATE INDEX index_transfer_stx_burn_header_hash ON transfer_stx(burn_header_hash);
-    "#,
-    r#"
     CREATE TABLE missed_commits (
         txid TEXT NOT NULL,
         input TEXT NOT NULL,
@@ -614,9 +589,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         PRIMARY KEY(txid, intended_sortition_id)
     );"#,
     r#"
-    CREATE INDEX index_missed_commits_intended_sortition_id ON missed_commits(intended_sortition_id);
-    "#,
-    r#"
     CREATE TABLE canonical_accepted_stacks_blocks(
         tip_consensus_hash TEXT NOT NULL,
         consensus_hash TEXT NOT NULL,
@@ -624,7 +596,6 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         block_height INTEGER NOT NULL,
         PRIMARY KEY(consensus_hash, stacks_block_hash)
     );"#,
-    "CREATE INDEX canonical_stacks_blocks ON canonical_accepted_stacks_blocks(tip_consensus_hash,stacks_block_hash);",
     "CREATE TABLE db_config(version TEXT PRIMARY KEY);",
 ];
 
@@ -637,6 +608,26 @@ const SORTITION_DB_SCHEMA_2: &'static [&'static str] = &[r#"
          network_epoch INTEGER NOT NULL,
          PRIMARY KEY(start_block_height,epoch_id)
      );"#];
+
+const SORTITION_DB_INDEXES: &'static [&'static str] = &[
+    "CREATE INDEX IF NOT EXISTS snapshots_block_hashes ON snapshots(block_height,index_root,winning_stacks_block_hash);",
+    "CREATE INDEX IF NOT EXISTS snapshots_block_stacks_hashes ON snapshots(num_sortitions,index_root,winning_stacks_block_hash);",
+    "CREATE INDEX IF NOT EXISTS snapshots_block_heights ON snapshots(burn_header_hash,block_height);",
+    "CREATE INDEX IF NOT EXISTS snapshots_block_winning_hash ON snapshots(winning_stacks_block_hash);",
+    "CREATE INDEX IF NOT EXISTS snapshots_canonical_chain_tip ON snapshots(pox_valid,block_height DESC,burn_header_hash ASC);",
+    "CREATE INDEX IF NOT EXISTS block_arrivals ON snapshots(arrival_index,burn_header_hash);",
+    "CREATE INDEX IF NOT EXISTS arrival_indexes ON snapshots(arrival_index);",
+    "CREATE INDEX IF NOT EXISTS index_leader_keys_sortition_id_block_height_vtxindex ON leader_keys(sortition_id,block_height,vtxindex);",
+    "CREATE INDEX IF NOT EXISTS index_block_commits_sortition_id_vtxindex ON block_commits(sortition_id,vtxindex);",
+    "CREATE INDEX IF NOT EXISTS index_block_commits_sortition_id_block_height_vtxindex ON block_commits(sortition_id,block_height,vtxindex);",
+    "CREATE INDEX IF NOT EXISTS index_user_burn_support_txid ON user_burn_support(txid);",
+    "CREATE INDEX IF NOT EXISTS index_user_burn_support_sortition_id_vtxindex ON user_burn_support(sortition_id,vtxindex);",
+    "CREATE INDEX IF NOT EXISTS index_user_burn_support_sortition_id_hash_160_key_vtxindex_key_block_ptr_vtxindex ON user_burn_support(sortition_id,block_header_hash_160,key_vtxindex,key_block_ptr,vtxindex ASC);",
+    "CREATE INDEX IF NOT EXISTS index_stack_stx_burn_header_hash ON stack_stx(burn_header_hash);",
+    "CREATE INDEX IF NOT EXISTS index_transfer_stx_burn_header_hash ON transfer_stx(burn_header_hash);",
+    "CREATE INDEX IF NOT EXISTS index_missed_commits_intended_sortition_id ON missed_commits(intended_sortition_id);",
+    "CREATE INDEX IF NOT EXISTS canonical_stacks_blocks ON canonical_accepted_stacks_blocks(tip_consensus_hash,stacks_block_hash);"
+];
 
 pub struct SortitionDB {
     pub readwrite: bool,
@@ -2293,6 +2284,9 @@ impl SortitionDB {
             db_tx.execute_batch(row_text)?;
         }
         for row_text in SORTITION_DB_SCHEMA_2 {
+            db_tx.execute_batch(row_text)?;
+        }
+        for row_text in SORTITION_DB_INDEXES {
             db_tx.execute_batch(row_text)?;
         }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -597,10 +597,6 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
 
         PRIMARY KEY(consensus_hash,block_hash)
     );"#,
-    "CREATE INDEX index_block_hash_to_primary_key ON block_headers(index_block_hash,consensus_hash,block_hash);",
-    "CREATE INDEX block_headers_hash_index ON block_headers(block_hash,block_height);",
-    "CREATE INDEX block_index_hash_index ON block_headers(index_block_hash,consensus_hash,block_hash);",
-    "CREATE INDEX block_headers_burn_header_height ON block_headers(burn_header_height);",
     r#"
     -- scheduled payments
     -- no designated primary key since there can be duplicate entries
@@ -623,10 +619,6 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
         index_block_hash TEXT NOT NULL,     -- NOTE: can't enforce UNIQUE here, because there will be multiple entries per block
         vtxindex INT NOT NULL               -- user burn support vtxindex
     );"#,
-    r#"
-    CREATE INDEX index_payments_block_hash_consensus_hash_vtxindex ON payments(block_hash,consensus_hash,vtxindex ASC);
-    CREATE INDEX index_payments_index_block_hash_vtxindex ON payments(index_block_hash,vtxindex ASC);
-    "#,
     r#"
     -- users who supported miners
     CREATE TABLE user_supporters(
@@ -656,11 +648,6 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
                                      orphaned INT NOT NULL,
                                      PRIMARY KEY(anchored_block_hash,consensus_hash,microblock_hash)
     );"#,
-    "CREATE INDEX staging_microblocks_processed ON staging_microblocks(processed);",
-    "CREATE INDEX staging_microblocks_orphaned ON staging_microblocks(orphaned);",
-    "CREATE INDEX staging_microblocks_index_hash ON staging_microblocks(index_block_hash);",
-    "CREATE INDEX staging_microblocks_index_hash_processed ON staging_microblocks(index_block_hash,processed);",
-    "CREATE INDEX staging_microblocks_index_hash_orphaned ON staging_microblocks(index_block_hash,orphaned);",
     r#"
     -- Staging microblocks data
     CREATE TABLE staging_microblocks_data(block_hash TEXT NOT NULL,
@@ -695,12 +682,6 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
                                 processed_time INT NOT NULL,              -- when this block was processed
                                 PRIMARY KEY(anchored_block_hash,consensus_hash)
     );"#,
-    "CREATE INDEX processed_stacks_blocks ON staging_blocks(processed,anchored_block_hash,consensus_hash);",
-    "CREATE INDEX orphaned_stacks_blocks ON staging_blocks(orphaned,anchored_block_hash,consensus_hash);",
-    "CREATE INDEX parent_blocks ON staging_blocks(parent_anchored_block_hash);",
-    "CREATE INDEX parent_consensus_hashes ON staging_blocks(parent_consensus_hash);",
-    "CREATE INDEX index_block_hashes ON staging_blocks(index_block_hash);",
-    "CREATE INDEX height_stacks_blocks ON staging_blocks(height);",
     r#"
     -- users who burned in support of a block
     CREATE TABLE staging_user_burn_support(anchored_block_hash TEXT NOT NULL,
@@ -710,9 +691,6 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
                                            vtxindex INT NOT NULL
     );"#,
     r#"
-    CREATE INDEX index_staging_user_burn_support ON staging_user_burn_support(anchored_block_hash,consensus_hash);
-    "#,
-    r#"
     CREATE TABLE transactions(
         id INTEGER PRIMARY KEY,
         txid TEXT NOT NULL,
@@ -721,8 +699,6 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
         result TEXT NOT NULL,
         UNIQUE (txid,index_block_hash)
     );"#,
-    "CREATE INDEX txid_tx_index ON transactions(txid);",
-    "CREATE INDEX index_block_hash_tx_index ON transactions(index_block_hash);",
 ];
 
 const CHAINSTATE_SCHEMA_2: &'static [&'static str] = &[
@@ -735,6 +711,29 @@ const CHAINSTATE_SCHEMA_2: &'static [&'static str] = &[
     r#"
     UPDATE db_config SET version = "2";
     "#,
+];
+
+const CHAINSTATE_INDEXES: &'static [&'static str] = &[
+    "CREATE INDEX IF NOT EXISTS index_block_hash_to_primary_key ON block_headers(index_block_hash,consensus_hash,block_hash);",
+    "CREATE INDEX IF NOT EXISTS block_headers_hash_index ON block_headers(block_hash,block_height);",
+    "CREATE INDEX IF NOT EXISTS block_index_hash_index ON block_headers(index_block_hash,consensus_hash,block_hash);",
+    "CREATE INDEX IF NOT EXISTS block_headers_burn_header_height ON block_headers(burn_header_height);",
+    "CREATE INDEX IF NOT EXISTS index_payments_block_hash_consensus_hash_vtxindex ON payments(block_hash,consensus_hash,vtxindex ASC);",
+    "CREATE INDEX IF NOT EXISTS index_payments_index_block_hash_vtxindex ON payments(index_block_hash,vtxindex ASC);",
+    "CREATE INDEX IF NOT EXISTS staging_microblocks_processed ON staging_microblocks(processed);",
+    "CREATE INDEX IF NOT EXISTS staging_microblocks_orphaned ON staging_microblocks(orphaned);",
+    "CREATE INDEX IF NOT EXISTS staging_microblocks_index_hash ON staging_microblocks(index_block_hash);",
+    "CREATE INDEX IF NOT EXISTS staging_microblocks_index_hash_processed ON staging_microblocks(index_block_hash,processed);",
+    "CREATE INDEX IF NOT EXISTS staging_microblocks_index_hash_orphaned ON staging_microblocks(index_block_hash,orphaned);",
+    "CREATE INDEX IF NOT EXISTS processed_stacks_blocks ON staging_blocks(processed,anchored_block_hash,consensus_hash);",
+    "CREATE INDEX IF NOT EXISTS orphaned_stacks_blocks ON staging_blocks(orphaned,anchored_block_hash,consensus_hash);",
+    "CREATE INDEX IF NOT EXISTS parent_blocks ON staging_blocks(parent_anchored_block_hash);",
+    "CREATE INDEX IF NOT EXISTS parent_consensus_hashes ON staging_blocks(parent_consensus_hash);",
+    "CREATE INDEX IF NOT EXISTS index_block_hashes ON staging_blocks(index_block_hash);",
+    "CREATE INDEX IF NOT EXISTS height_stacks_blocks ON staging_blocks(height);",
+    "CREATE INDEX IF NOT EXISTS index_staging_user_burn_support ON staging_user_burn_support(anchored_block_hash,consensus_hash);",
+    "CREATE INDEX IF NOT EXISTS txid_tx_index ON transactions(txid);",
+    "CREATE INDEX IF NOT EXISTS index_block_hash_tx_index ON transactions(index_block_hash);",
 ];
 
 #[cfg(test)]
@@ -857,6 +856,10 @@ impl StacksChainState {
 
             if migrate {
                 StacksChainState::apply_schema_migrations(&tx, mainnet, chain_id)?;
+            }
+
+            for cmd in CHAINSTATE_INDEXES {
+                tx.execute_batch(cmd)?;
             }
         }
 

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -858,9 +858,7 @@ impl StacksChainState {
                 StacksChainState::apply_schema_migrations(&tx, mainnet, chain_id)?;
             }
 
-            for cmd in CHAINSTATE_INDEXES {
-                tx.execute_batch(cmd)?;
-            }
+            StacksChainState::add_indexes(&tx)?;
         }
 
         dbtx.instantiate_index()?;
@@ -939,6 +937,13 @@ impl StacksChainState {
         Ok(())
     }
 
+    fn add_indexes<'a>(tx: &DBTx<'a>) -> Result<(), Error> {
+        for cmd in CHAINSTATE_INDEXES {
+            tx.execute_batch(cmd)?;
+        }
+        Ok(())
+    }
+
     fn open_db(
         mainnet: bool,
         chain_id: u32,
@@ -953,6 +958,7 @@ impl StacksChainState {
             let mut marf = StacksChainState::open_index(index_path)?;
             let tx = marf.storage_tx()?;
             StacksChainState::apply_schema_migrations(&tx, mainnet, chain_id)?;
+            StacksChainState::add_indexes(&tx)?;
             tx.commit()?;
             Ok(marf)
         }
@@ -972,6 +978,7 @@ impl StacksChainState {
         } else {
             let mut marf = StacksChainState::open_index(index_path)?;
             let tx = marf.storage_tx()?;
+            StacksChainState::add_indexes(&tx)?;
             tx.commit()?;
             Ok(marf)
         }

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -655,9 +655,7 @@ impl MemPoolDB {
         MemPoolDB::apply_schema_migrations(&mut tx)?;
 
         // add all indexes
-        for cmd in MEMPOOL_INDEXES {
-            tx.execute_batch(cmd).map_err(db_error::SqliteError)?;
-        }
+        MemPoolDB::add_indexes(&mut tx)?;
 
         tx.commit().map_err(db_error::SqliteError)?;
         Ok(())
@@ -700,6 +698,14 @@ impl MemPoolDB {
                     panic!("Unknown schema version {}", version);
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Add indexes
+    fn add_indexes(tx: &mut DBTx) -> Result<(), db_error> {
+        for cmd in MEMPOOL_INDEXES {
+            tx.execute_batch(cmd).map_err(db_error::SqliteError)?;
         }
         Ok(())
     }
@@ -794,6 +800,7 @@ impl MemPoolDB {
         } else {
             let mut tx = tx_begin_immediate(&mut conn)?;
             MemPoolDB::apply_schema_migrations(&mut tx)?;
+            MemPoolDB::add_indexes(&mut tx)?;
             tx.commit().map_err(db_error::SqliteError)?;
         }
 

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -482,7 +482,7 @@ impl PeerDB {
     }
 
     fn reset_allows<'a>(tx: &mut Transaction<'a>) -> Result<(), db_error> {
-        tx.execute("UPDATE frontier SET allowed = -1", NO_PARAMS)
+        tx.execute("UPDATE frontier SET allowed = 0", NO_PARAMS)
             .map_err(db_error::SqliteError)?;
         Ok(())
     }
@@ -2320,7 +2320,7 @@ mod test {
         assert_eq!(n1.denied, i64::MAX);
         assert_eq!(n2.denied, 0); // refreshed; no longer denied
 
-        assert_eq!(n1.allowed, -1);
-        assert_eq!(n2.allowed, -1);
+        assert_eq!(n1.allowed, 0);
+        assert_eq!(n2.allowed, 0);
     }
 }

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -396,10 +396,6 @@ impl PeerDB {
             tx.execute_batch(row_text).map_err(db_error::SqliteError)?;
         }
 
-        for row_text in PEERDB_INDEXES {
-            tx.execute_batch(row_text).map_err(db_error::SqliteError)?;
-        }
-
         tx.execute(
             "INSERT INTO db_config (version) VALUES (?1)",
             &[&PEERDB_VERSION],
@@ -445,6 +441,16 @@ impl PeerDB {
 
         tx.commit().map_err(db_error::SqliteError)?;
 
+        self.add_indexes()?;
+        Ok(())
+    }
+
+    fn add_indexes(&mut self) -> Result<(), db_error> {
+        let tx = self.tx_begin()?;
+        for row_text in PEERDB_INDEXES {
+            tx.execute_batch(row_text).map_err(db_error::SqliteError)?;
+        }
+        tx.commit()?;
         Ok(())
     }
 
@@ -593,6 +599,9 @@ impl PeerDB {
 
                 tx.commit()?;
             }
+        }
+        if readwrite {
+            db.add_indexes()?;
         }
         Ok(db)
     }

--- a/src/net/db.rs
+++ b/src/net/db.rs
@@ -323,7 +323,6 @@ const PEERDB_INITIAL_SCHEMA: &'static [&'static str] = &[
 
         PRIMARY KEY(slot)
     );"#,
-    "CREATE INDEX peer_address_index ON frontier(network_id,addrbytes,port);",
     r#"
     CREATE TABLE asn4(
         prefix INTEGER NOT NULL,
@@ -359,6 +358,9 @@ const PEERDB_INITIAL_SCHEMA: &'static [&'static str] = &[
     );"#,
 ];
 
+const PEERDB_INDEXES: &'static [&'static str] =
+    &["CREATE INDEX IF NOT EXISTS peer_address_index ON frontier(network_id,addrbytes,port);"];
+
 #[derive(Debug)]
 pub struct PeerDB {
     pub conn: Connection,
@@ -391,6 +393,10 @@ impl PeerDB {
         let mut tx = self.tx_begin()?;
 
         for row_text in PEERDB_INITIAL_SCHEMA {
+            tx.execute_batch(row_text).map_err(db_error::SqliteError)?;
+        }
+
+        for row_text in PEERDB_INDEXES {
             tx.execute_batch(row_text).map_err(db_error::SqliteError)?;
         }
 

--- a/src/net/neighbors.rs
+++ b/src/net/neighbors.rs
@@ -1890,10 +1890,16 @@ impl PeerNetwork {
         Ok((count, num_allowed_peers as u64))
     }
 
-    /// Instantiate the neighbor walk to an always-allowed node
-    fn instantiate_walk_to_always_allowed(&mut self) -> Result<(), net_error> {
-        let allowed_peers =
-            PeerDB::get_always_allowed_peers(self.peerdb.conn(), self.local_peer.network_id)?;
+    /// Instantiate the neighbor walk to an always-allowed node.
+    /// If we're in the initial block download, then this must also be a *bootstrap* peer.
+    fn instantiate_walk_to_always_allowed(&mut self, ibd: bool) -> Result<(), net_error> {
+        let allowed_peers = if ibd {
+            // only get bootstrap peers
+            PeerDB::get_bootstrap_peers(&self.peerdb.conn(), self.local_peer.network_id)?
+        } else {
+            // can be any peer
+            PeerDB::get_always_allowed_peers(self.peerdb.conn(), self.local_peer.network_id)?
+        };
 
         let mut count = 0;
         for allowed in allowed_peers.iter() {
@@ -2764,7 +2770,7 @@ impl PeerNetwork {
     /// Mask errors by restarting the graph walk.
     /// Returns the walk result, and a true/false flag to indicate whether or not the work for the
     /// walk was finished (i.e. we either completed the walk, or we reset the walk)
-    pub fn walk_peer_graph(&mut self) -> (bool, Option<NeighborWalkResult>) {
+    pub fn walk_peer_graph(&mut self, ibd: bool) -> (bool, Option<NeighborWalkResult>) {
         if self.walk.is_none() {
             // time to do a walk yet?
             if (self.walk_count > self.connection_opts.num_initial_walks
@@ -2799,7 +2805,7 @@ impl PeerNetwork {
             );
 
             // always ensure we're connected to always-allowed outbound peers
-            let walk_res = match self.instantiate_walk_to_always_allowed() {
+            let walk_res = match self.instantiate_walk_to_always_allowed(ibd) {
                 Ok(x) => Ok(x),
                 Err(net_error::NotFoundError) => {
                     if self.walk_attempts % (self.connection_opts.walk_inbound_ratio + 1) == 0 {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2131,7 +2131,7 @@ impl PeerNetwork {
 
     /// Update the state of our neighbor walk.
     /// Return true if we finish, and true if we're throttled
-    fn do_network_neighbor_walk(&mut self) -> Result<bool, net_error> {
+    fn do_network_neighbor_walk(&mut self, ibd: bool) -> Result<bool, net_error> {
         if cfg!(test) && self.connection_opts.disable_neighbor_walk {
             test_debug!("neighbor walk is disabled");
             return Ok(true);
@@ -2140,7 +2140,7 @@ impl PeerNetwork {
         debug!("{:?}: walk peer graph", &self.local_peer);
 
         // walk the peer graph and deal with new/dropped connections
-        let (done, walk_result_opt) = self.walk_peer_graph();
+        let (done, walk_result_opt) = self.walk_peer_graph(ibd);
         match walk_result_opt {
             None => {}
             Some(walk_result) => {
@@ -5040,7 +5040,7 @@ impl PeerNetwork {
         }
 
         // In parallel, do a neighbor walk
-        self.do_network_neighbor_walk()?;
+        self.do_network_neighbor_walk(ibd)?;
 
         // In parallel, do a mempool sync.
         // Remember any txs we get, so we can feed them to the relayer thread.


### PR DESCRIPTION
This PR makes it so all database indexes in all databases are instantiated unconditionally, in an idempotent fashion, after all migrations have been applied.  This way, if we want to add future indexes in subsequent PRs and have them take effect on existing chain state, we can do so just by adding the index-creation command to the list of indexes to create.

While testing this, I uncovered and fixed two small bugs that arise only when a node is stopped and restarted during boot-up:

* When booting up, the neighbor-walk logic should always try to walk to a bootstrap peer during IBD.  This way, the inventory state-machine will be able to resume crawling bootstrap peers right away, which causes block downloads to resume right away.  Before, it would take potentially a long time for the node to resume downloading blocks, because it would only stumble upon a bootstrap peer by chance.

* When booting up from existing chainstate, the burnchain controller would download 2100 Bitcoin blocks (1 reward cycle) unconditionally from when it left off, before starting the runloop and chains coordinator.  This PR makes it so that the node will instead just resume the main run loop and chains coordinator, so that both Bitcoin and Stacks blocks can proceed in parallel.