### PR TITLE
updating metrics for issue 2987

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+- Fixed a few prometheus metrics to be more accurate comapared to `/v2` endpoints when polling data (#2987)
+
 ## [2.05.0.1.0]
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-- Fixed a few prometheus metrics to be more accurate comapared to `/v2` endpoints when polling data (#2987)
-
 ## [2.05.0.1.0]
 
 ### Added 
@@ -84,6 +75,8 @@ tests (#2989).
 - Updates the lookup key for contracts in the pessimistic cost estimator. Before, contracts
   published by different principals with the same name would have had the same 
   key in the cost estimator. (#2984)
+- Fixed a few prometheus metrics to be more accurate compared to `/v2` endpoints 
+  when polling data (#2987)
 
 ## [2.05.0.0.0]
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -42,10 +42,7 @@ use chainstate::stacks::{
     Error as ChainstateError, StacksBlock, TransactionPayload,
 };
 use core::StacksEpoch;
-use monitoring::{
-    increment_contract_calls_processed, increment_stx_blocks_processed_counter,
-    update_stacks_tip_height,
-};
+use monitoring::{increment_contract_calls_processed, increment_stx_blocks_processed_counter};
 use net::atlas::{AtlasConfig, AttachmentInstance};
 use util::db::Error as DBError;
 use vm::{
@@ -698,8 +695,6 @@ impl<
 
         let sortdb_handle = self.sortition_db.tx_handle_begin(canonical_sortition_tip)?;
         let mut processed_blocks = self.chain_state_db.process_blocks(sortdb_handle, 1)?;
-        let stacks_tip = SortitionDB::get_canonical_burn_chain_tip(self.sortition_db.conn())?;
-        update_stacks_tip_height(stacks_tip.canonical_stacks_tip_height as i64);
 
         while let Some(block_result) = processed_blocks.pop() {
             if let (Some(block_receipt), _) = block_result {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -5033,10 +5033,6 @@ impl PeerNetwork {
                 self.deregister_peer(dead);
             }
             self.prune_connections();
-            let outbound_neighbors = PeerNetwork::count_outbound_conversations(&self.peers);
-            let inbound_neighbors = self.peers.len() - outbound_neighbors as usize;
-            update_outbound_neighbors(outbound_neighbors as i64);
-            update_inbound_neighbors(inbound_neighbors as i64);
         }
 
         // In parallel, do a neighbor walk
@@ -5092,6 +5088,11 @@ impl PeerNetwork {
         // finally, handle network I/O requests from other threads, and get back reply handles to them.
         // do this after processing new sockets, so we don't accidentally re-use an event ID.
         self.dispatch_requests();
+
+        let outbound_neighbors = PeerNetwork::count_outbound_conversations(&self.peers);
+        let inbound_neighbors = self.peers.len() - outbound_neighbors as usize;
+        update_outbound_neighbors(outbound_neighbors as i64);
+        update_inbound_neighbors(inbound_neighbors as i64);
 
         // fault injection -- periodically disconnect from everyone
         if cfg!(test) {

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -55,6 +55,7 @@ use crate::chainstate::coordinator::BlockEventDispatcher;
 use crate::types::chainstate::{PoxId, SortitionId};
 use chainstate::stacks::db::unconfirmed::ProcessedUnconfirmedState;
 use codec::MAX_PAYLOAD_LEN;
+use monitoring::update_stacks_tip_height;
 use types::chainstate::BurnchainHeaderHash;
 
 pub type BlocksAvailableMap = HashMap<BurnchainHeaderHash, (u64, ConsensusHash)>;
@@ -1083,6 +1084,7 @@ impl Relayer {
             MemPoolDB::garbage_collect(&mut mempool_tx, min_height, event_observer)?;
             mempool_tx.commit()?;
         }
+        update_stacks_tip_height(chain_height as i64);
 
         Ok(ret)
     }


### PR DESCRIPTION
2 metrics weren't as correct as they should be.
- `stacks_node_stacks_tip_height` was moved to the relayer. in tests, this proved to be a more effective location to track the data vs what `/v2/info` was reporting
- moved `stacks_node_neighbors_*` out of the pruning loop. this resulted in the metric being set more often, but the actual count of neighbors was far more accurate when compared to `/v2/neighbors`
- no changes were made to the mempool tx metric, to get this more accurate will be a far heavier lift. leaving for future work
- script used for testing: https://gist.github.com/wileyj/881eda423366134bc25e3fb5ec39ccbb


## Description
Some existing metrics were not as correct/up to date as they should be compared with `/v2` output.
  - `stacks_node_stacks_tip_height` was moved to the relayer. 
  - moved `stacks_node_neighbors_*` out of the pruning loop

In tests, the new locations of these directives showed much more accurate metric data when compared to the `/v2` output of a running/syncing stacks blockchain node. This change has no impact application developers and is not a breaking change. 
For details refer to issue https://github.com/stacks-network/stacks-blockchain/issues/2987


## Type of Change
- Bug fix

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
No blockchain tests are necessary for this change. However, I used this script https://gist.github.com/wileyj/881eda423366134bc25e3fb5ec39ccbb to help determine the current state of accuracy, compared to the updates proposed in this PR. The changes proposed are much more closely aligned with what the blockchain reports via http over `/v2` endpoints. 


