### PR TITLE
feat: include the node public key in /v2/info

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1046,6 +1046,9 @@ pub struct RPCPeerInfoData {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_public_key: Option<StacksPublicKey>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_public_key_hash: Option<Hash160>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1043,6 +1043,9 @@ pub struct RPCPeerInfoData {
     pub unanchored_tip: Option<StacksBlockId>,
     pub unanchored_seq: Option<u16>,
     pub exit_at_block_height: Option<u64>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_public_key: Option<StacksPublicKey>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -229,6 +229,7 @@ impl RPCPeerInfoData {
         };
 
         let public_key = StacksPublicKey::from_private(&network.local_peer.private_key);
+        let public_key_hash = Hash160::from_node_public_key(&public_key);
 
         RPCPeerInfoData {
             peer_version: network.burnchain.peer_version,
@@ -250,6 +251,7 @@ impl RPCPeerInfoData {
             exit_at_block_height: exit_at_block_height.cloned(),
             genesis_chainstate_hash: genesis_chainstate_hash.clone(),
             node_public_key: Some(public_key),
+            node_public_key_hash: Some(public_key_hash),
         }
     }
 }
@@ -4047,6 +4049,13 @@ mod test {
                     HttpResponseType::PeerInfo(response_md, peer_data) => {
                         assert_eq!(Some((*peer_data).clone()), *peer_server_info.borrow());
                         assert!(peer_data.node_public_key.is_some());
+                        assert!(peer_data.node_public_key_hash.is_some());
+                        assert_eq!(
+                            peer_data.node_public_key_hash,
+                            Some(Hash160::from_node_public_key(
+                                &peer_data.node_public_key.clone().unwrap()
+                            ))
+                        );
                         true
                     }
                     _ => {


### PR DESCRIPTION
Expose the node's network public key and its Hash160 in `/v2/info`.  Fixes #3046.