### PR TITLE
fix: set the default subsequent-attempt time to 30s

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1442,7 +1442,7 @@ impl MinerConfig {
         MinerConfig {
             min_tx_fee: 1,
             first_attempt_time_ms: 5_000,
-            subsequent_attempt_time_ms: 180_000,
+            subsequent_attempt_time_ms: 30_000,
             microblock_attempt_time_ms: 30_000,
             probability_pick_no_estimate_tx: 5,
         }


### PR DESCRIPTION
Fixes https://github.com/stacks-network/stacks-blockchain/issues/3098.  Sets the new time to 30s, based on real-world benchmarks with `develop`.