### PR TITLE
Fix/utxo chaining

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ default = ["developer-mode"]
 developer-mode = []
 monitoring_prom = ["prometheus"]
 slog_json = ["slog-json", "stacks_common/slog_json", "clarity/slog_json"]
-
+testing = []
 
 [profile.dev.package.regex]
 opt-level = 2

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -691,12 +691,11 @@ impl LeaderBlockCommitOp {
             let intended_sortition = match epoch.epoch_id {
                 StacksEpochId::Epoch21 => {
                     // correct behavior
-                    if self.block_height < burnchain.first_block_height {
-                        return Err(op_error::BlockCommitPredatesGenesis);
-                    }
                     let sortition_height = self
                         .block_height
-                        .saturating_sub(burnchain.first_block_height);
+                        .checked_sub(burnchain.first_block_height)
+                        .ok_or_else(|| op_error::BlockCommitPredatesGenesis)?;
+
                     if miss_distance > sortition_height {
                         return Err(op_error::BlockCommitBadModulus);
                     }

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -35,8 +35,8 @@ use crate::chainstate::burn::SortitionId;
 use crate::chainstate::stacks::index::storage::TrieFileStorage;
 use crate::chainstate::stacks::{StacksPrivateKey, StacksPublicKey};
 use crate::codec::{write_next, Error as codec_error, StacksMessageCodec};
-use crate::core::STACKS_EPOCH_2_05_MARKER;
 use crate::core::{StacksEpoch, StacksEpochId};
+use crate::core::{STACKS_EPOCH_2_05_MARKER, STACKS_EPOCH_2_1_MARKER};
 use crate::net::Error as net_error;
 use crate::types::chainstate::TrieHash;
 use crate::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksAddress, VRFSeed};
@@ -679,17 +679,43 @@ impl LeaderBlockCommitOp {
             //  is not valid, but we should allow this UTXO to "chain" to valid
             //  UTXOs to allow the miner windowing to work in the face of missed
             //  blocks.
+            let epoch = SortitionDB::get_stacks_epoch(tx, self.block_height)?.expect(&format!(
+                "FATAL: impossible block height: no epoch defined for {}",
+                self.block_height
+            ));
             let miss_distance = if actual_modulus > intended_modulus {
                 actual_modulus - intended_modulus
             } else {
                 BURN_BLOCK_MINED_AT_MODULUS + actual_modulus - intended_modulus
             };
-            if miss_distance > self.block_height {
-                return Err(op_error::BlockCommitBadModulus);
-            }
-            let intended_sortition = tx
-                .get_ancestor_block_hash(self.block_height - miss_distance, &tx_tip)?
-                .ok_or_else(|| op_error::BlockCommitNoParent)?;
+            let intended_sortition = match epoch.epoch_id {
+                StacksEpochId::Epoch21 => {
+                    // correct behavior
+                    if self.block_height < burnchain.first_block_height {
+                        return Err(op_error::BlockCommitPredatesGenesis);
+                    }
+                    let sortition_height = self
+                        .block_height
+                        .saturating_sub(burnchain.first_block_height);
+                    if miss_distance > sortition_height {
+                        return Err(op_error::BlockCommitBadModulus);
+                    }
+
+                    tx.get_ancestor_block_hash(sortition_height - miss_distance, &tx_tip)?
+                        .ok_or_else(|| op_error::BlockCommitNoParent)?
+                }
+                StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
+                    // buggy behavior that must be preserved for compatibility :(
+                    if miss_distance > self.block_height {
+                        return Err(op_error::BlockCommitBadModulus);
+                    }
+                    tx.get_ancestor_block_hash(self.block_height - miss_distance, &tx_tip)?
+                        .ok_or_else(|| op_error::BlockCommitNoParent)?
+                }
+                StacksEpochId::Epoch10 => {
+                    panic!("Block commits are not supported in epoch 1.0");
+                }
+            };
             let missed_data = MissedBlockCommit {
                 input: self.input.clone(),
                 txid: self.txid.clone(),
@@ -893,6 +919,8 @@ mod tests {
     use clarity::vm::costs::ExecutionCost;
     use rand::thread_rng;
     use rand::RngCore;
+
+    use crate::core::StacksEpochExtension;
 
     struct OpFixture {
         txstr: String,
@@ -1505,6 +1533,563 @@ mod tests {
                     assert!(false);
                 }
             };
+        }
+    }
+
+    #[test]
+    fn test_check_2_1() {
+        let first_block_height = 121;
+        let first_burn_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000123",
+        )
+        .unwrap();
+
+        let block_122_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000001220",
+        )
+        .unwrap();
+        let block_123_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000001230",
+        )
+        .unwrap();
+        let block_124_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000001240",
+        )
+        .unwrap();
+        let block_125_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000001250",
+        )
+        .unwrap();
+        let block_126_hash = BurnchainHeaderHash::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000001260",
+        )
+        .unwrap();
+
+        let block_header_hashes = [
+            block_122_hash.clone(),
+            block_123_hash.clone(),
+            block_124_hash.clone(),
+            block_125_hash.clone(), // prepare phase
+            block_126_hash.clone(), // prepare phase
+        ];
+
+        let burnchain = Burnchain {
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            peer_version: 0x012345678,
+            network_id: 0x9abcdef0,
+            chain_name: "bitcoin".to_string(),
+            network_name: "testnet".to_string(),
+            working_dir: "/nope".to_string(),
+            consensus_hash_lifetime: 24,
+            stable_confirmations: 7,
+            first_block_height,
+            initial_reward_start_block: first_block_height,
+            first_block_timestamp: 0,
+            first_block_hash: first_burn_hash.clone(),
+        };
+
+        let leader_key_1 = LeaderKeyRegisterOp {
+            consensus_hash: ConsensusHash::from_bytes(
+                &hex_bytes("2222222222222222222222222222222222222222").unwrap(),
+            )
+            .unwrap(),
+            public_key: VRFPublicKey::from_bytes(
+                &hex_bytes("a366b51292bef4edd64063d9145c617fec373bceb0758e98cd72becd84d54c7a")
+                    .unwrap(),
+            )
+            .unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: StacksAddress::from_bitcoin_address(
+                &BitcoinAddress::from_scriptpubkey(
+                    BitcoinNetworkType::Testnet,
+                    &hex_bytes("76a914306231b2782b5f80d944bf69f9d46a1453a0a0eb88ac").unwrap(),
+                )
+                .unwrap(),
+            ),
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("1bfa831b5fc56c858198acb8e77e5863c1e9d8ac26d49ddb914e24d8d4083562")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 456,
+            block_height: 124,
+            burn_header_hash: block_124_hash.clone(),
+        };
+
+        let leader_key_2 = LeaderKeyRegisterOp {
+            consensus_hash: ConsensusHash::from_bytes(
+                &hex_bytes("3333333333333333333333333333333333333333").unwrap(),
+            )
+            .unwrap(),
+            public_key: VRFPublicKey::from_bytes(
+                &hex_bytes("bb519494643f79f1dea0350e6fb9a1da88dfdb6137117fc2523824a8aa44fe1c")
+                    .unwrap(),
+            )
+            .unwrap(),
+            memo: vec![01, 02, 03, 04, 05],
+            address: StacksAddress::from_bitcoin_address(
+                &BitcoinAddress::from_scriptpubkey(
+                    BitcoinNetworkType::Testnet,
+                    &hex_bytes("76a914306231b2782b5f80d944bf69f9d46a1453a0a0eb88ac").unwrap(),
+                )
+                .unwrap(),
+            ),
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("9410df84e2b440055c33acb075a0687752df63fe8fe84aeec61abe469f0448c7")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 457,
+            block_height: 124,
+            burn_header_hash: block_124_hash.clone(),
+        };
+
+        // consumes leader_key_1
+        let block_commit_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
+            block_header_hash: BlockHeaderHash::from_bytes(
+                &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
+                    .unwrap(),
+            )
+            .unwrap(),
+            new_seed: VRFSeed::from_bytes(
+                &hex_bytes("3333333333333333333333333333333333333333333333333333333333333333")
+                    .unwrap(),
+            )
+            .unwrap(),
+            parent_block_ptr: 0,
+            parent_vtxindex: 0,
+            key_block_ptr: 124,
+            key_vtxindex: 456,
+            memo: vec![0x80],
+            commit_outs: vec![],
+
+            burn_fee: 12345,
+            input: (Txid([0; 32]), 0),
+            apparent_sender: BurnchainSigner {
+                public_keys: vec![StacksPublicKey::from_hex(
+                    "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                )
+                .unwrap()],
+                num_sigs: 1,
+                hash_mode: AddressHashMode::SerializeP2PKH,
+            },
+
+            txid: Txid::from_bytes_be(
+                &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
+                    .unwrap(),
+            )
+            .unwrap(),
+            vtxindex: 444,
+            block_height: 125,
+            burn_parent_modulus: (124 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+            burn_header_hash: block_125_hash.clone(),
+        };
+
+        let mut db = SortitionDB::connect_test_with_epochs(
+            first_block_height,
+            &first_burn_hash,
+            StacksEpoch::all(0, 0, first_block_height),
+        )
+        .unwrap();
+        let block_ops = vec![
+            // 122
+            vec![],
+            // 123
+            vec![],
+            // 124
+            vec![
+                BlockstackOperationType::LeaderKeyRegister(leader_key_1.clone()),
+                BlockstackOperationType::LeaderKeyRegister(leader_key_2.clone()),
+            ],
+            // 125
+            vec![BlockstackOperationType::LeaderBlockCommit(
+                block_commit_1.clone(),
+            )],
+            // 126
+            vec![],
+        ];
+
+        let tip_index_root = {
+            let mut prev_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
+            for i in 0..block_header_hashes.len() {
+                let mut snapshot_row = BlockSnapshot {
+                    accumulated_coinbase_ustx: 0,
+                    pox_valid: true,
+                    block_height: (i + 1 + first_block_height as usize) as u64,
+                    burn_header_timestamp: get_epoch_time_secs(),
+                    burn_header_hash: block_header_hashes[i].clone(),
+                    sortition_id: SortitionId(block_header_hashes[i as usize].0.clone()),
+                    parent_sortition_id: prev_snapshot.sortition_id.clone(),
+                    parent_burn_header_hash: prev_snapshot.burn_header_hash.clone(),
+                    consensus_hash: ConsensusHash::from_bytes(&[
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        (i + 1) as u8,
+                    ])
+                    .unwrap(),
+                    ops_hash: OpsHash::from_bytes(&[
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, i as u8,
+                    ])
+                    .unwrap(),
+                    total_burn: i as u64,
+                    sortition: true,
+                    sortition_hash: SortitionHash::initial(),
+                    winning_block_txid: Txid::from_hex(
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                    .unwrap(),
+                    winning_stacks_block_hash: BlockHeaderHash::from_hex(
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                    .unwrap(),
+                    index_root: TrieHash::from_empty_data(),
+                    num_sortitions: (i + 1) as u64,
+                    stacks_block_accepted: false,
+                    stacks_block_height: 0,
+                    arrival_index: 0,
+                    canonical_stacks_tip_height: 0,
+                    canonical_stacks_tip_hash: BlockHeaderHash([0u8; 32]),
+                    canonical_stacks_tip_consensus_hash: ConsensusHash([0u8; 20]),
+                };
+                let mut tx =
+                    SortitionHandleTx::begin(&mut db, &prev_snapshot.sortition_id).unwrap();
+                let next_index_root = tx
+                    .append_chain_tip_snapshot(
+                        &prev_snapshot,
+                        &snapshot_row,
+                        &block_ops[i],
+                        &vec![],
+                        None,
+                        None,
+                        None,
+                    )
+                    .unwrap();
+
+                snapshot_row.index_root = next_index_root;
+                tx.commit().unwrap();
+
+                prev_snapshot = snapshot_row;
+            }
+
+            prev_snapshot.index_root.clone()
+        };
+
+        let fixtures = vec![
+            CheckFixture {
+                // accept -- consumes leader_key_2
+                op: LeaderBlockCommitOp {
+                    sunset_burn: 0,
+                    block_header_hash: BlockHeaderHash::from_bytes(
+                        &hex_bytes(
+                            "2222222222222222222222222222222222222222222222222222222222222222",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    new_seed: VRFSeed::from_bytes(
+                        &hex_bytes(
+                            "3333333333333333333333333333333333333333333333333333333333333333",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    parent_block_ptr: 125,
+                    parent_vtxindex: 444,
+                    key_block_ptr: 124,
+                    key_vtxindex: 457,
+                    memo: vec![STACKS_EPOCH_2_1_MARKER],
+                    commit_outs: vec![],
+
+                    burn_fee: 12345,
+                    input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
+
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    vtxindex: 445,
+                    block_height: 126,
+                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    burn_header_hash: block_126_hash.clone(),
+                },
+                res: Ok(()),
+            },
+            CheckFixture {
+                // accept -- builds directly off of genesis block and consumes leader_key_2
+                op: LeaderBlockCommitOp {
+                    sunset_burn: 0,
+                    block_header_hash: BlockHeaderHash::from_bytes(
+                        &hex_bytes(
+                            "2222222222222222222222222222222222222222222222222222222222222222",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    new_seed: VRFSeed::from_bytes(
+                        &hex_bytes(
+                            "3333333333333333333333333333333333333333333333333333333333333333",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    parent_block_ptr: 0,
+                    parent_vtxindex: 0,
+                    key_block_ptr: 124,
+                    key_vtxindex: 457,
+                    memo: vec![STACKS_EPOCH_2_1_MARKER],
+                    commit_outs: vec![],
+
+                    burn_fee: 12345,
+                    input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
+
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    vtxindex: 445,
+                    block_height: 126,
+                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    burn_header_hash: block_126_hash.clone(),
+                },
+                res: Ok(()),
+            },
+            CheckFixture {
+                // accept -- also consumes leader_key_1
+                op: LeaderBlockCommitOp {
+                    sunset_burn: 0,
+                    block_header_hash: BlockHeaderHash::from_bytes(
+                        &hex_bytes(
+                            "2222222222222222222222222222222222222222222222222222222222222222",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    new_seed: VRFSeed::from_bytes(
+                        &hex_bytes(
+                            "3333333333333333333333333333333333333333333333333333333333333333",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    parent_block_ptr: 0,
+                    parent_vtxindex: 0,
+                    key_block_ptr: 124,
+                    key_vtxindex: 456,
+                    memo: vec![STACKS_EPOCH_2_1_MARKER],
+                    commit_outs: vec![],
+
+                    burn_fee: 12345,
+                    input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
+
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    vtxindex: 444,
+                    block_height: 126,
+                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    burn_header_hash: block_126_hash.clone(),
+                },
+                res: Ok(()),
+            },
+            CheckFixture {
+                // reject -- bad burn parent modulus
+                op: LeaderBlockCommitOp {
+                    sunset_burn: 0,
+                    block_header_hash: BlockHeaderHash::from_bytes(
+                        &hex_bytes(
+                            "2222222222222222222222222222222222222222222222222222222222222222",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    new_seed: VRFSeed::from_bytes(
+                        &hex_bytes(
+                            "3333333333333333333333333333333333333333333333333333333333333333",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    parent_block_ptr: 0,
+                    parent_vtxindex: 0,
+                    key_block_ptr: 124,
+                    key_vtxindex: 456,
+                    memo: vec![0x80],
+                    commit_outs: vec![],
+
+                    burn_fee: 12345,
+                    input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
+
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    vtxindex: 444,
+                    block_height: 126,
+                    burn_parent_modulus: (124 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    burn_header_hash: block_126_hash.clone(),
+                },
+                res: Err(op_error::MissedBlockCommit(MissedBlockCommit {
+                    input: (Txid([0; 32]), 0),
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    // miss distance from height 126 was 1, which corresponds to the hash at height
+                    // 125 (intended modulus = ((124 % 5) + 1) % 5 = 0, actual = (126 % 5) = 1
+                    intended_sortition: SortitionId(block_125_hash.0.clone()),
+                })),
+            },
+            CheckFixture {
+                // reject -- bad burn parent modulus
+                op: LeaderBlockCommitOp {
+                    sunset_burn: 0,
+                    block_header_hash: BlockHeaderHash::from_bytes(
+                        &hex_bytes(
+                            "2222222222222222222222222222222222222222222222222222222222222222",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    new_seed: VRFSeed::from_bytes(
+                        &hex_bytes(
+                            "3333333333333333333333333333333333333333333333333333333333333333",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    parent_block_ptr: 0,
+                    parent_vtxindex: 0,
+                    key_block_ptr: 124,
+                    key_vtxindex: 456,
+                    memo: vec![0x80],
+                    commit_outs: vec![],
+
+                    burn_fee: 12345,
+                    input: (Txid([0; 32]), 0),
+                    apparent_sender: BurnchainSigner {
+                        public_keys: vec![StacksPublicKey::from_hex(
+                            "02d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d0",
+                        )
+                        .unwrap()],
+                        num_sigs: 1,
+                        hash_mode: AddressHashMode::SerializeP2PKH,
+                    },
+
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    vtxindex: 444,
+                    block_height: 124,
+                    burn_parent_modulus: (125 % BURN_BLOCK_MINED_AT_MODULUS) as u8,
+                    burn_header_hash: block_126_hash.clone(),
+                },
+                res: Err(op_error::MissedBlockCommit(MissedBlockCommit {
+                    input: (Txid([0; 32]), 0),
+                    txid: Txid::from_bytes_be(
+                        &hex_bytes(
+                            "3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf",
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
+                    // miss distance from height 124 was 3, which corresponds to the hash at height
+                    // 121 (intended modulus = (((125 % 5) + 1) % 5) = 1, actual modulus = 124 % 5 = 4
+                    intended_sortition: SortitionId(first_burn_hash.0.clone()),
+                })),
+            },
+        ];
+
+        for (ix, fixture) in fixtures.iter().enumerate() {
+            eprintln!("Processing {}", ix);
+            let header = BurnchainBlockHeader {
+                block_height: fixture.op.block_height,
+                block_hash: fixture.op.burn_header_hash.clone(),
+                parent_block_hash: fixture.op.burn_header_hash.clone(),
+                num_txs: 1,
+                timestamp: get_epoch_time_secs(),
+            };
+            let mut ic = SortitionHandleTx::begin(
+                &mut db,
+                &SortitionId::stubbed(&fixture.op.burn_header_hash),
+            )
+            .unwrap();
+            assert_eq!(
+                format!("{:?}", &fixture.res),
+                format!("{:?}", &fixture.op.check(&burnchain, &mut ic, None))
+            );
         }
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -309,6 +309,10 @@ lazy_static! {
 /// *or greater*.
 pub static STACKS_EPOCH_2_05_MARKER: u8 = 0x05;
 
+/// Stacks 2.1 epoch marker.  All block-commits in 2.1 must have a memo bitfield with this value
+/// *or greater*.
+pub static STACKS_EPOCH_2_1_MARKER: u8 = 0x06;
+
 #[test]
 fn test_ord_for_stacks_epoch() {
     let epochs = STACKS_EPOCHS_MAINNET.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,7 +321,7 @@ fn main() {
         let sort_db_path = format!("{}/mainnet/burnchain/sortition", &argv[2]);
         let (chainstate, _) =
             StacksChainState::open(true, CHAIN_ID_MAINNET, &chain_state_path, None).unwrap();
-        let sort_db = SortitionDB::open(&sort_db_path, false)
+        let sort_db = SortitionDB::open(&sort_db_path, false, PoxConstants::mainnet_default())
             .expect(&format!("Failed to open {}", &sort_db_path));
 
         let num_blocks = argv[3].parse::<u64>().unwrap();

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -30,6 +30,9 @@ ring = "0.16.19"
 warp = "0.3"
 tokio = "1.15"
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls"] }
+stacks = { package = "blockstack-core", path = "../../.", features = ["testing"] }
+clarity = { package = "clarity", path = "../../clarity/.", features = ["testing"] }
+stacks_common = { package = "stacks-common", path = "../../stacks-common/.", features = ["testing"] }
 
 [dev-dependencies.rusqlite]
 version = "=0.24.2"

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1469,6 +1469,9 @@ impl BitcoinRegtestController {
         self.allow_rbf = val;
     }
 
+    #[cfg(not(test))]
+    pub fn set_allow_rbf(&mut self, _val: bool) {}
+
     pub fn make_operation_tx(
         &mut self,
         operation: BlockstackOperationType,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -174,7 +174,7 @@ fn fault_injection_delay_transactions(
     _op_signer: &mut BurnchainOpSigner,
     _attempt: u64,
 ) -> bool {
-    false
+    true
 }
 
 struct AssembledAnchorBlock {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -93,6 +93,9 @@ fn store_delayed_tx(tx: SerializedTx, send_height: u64) {
     }
 }
 
+#[cfg(not(test))]
+fn store_delayed_tx(_tx: SerializedTx, _send_height: u64) {}
+
 #[cfg(test)]
 fn get_delayed_txs(height: u64) -> Vec<SerializedTx> {
     match DELAYED_TXS.lock() {
@@ -101,6 +104,11 @@ fn get_delayed_txs(height: u64) -> Vec<SerializedTx> {
             panic!("Poisoned DELAYED_TXS mutex");
         }
     }
+}
+
+#[cfg(not(test))]
+fn get_delayed_txs(_height: u64) -> Vec<SerializedTx> {
+    vec![]
 }
 
 struct AssembledAnchorBlock {

--- a/testnet/stacks-node/src/operations.rs
+++ b/testnet/stacks-node/src/operations.rs
@@ -36,7 +36,7 @@ impl BurnchainOpSigner {
 
     pub fn sign_message(&mut self, hash: &[u8]) -> Option<MessageSignature> {
         if self.is_disposed {
-            debug!("Signer is dsposed");
+            debug!("Signer is disposed");
             return None;
         }
 

--- a/testnet/stacks-node/src/operations.rs
+++ b/testnet/stacks-node/src/operations.rs
@@ -36,12 +36,16 @@ impl BurnchainOpSigner {
 
     pub fn sign_message(&mut self, hash: &[u8]) -> Option<MessageSignature> {
         if self.is_disposed {
+            debug!("Signer is dsposed");
             return None;
         }
 
         let signature = match self.secret_key.sign(hash) {
             Ok(r) => r,
-            _ => return None,
+            Err(e) => {
+                debug!("Secret key error: {:?}", &e);
+                return None;
+            }
         };
         self.usages += 1;
 

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -1,0 +1,231 @@
+use std::env;
+use std::thread;
+
+use stacks::burnchains::Burnchain;
+use stacks::chainstate::stacks::db::StacksChainState;
+use stacks::chainstate::stacks::StacksBlockHeader;
+use stacks::types::chainstate::StacksAddress;
+
+use crate::neon;
+use crate::tests::bitcoin_regtest::BitcoinCoreController;
+use crate::tests::neon_integrations::*;
+use crate::BitcoinRegtestController;
+use crate::BurnchainController;
+use stacks::core;
+
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
+use stacks::chainstate::burn::distribution::BurnSamplePoint;
+
+use stacks::burnchains::PoxConstants;
+
+use crate::stacks_common::types::Address;
+
+use stacks_common::util::secp256k1::Secp256k1PublicKey;
+
+#[test]
+#[ignore]
+fn transition_fixes_utxo_chaining() {
+    // very simple test to verify that the miner will keep making valid (empty) blocks after the
+    // transition.  Really tests that the block-commits are well-formed before and after the epoch
+    // transition.
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let epoch_2_05 = 210;
+    let epoch_2_1 = 215;
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = epoch_2_05;
+    epochs[2].start_height = epoch_2_05;
+    epochs[2].end_height = epoch_2_1;
+    epochs[3].start_height = epoch_2_1;
+
+    conf.burnchain.epochs = Some(epochs);
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let reward_cycle_len = 2000;
+    let prepare_phase_len = 100;
+    let pox_constants = PoxConstants::new(
+        reward_cycle_len,
+        prepare_phase_len,
+        4 * prepare_phase_len / 5,
+        5,
+        15,
+        (16 * reward_cycle_len - 1).into(),
+        (17 * reward_cycle_len).into(),
+        u32::max_value(),
+    );
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    // give one coinbase to the miner, and then burn the rest
+    btc_regtest_controller.bootstrap_chain(1);
+
+    let mining_pubkey = btc_regtest_controller.get_mining_pubkey().unwrap();
+    btc_regtest_controller.set_mining_pubkey(
+        "03dc62fe0b8964d01fc9ca9a5eec0e22e557a12cc656919e648f04e0b26fea5faa".to_string(),
+    );
+
+    // bitcoin chain starts at epoch 2.05 boundary, minus 5 blocks to go
+    btc_regtest_controller.bootstrap_chain(epoch_2_05 - 6);
+
+    // only one UTXO for our mining pubkey
+    let utxos = btc_regtest_controller
+        .get_all_utxos(&Secp256k1PublicKey::from_hex(&mining_pubkey).unwrap());
+    assert_eq!(utxos.len(), 1);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    let runloop_burnchain = burnchain_config.clone();
+    thread::spawn(move || run_loop.start(Some(runloop_burnchain), 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let tip_info = get_chain_info(&conf);
+    assert_eq!(tip_info.burn_block_height, epoch_2_05 - 4);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // cross the epoch 2.05 boundary
+    for _i in 0..3 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let tip_info = get_chain_info(&conf);
+    assert_eq!(tip_info.burn_block_height, epoch_2_05 + 1);
+
+    // these should all succeed across the epoch 2.1 boundary
+    for _i in 0..5 {
+        // also, make *huge* block-commits with invalid marker bytes once we reach the new
+        // epoch, and verify that it fails.
+        let tip_info = get_chain_info(&conf);
+
+        // this block is the epoch transition?
+        let (chainstate, _) = StacksChainState::open(
+            false,
+            conf.burnchain.chain_id,
+            &conf.get_chainstate_path_str(),
+            None,
+        )
+        .unwrap();
+        let res = StacksChainState::block_crosses_epoch_boundary(
+            &chainstate.db(),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+        )
+        .unwrap();
+        debug!(
+            "Epoch transition at {} ({}/{}) height {}: {}",
+            &StacksBlockHeader::make_index_block_hash(
+                &tip_info.stacks_tip_consensus_hash,
+                &tip_info.stacks_tip
+            ),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+            tip_info.burn_block_height,
+            res
+        );
+
+        if tip_info.burn_block_height >= epoch_2_1 {
+            if tip_info.burn_block_height == epoch_2_1 {
+                assert!(res);
+            }
+
+            // pox-2 should be initialized now
+            let _ = get_contract_src(
+                &http_origin,
+                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                "pox-2".to_string(),
+                true,
+            )
+            .unwrap();
+        } else {
+            assert!(!res);
+
+            // pox-2 should NOT be initialized
+            let e = get_contract_src(
+                &http_origin,
+                StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+                "pox-2".to_string(),
+                true,
+            )
+            .unwrap_err();
+            eprintln!("No pox-2: {}", &e);
+        }
+
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let tip_info = get_chain_info(&conf);
+    assert_eq!(tip_info.burn_block_height, epoch_2_1 + 1);
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 9);
+
+    eprintln!("Begin epoch 2.1");
+
+    // post epoch 2.1 -- UTXO chaining should be fixed
+    for i in 0..10 {
+        let tip_info = get_chain_info(&conf);
+
+        if i % 2 == 1 {
+            std::env::set_var(
+                "STX_TEST_LATE_BLOCK_COMMIT",
+                format!("{}", tip_info.burn_block_height + 1),
+            );
+        }
+
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let sortdb = btc_regtest_controller.sortdb_mut();
+    let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+    let burn_sample: Vec<BurnSamplePoint> = sortdb
+        .conn()
+        .query_row(
+            "SELECT data FROM snapshot_burn_distributions WHERE sortition_id = ?",
+            &[tip.sortition_id],
+            |row| {
+                let data_str: String = row.get_unwrap(0);
+                Ok(serde_json::from_str(&data_str).unwrap())
+            },
+        )
+        .unwrap();
+
+    // if UTXO linking is fixed, then our median burn will be int((20,000 + 1) / 2).
+    // Otherwise, it will be 1.
+    assert_eq!(burn_sample.len(), 1);
+    assert_eq!(burn_sample[0].burns, 10_000);
+
+    channel.stop_chains_coordinator();
+}

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -1,4 +1,6 @@
 use std::convert::TryInto;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 use rand::RngCore;
 
@@ -26,6 +28,9 @@ use stacks::vm::{ClarityName, ContractName, Value};
 use stacks::{address::AddressHashMode, util::hash::to_hex};
 
 use crate::helium::RunLoop;
+use crate::tests::neon_integrations::get_chain_info;
+use crate::tests::neon_integrations::next_block_and_wait;
+use crate::BitcoinRegtestController;
 use stacks::core::StacksEpochId;
 
 use super::burnchains::bitcoin_regtest_controller::ParsedUTXO;
@@ -34,6 +39,7 @@ use super::Config;
 mod atlas;
 mod bitcoin_regtest;
 mod epoch_205;
+mod epoch_21;
 mod integrations;
 mod mempool;
 pub mod neon_integrations;
@@ -428,6 +434,59 @@ fn make_microblock(
         .mine_next_microblock_from_txs(mempool_txs, privk)
         .unwrap();
     microblock
+}
+
+/// Deserializes the `StacksTransaction` objects from `blocks` and returns all those that
+/// match `test_fn`.
+pub fn select_transactions_where(
+    blocks: &Vec<serde_json::Value>,
+    test_fn: fn(&StacksTransaction) -> bool,
+) -> Vec<StacksTransaction> {
+    let mut result = vec![];
+    for block in blocks {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        for tx in transactions.iter() {
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+            if test_fn(&parsed) {
+                result.push(parsed);
+            }
+        }
+    }
+
+    return result;
+}
+
+/// This function will call `next_block_and_wait` until the burnchain height underlying `BitcoinRegtestController`
+/// reaches *exactly* `target_height`.
+///
+/// Returns `false` if `next_block_and_wait` times out.
+pub fn run_until_burnchain_height(
+    btc_regtest_controller: &mut BitcoinRegtestController,
+    blocks_processed: &Arc<AtomicU64>,
+    target_height: u64,
+    conf: &Config,
+) -> bool {
+    let tip_info = get_chain_info(&conf);
+    let mut current_height = tip_info.burn_block_height;
+
+    while current_height < target_height {
+        eprintln!(
+            "run_until_burnchain_height: Issuing block at {}, current_height burnchain height is ({})",
+            get_epoch_time_secs(),
+            current_height
+        );
+        let next_result = next_block_and_wait(btc_regtest_controller, &blocks_processed);
+        if !next_result {
+            return false;
+        }
+        let tip_info = get_chain_info(&conf);
+        current_height = tip_info.burn_block_height;
+    }
+
+    assert_eq!(current_height, target_height);
+    true
 }
 
 #[test]

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -72,7 +72,6 @@ use super::{
     make_microblock, make_stacks_transfer, make_stacks_transfer_mblock_only, to_addr, ADDR_4, SK_1,
     SK_2,
 };
-use crate::tests::SK_3;
 use stacks::chainstate::stacks::miner::{
     TransactionErrorEvent, TransactionEvent, TransactionSkippedEvent, TransactionSuccessEvent,
 };
@@ -799,7 +798,7 @@ fn get_chain_tip_height(http_origin: &str) -> u64 {
     res.stacks_tip_height
 }
 
-fn get_contract_src(
+pub fn get_contract_src(
     http_origin: &str,
     contract_addr: StacksAddress,
     contract_name: String,
@@ -4350,7 +4349,7 @@ fn microblock_limit_hit_integration_test() {
         100,
     );
 
-    let (mut conf, miner_account) = neon_integration_test_conf();
+    let (mut conf, _miner_account) = neon_integration_test_conf();
 
     conf.initial_balances.push(InitialBalance {
         address: addr.clone().into(),


### PR DESCRIPTION
This fixes miner UTXO chaining (#2358), and adds unit tests and integration tests to verify that missed block commits are now included in a miner's UTXO chain when determining its sortition weight.

Nearly all of this new code is tests and test infrastructure.  The change itself is less than 20 lines long.