### PR TITLE
Feat/contract events

### DIFF
--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1415,6 +1415,30 @@ impl<'a, 'b> Environment<'a, 'b> {
         }
         Ok(())
     }
+
+    pub fn register_contract_call_event(
+        &mut self,
+        contract_id: QualifiedContractIdentifier,
+        sender: Option<PrincipalData>,
+        caller: Option<PrincipalData>,
+        function_name: String,
+        function_args: Vec<Value>
+    ) -> Result<()> {
+        let event_data = ContractCallEventData {
+            contract_id,
+            sender,
+            caller,
+            function_name,
+            function_args,
+        };
+
+        if let Some(batch) = self.global_context.event_batches.last_mut() {
+            batch
+                .events
+                .push(StacksTransactionEvent::ContractCallEvent(event_data));
+        }
+        Ok(())
+    }
 }
 
 impl<'a> GlobalContext<'a> {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1353,6 +1353,68 @@ impl<'a, 'b> Environment<'a, 'b> {
         }
         Ok(())
     }
+
+    pub fn register_var_set_event(
+        &mut self,
+        contract_id: QualifiedContractIdentifier,
+        var_name: String,
+        value: Value,
+    ) -> Result<()> {
+        let event_data = StorageVarSetEventData {
+            contract_id,
+            var_name,
+            value,
+        };
+
+        if let Some(batch) = self.global_context.event_batches.last_mut() {
+            batch.events.push(StacksTransactionEvent::StorageEvent(
+                StorageEventType::StorageVarSetEvent(event_data),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn register_map_set_event(
+        &mut self,
+        contract_id: QualifiedContractIdentifier,
+        map_name: String,
+        key: Value,
+        value: Value,
+    ) -> Result<()> {
+        let event_data = StorageMapSetEventData {
+            contract_id,
+            map_name,
+            key,
+            value,
+        };
+
+        if let Some(batch) = self.global_context.event_batches.last_mut() {
+            batch.events.push(StacksTransactionEvent::StorageEvent(
+                StorageEventType::StorageMapSetEvent(event_data),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn register_map_delete_event(
+        &mut self,
+        contract_id: QualifiedContractIdentifier,
+        map_name: String,
+        key: Value,
+    ) -> Result<()> {
+        let event_data = StorageMapDeleteEventData {
+            contract_id,
+            map_name,
+            key,
+        };
+
+        if let Some(batch) = self.global_context.event_batches.last_mut() {
+            batch.events.push(StacksTransactionEvent::StorageEvent(
+                StorageEventType::StorageMapDeleteEvent(event_data),
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl<'a> GlobalContext<'a> {

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1396,6 +1396,28 @@ impl<'a, 'b> Environment<'a, 'b> {
         Ok(())
     }
 
+    pub fn register_map_insert_event(
+        &mut self,
+        contract_id: QualifiedContractIdentifier,
+        map_name: String,
+        key: Value,
+        value: Value,
+    ) -> Result<()> {
+        let event_data = StorageMapInsertEventData {
+            contract_id,
+            map_name,
+            key,
+            value,
+        };
+
+        if let Some(batch) = self.global_context.event_batches.last_mut() {
+            batch.events.push(StacksTransactionEvent::StorageEvent(
+                StorageEventType::StorageMapInsertEvent(event_data),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn register_map_delete_event(
         &mut self,
         contract_id: QualifiedContractIdentifier,

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -299,6 +299,8 @@ pub fn special_set_variable_v200(
 
     env.add_memory(value.get_memory_use())?;
 
+    env.register_var_set_event(contract.clone(), var_name.to_string(), value.clone())?;
+
     env.global_context
         .database
         .set_variable(contract, var_name, value, data_types)
@@ -319,6 +321,7 @@ pub fn special_set_variable_v205(
     check_argument_count(2, args)?;
 
     let value = eval(&args[1], env, &context)?;
+    let value_copy = value.clone();
 
     let var_name = args[0].match_atom().ok_or(CheckErrors::ExpectedName)?;
 
@@ -343,6 +346,8 @@ pub fn special_set_variable_v205(
     runtime_cost(ClarityCostFunction::SetVar, env, result_size)?;
 
     env.add_memory(result_size)?;
+
+    env.register_var_set_event(contract.clone(), var_name.to_string(), value_copy)?;
 
     result.map(|data| data.value)
 }
@@ -474,6 +479,8 @@ pub fn special_set_entry_v200(
     env.add_memory(key.get_memory_use())?;
     env.add_memory(value.get_memory_use())?;
 
+    env.register_map_set_event(contract.clone(), map_name.to_string(), key.clone(), value.clone())?;
+
     env.global_context
         .database
         .set_entry(contract, map_name, key, value, data_types)
@@ -494,8 +501,10 @@ pub fn special_set_entry_v205(
     check_argument_count(3, args)?;
 
     let key = eval(&args[1], env, &context)?;
+    let key_copy = key.clone();
 
     let value = eval(&args[2], env, &context)?;
+    let value_copy = value.clone();
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::ExpectedName)?;
 
@@ -520,6 +529,8 @@ pub fn special_set_entry_v205(
     runtime_cost(ClarityCostFunction::SetEntry, env, result_size)?;
 
     env.add_memory(result_size)?;
+
+    env.register_map_set_event(contract.clone(), map_name.to_string(), key_copy, value_copy)?;
 
     result.map(|data| data.value)
 }
@@ -558,6 +569,8 @@ pub fn special_insert_entry_v200(
     env.add_memory(key.get_memory_use())?;
     env.add_memory(value.get_memory_use())?;
 
+    env.register_map_set_event(contract.clone(), map_name.to_string(), key.clone(), value.clone())?;
+
     env.global_context
         .database
         .insert_entry(contract, map_name, key, value, data_types)
@@ -578,8 +591,10 @@ pub fn special_insert_entry_v205(
     check_argument_count(3, args)?;
 
     let key = eval(&args[1], env, &context)?;
+    let key_copy = key.clone();
 
     let value = eval(&args[2], env, &context)?;
+    let value_copy = value.clone();
 
     let map_name = args[0].match_atom().ok_or(CheckErrors::ExpectedName)?;
 
@@ -604,6 +619,8 @@ pub fn special_insert_entry_v205(
     runtime_cost(ClarityCostFunction::SetEntry, env, result_size)?;
 
     env.add_memory(result_size)?;
+
+    env.register_map_set_event(contract.clone(), map_name.to_string(), key_copy, value_copy)?;
 
     result.map(|data| data.value)
 }
@@ -638,6 +655,8 @@ pub fn special_delete_entry_v200(
     )?;
 
     env.add_memory(key.get_memory_use())?;
+
+    env.register_map_delete_event(contract.clone(), map_name.to_string(), key.clone())?;
 
     env.global_context
         .database
@@ -683,6 +702,8 @@ pub fn special_delete_entry_v205(
     runtime_cost(ClarityCostFunction::SetEntry, env, result_size)?;
 
     env.add_memory(result_size)?;
+
+    env.register_map_delete_event(contract.clone(), map_name.to_string(), key.clone())?;
 
     result.map(|data| data.value)
 }

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -586,7 +586,7 @@ pub fn special_insert_entry_v200(
     env.add_memory(key.get_memory_use())?;
     env.add_memory(value.get_memory_use())?;
 
-    env.register_map_set_event(contract.clone(), map_name.to_string(), key.clone(), value.clone())?;
+    env.register_map_insert_event(contract.clone(), map_name.to_string(), key.clone(), value.clone())?;
 
     env.global_context
         .database
@@ -637,7 +637,7 @@ pub fn special_insert_entry_v205(
 
     env.add_memory(result_size)?;
 
-    env.register_map_set_event(contract.clone(), map_name.to_string(), key_copy, value_copy)?;
+    env.register_map_insert_event(contract.clone(), map_name.to_string(), key_copy, value_copy)?;
 
     result.map(|data| data.value)
 }

--- a/clarity/src/vm/functions/database.rs
+++ b/clarity/src/vm/functions/database.rs
@@ -203,6 +203,23 @@ pub fn special_contract_call(
         }
     }
 
+    let sender = nested_env.sender.clone();
+    let caller = nested_env.caller.clone();
+
+    let mut function_args = vec![];
+    for arg in args[2..].iter() {
+        let evaluated_arg = eval(arg, env, context)?;
+        function_args.push(evaluated_arg);
+    }
+
+    env.register_contract_call_event(
+        contract_identifier.clone(), 
+        sender,
+        caller, 
+        function_name.to_string(),
+        function_args
+    )?;
+
     Ok(result)
 }
 

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -1846,7 +1846,8 @@ mod test {
 
         assert_eq!(exit, 0);
         assert!(result["message"].as_str().unwrap().len() > 0);
-        assert!(result["events"].as_array().unwrap().len() == 0);
+        // there is 1 map-set event
+        assert!(result["events"].as_array().unwrap().len() == 1);
         assert_eq!(result["output"], json!({"UInt": 1000}));
 
         eprintln!("eval tokens");

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -599,6 +599,7 @@ impl EventDispatcher {
                     | StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(_))
                     | StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(_))
                     | StacksTransactionEvent::StorageEvent(StorageEventType::StorageVarSetEvent(_))
+                    | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapInsertEvent(_))
                     | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapSetEvent(_))
                     | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapDeleteEvent(_)) 
                     | StacksTransactionEvent::ContractCallEvent(_)=> {

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -600,7 +600,8 @@ impl EventDispatcher {
                     | StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(_))
                     | StacksTransactionEvent::StorageEvent(StorageEventType::StorageVarSetEvent(_))
                     | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapSetEvent(_))
-                    | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapDeleteEvent(_)) => {
+                    | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapDeleteEvent(_)) 
+                    | StacksTransactionEvent::ContractCallEvent(_)=> {
                         for o_i in &self.stx_observers_lookup {
                             dispatch_matrix[*o_i as usize].insert(i);
                         }

--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -34,7 +34,7 @@ use stacks::types::chainstate::{
 use stacks::util::hash::bytes_to_hex;
 use stacks::vm::analysis::contract_interface_builder::build_contract_interface;
 use stacks::vm::costs::ExecutionCost;
-use stacks::vm::events::{FTEventType, NFTEventType, STXEventType};
+use stacks::vm::events::{FTEventType, NFTEventType, STXEventType, StorageEventType};
 use stacks::vm::types::{AssetIdentifier, QualifiedContractIdentifier, Value};
 
 use super::config::{EventKeyType, EventObserverConfig};
@@ -597,7 +597,10 @@ impl EventDispatcher {
                     StacksTransactionEvent::STXEvent(STXEventType::STXTransferEvent(_))
                     | StacksTransactionEvent::STXEvent(STXEventType::STXMintEvent(_))
                     | StacksTransactionEvent::STXEvent(STXEventType::STXBurnEvent(_))
-                    | StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(_)) => {
+                    | StacksTransactionEvent::STXEvent(STXEventType::STXLockEvent(_))
+                    | StacksTransactionEvent::StorageEvent(StorageEventType::StorageVarSetEvent(_))
+                    | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapSetEvent(_))
+                    | StacksTransactionEvent::StorageEvent(StorageEventType::StorageMapDeleteEvent(_)) => {
                         for o_i in &self.stx_observers_lookup {
                             dispatch_matrix[*o_i as usize].insert(i);
                         }


### PR DESCRIPTION
### Description
This PR adds new events dispatched by node, that covers storage modifications (`var-set`, `map-insert`, `map-set`, `map-delete`) and contract calls (`contract-call?`).

Having these events exposed to the event observers will allow to build much more advanced indexer services than the ones we have right now.

With full access to what is going on with contract storage during each transaction we allow users to build more performant dApps and reduce number of calls made to node itself (to execute read-only function)

### Additional info (benefits, drawbacks, caveats)
I used `clone()` in multiple places because I couldn't figure out how to deal with borrow checker.
One event is registered to late, but I don't know if we could register it sooner without adding any unwanted, negative side-effects to contract execution.

If you can point out how I could improve it, please let me know.


https://github.com/stacksgov/Stacks-Grants/issues/291

### Checklist
- [ x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
