### PR TITLE
Fix: slog-json feature in `develop`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ stacks_common = { package = "stacks-common", features = ["default", "testing"], 
 default = ["developer-mode"]
 developer-mode = []
 monitoring_prom = ["prometheus"]
-slog_json = ["slog-json"]
+slog_json = ["slog-json", "stacks_common/slog_json", "clarity/slog_json"]
 
 
 [profile.dev.package.regex]

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -49,3 +49,4 @@ assert-json-diff = "1.0.0"
 default = ["developer-mode"]
 developer-mode = []
 testing = []
+slog_json = ["stacks_common/slog_json"]

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -40,6 +40,6 @@ path = "src/main.rs"
 
 [features]
 monitoring_prom = ["stacks/monitoring_prom"]
-slog_json = ["stacks/slog_json"]
+slog_json = ["stacks/slog_json", "stacks_common/slog_json", "clarity/slog_json"]
 prod-genesis-chainstate = []
 default = []


### PR DESCRIPTION
### Description

This fixes an issue in `develop` currently where the `slog-json` feature wasn't propagating to the necessary dependencies of `stacks-node`.

### Checklist
- [x] Test coverage for new or modified code paths: there are no new codepaths, this is a build change.
- [x] Changelog is updated: changelog update is unnecessary, this is fixing something in `develop`, not `master`
- [x] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events): there are no new endpoints in this PR.
- [x] New clarity functions have corresponding PR in `clarity-benchmarking` repo: no new clarity functions
- [x] New integration test(s) added to `bitcoin-tests.yml`: no new integration tests added
