### PR TITLE
fix: CI error while building dist files

### DIFF
--- a/build-scripts/Dockerfile.linux-arm64
+++ b/build-scripts/Dockerfile.linux-arm64
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y git gcc-aarch64-linux-gnu
 RUN CC=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-    cargo build --release --workspace=./ --target aarch64-unknown-linux-gnu
+    cargo build --release --workspace --target aarch64-unknown-linux-gnu
 
 RUN mkdir /out && cp -R /src/target/aarch64-unknown-linux-gnu/release/. /out
 

--- a/build-scripts/Dockerfile.linux-armv7
+++ b/build-scripts/Dockerfile.linux-armv7
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y git gcc-arm-linux-gnueabihf
 RUN CC=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    cargo build --release --workspace=./ --target armv7-unknown-linux-gnueabihf
+    cargo build --release --workspace --target armv7-unknown-linux-gnueabihf
 
 RUN mkdir /out && cp -R /src/target/armv7-unknown-linux-gnueabihf/release/. /out
 

--- a/build-scripts/Dockerfile.linux-musl-x64
+++ b/build-scripts/Dockerfile.linux-musl-x64
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y git musl-tools
 RUN CC=musl-gcc \
     CC_x86_64_unknown_linux_musl=musl-gcc \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    cargo build --release --workspace=./ --target x86_64-unknown-linux-musl
+    cargo build --release --workspace --target x86_64-unknown-linux-musl
 
 RUN mkdir /out && cp -R /src/target/x86_64-unknown-linux-musl/release/. /out
 

--- a/build-scripts/Dockerfile.linux-x64
+++ b/build-scripts/Dockerfile.linux-x64
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y git
 
 RUN rustup target add x86_64-unknown-linux-gnu
 
-RUN cargo build --release --workspace=./ --target x86_64-unknown-linux-gnu
+RUN cargo build --release --workspace --target x86_64-unknown-linux-gnu
 
 RUN mkdir /out && cp -R /src/target/x86_64-unknown-linux-gnu/release/. /out
 

--- a/build-scripts/Dockerfile.macos-arm64
+++ b/build-scripts/Dockerfile.macos-arm64
@@ -16,7 +16,7 @@ RUN wget -nc -O /tmp/osxcross.tar.zst "https://github.com/hirosystems/docker-osx
 RUN mkdir /opt/osxcross && tar -xaf /tmp/osxcross.tar.zst -C /opt/osxcross
 
 RUN . /opt/osxcross/env-macos-aarch64 && \
-    cargo build --target aarch64-apple-darwin --release --workspace=./
+    cargo build --target aarch64-apple-darwin --release --workspace
 
 RUN mkdir /out && cp -R /src/target/aarch64-apple-darwin/release/. /out
 

--- a/build-scripts/Dockerfile.macos-x64
+++ b/build-scripts/Dockerfile.macos-x64
@@ -16,7 +16,7 @@ RUN wget -nc -O /tmp/osxcross.tar.zst "https://github.com/hirosystems/docker-osx
 RUN mkdir /opt/osxcross && tar -xaf /tmp/osxcross.tar.zst -C /opt/osxcross
 
 RUN . /opt/osxcross/env-macos-x86_64 && \
-    cargo build --target x86_64-apple-darwin --release --workspace=./
+    cargo build --target x86_64-apple-darwin --release --workspace
 
 RUN mkdir /out && cp -R /src/target/x86_64-apple-darwin/release/. /out
 

--- a/build-scripts/Dockerfile.windows-x64
+++ b/build-scripts/Dockerfile.windows-x64
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y git gcc-mingw-w64-x86-64
 
 RUN CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
-    cargo build --release --workspace=./ --target x86_64-pc-windows-gnu
+    cargo build --release --workspace --target x86_64-pc-windows-gnu
     
 RUN mkdir /out && cp -R /src/target/x86_64-pc-windows-gnu/release/. /out
 


### PR DESCRIPTION
A recent cargo/rust change made the build arg `--workspace` error if a value was provided, since then all platform dist builds have been broken in CI with an error message like:
```
#9 ERROR: process "/bin/sh -c cargo build --release --workspace=./ --target x86_64-unknown-linux-gnu" did not complete successfully: exit code: 1
------
 > [build 6/7] RUN cargo build --release --workspace=./ --target x86_64-unknown-linux-gnu:
#0 0.080 error: The value '=./' was provided to '--workspace' but it wasn't expecting any more values
```
This PR should fix that.