### PR TITLE
Bootup fixes for 2.05.0.2.0-rc1

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -66,6 +66,7 @@ use crate::net::neighbors::MAX_NEIGHBOR_BLOCK_DELAY;
 use crate::net::{Error as NetError, Error};
 use crate::util_lib::db::tx_begin_immediate;
 use crate::util_lib::db::tx_busy_handler;
+use crate::util_lib::db::DBTx;
 use crate::util_lib::db::Error as db_error;
 use crate::util_lib::db::{
     db_mkdirs, query_count, query_row, query_row_columns, query_row_panic, query_rows, sql_pragma,
@@ -2477,7 +2478,7 @@ impl SortitionDB {
         Ok(version)
     }
 
-    fn apply_schema_2(tx: &SortitionDBTx, epochs: &[StacksEpoch]) -> Result<(), db_error> {
+    fn apply_schema_2(tx: &DBTx, epochs: &[StacksEpoch]) -> Result<(), db_error> {
         for sql_exec in SORTITION_DB_SCHEMA_2 {
             tx.execute_batch(sql_exec)?;
         }
@@ -2492,7 +2493,7 @@ impl SortitionDB {
         Ok(())
     }
 
-    fn apply_schema_3(tx: &SortitionDBTx) -> Result<(), db_error> {
+    fn apply_schema_3(tx: &DBTx) -> Result<(), db_error> {
         for sql_exec in SORTITION_DB_SCHEMA_3 {
             tx.execute_batch(sql_exec)?;
         }
@@ -2510,10 +2511,8 @@ impl SortitionDB {
                 if version == expected_version {
                     Ok(())
                 } else {
-                    Err(db_error::Other(format!(
-                        "The version of the sortition DB {} does not match the expected {} and cannot be updated from SortitionDB::open()",
-                        version, expected_version
-                    )))
+                    let version_u64 = version.parse::<u64>().unwrap();
+                    Err(db_error::OldSchema(version_u64))
                 }
             }
             Ok(None) => panic!("The schema version of the sortition DB is not recorded."),
@@ -2521,19 +2520,23 @@ impl SortitionDB {
         }
     }
 
-    fn check_schema_version_and_update(&mut self, epochs: &[StacksEpoch]) -> Result<(), db_error> {
+    /// Migrate the sortition DB to its latest version, given the set of system epochs
+    pub fn check_schema_version_and_update(
+        &mut self,
+        epochs: &[StacksEpoch],
+    ) -> Result<(), db_error> {
         let expected_version = SORTITION_DB_VERSION.to_string();
         loop {
             match SortitionDB::get_schema_version(self.conn()) {
                 Ok(Some(version)) => {
                     if version == "1" {
                         let tx = self.tx_begin()?;
-                        SortitionDB::apply_schema_2(&tx, epochs)?;
+                        SortitionDB::apply_schema_2(&tx.deref(), epochs)?;
                         tx.commit()?;
                     } else if version == "2" {
                         // add the tables of schema 3, but do not populate them.
                         let tx = self.tx_begin()?;
-                        SortitionDB::apply_schema_3(&tx)?;
+                        SortitionDB::apply_schema_3(&tx.deref())?;
                         tx.commit()?;
                     } else if version == expected_version {
                         return Ok(());
@@ -2544,6 +2547,24 @@ impl SortitionDB {
                 Ok(None) => panic!("The schema version of the sortition DB is not recorded."),
                 Err(e) => panic!("Error obtaining the version of the sortition DB: {:?}", e),
             }
+        }
+    }
+
+    /// Open and migrate the sortition DB if it exists.
+    pub fn migrate_if_exists(path: &str, epochs: &[StacksEpoch]) -> Result<(), db_error> {
+        if let Err(db_error::OldSchema(_)) = SortitionDB::open(path, false) {
+            let index_path = db_mkdirs(path)?;
+            let marf = SortitionDB::open_index(&index_path)?;
+            let mut db = SortitionDB {
+                marf,
+                readwrite: true,
+                // not used by migration logic
+                first_block_height: 0,
+                first_burn_header_hash: BurnchainHeaderHash([0xff; 32]),
+            };
+            db.check_schema_version_and_update(epochs)
+        } else {
+            Ok(())
         }
     }
 

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -59,6 +59,8 @@ use crate::types::chainstate::{
 };
 use clarity::vm::database::BurnStateDB;
 
+use crate::chainstate::stacks::index::marf::MARFOpenOpts;
+
 pub use self::comm::CoordinatorCommunication;
 
 pub mod comm;
@@ -934,4 +936,36 @@ pub fn check_chainstate_db_versions(
     }
 
     Ok(true)
+}
+
+/// Migrate all databases to their latest schemas.
+/// Verifies that this is possible as well
+pub fn migrate_chainstate_dbs(
+    epochs: &[StacksEpoch],
+    sortdb_path: &str,
+    chainstate_path: &str,
+    chainstate_marf_opts: Option<MARFOpenOpts>,
+) -> Result<(), Error> {
+    if !check_chainstate_db_versions(epochs, sortdb_path, chainstate_path)? {
+        warn!("Unable to migrate chainstate DBs to the latest schemas in the current epoch");
+        return Err(DBError::TooOldForEpoch.into());
+    }
+
+    if fs::metadata(&sortdb_path).is_ok() {
+        info!("Migrating sortition DB to the latest schema version");
+        SortitionDB::migrate_if_exists(&sortdb_path, epochs)?;
+    }
+    if fs::metadata(&chainstate_path).is_ok() {
+        info!("Migrating chainstate DB to the latest schema version");
+        let db_config = StacksChainState::get_db_config_from_path(&chainstate_path)?;
+
+        // this does the migration internally
+        let _ = StacksChainState::open(
+            db_config.mainnet,
+            db_config.chain_id,
+            chainstate_path,
+            chainstate_marf_opts,
+        )?;
+    }
+    Ok(())
 }

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -1927,7 +1927,7 @@ impl PeerNetwork {
         }
 
         for (event_id, convo) in self.peers.iter() {
-            if convo.is_authenticated() {
+            if convo.is_authenticated() && convo.stats.last_contact_time > 0 {
                 // have handshaked with this remote peer
                 if convo.stats.last_contact_time
                     + (convo.peer_heartbeat as u64)

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -106,6 +106,10 @@ pub enum Error {
     IOError(IOError),
     /// MARF index error
     IndexError(MARFError),
+    /// Old schema error
+    OldSchema(u64),
+    /// Database is too old for epoch
+    TooOldForEpoch,
     /// Other error
     Other(String),
 }
@@ -127,6 +131,10 @@ impl fmt::Display for Error {
             Error::IOError(ref e) => fmt::Display::fmt(e, f),
             Error::SqliteError(ref e) => fmt::Display::fmt(e, f),
             Error::IndexError(ref e) => fmt::Display::fmt(e, f),
+            Error::OldSchema(ref s) => write!(f, "Old database schema: {}", s),
+            Error::TooOldForEpoch => {
+                write!(f, "Database is not compatible with current system epoch")
+            }
             Error::Other(ref s) => fmt::Display::fmt(s, f),
         }
     }
@@ -149,6 +157,8 @@ impl error::Error for Error {
             Error::SqliteError(ref e) => Some(e),
             Error::IOError(ref e) => Some(e),
             Error::IndexError(ref e) => Some(e),
+            Error::OldSchema(ref _s) => None,
+            Error::TooOldForEpoch => None,
             Error::Other(ref _s) => None,
         }
     }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1319,6 +1319,8 @@ impl StacksNode {
             // bootstrap nodes *always* allowed
             let mut tx = peerdb.tx_begin().unwrap();
             for initial_neighbor in initial_neighbors.iter() {
+                // update peer in case public key changed
+                PeerDB::update_peer(&mut tx, &initial_neighbor).unwrap();
                 PeerDB::set_allow_peer(
                     &mut tx,
                     initial_neighbor.addr.network_id,


### PR DESCRIPTION
This PR fixes a couple of boot-up issues related to schema migrations and always-allowed peers when booting a 2.05.0.2.0-rc1 peer.  In particular:

* This PR fixes a runtime panic that arises when booting from genesis due to the unavailability of the first block snapshot.

* This PR fixes a runtime panic that arises when booting from non-migrated chainstate due to needing the first block snapshot before attempting migrations to the latest schemas.

* This PR makes it so that the public key of an always-allowed peer is reset from the config file on each boot-up.

* This PR makes it so that an always-allowed peer is only considered to have timed out if it has replied to a previous message first (this is specific to always-allowed peers since they are always considered authenticated, which precludes relying on checking whether or not the public key is known to determine if a peer has been contacted).