### PR TITLE
Feat/bitcoin wire format rigidity

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -72,6 +72,9 @@ jobs:
           - tests::epoch_205::test_cost_limit_switch_version205
           - tests::epoch_205::test_exact_block_costs
           - tests::epoch_205::bigger_microblock_streams_in_2_05
+          - tests::epoch_21::transition_fixes_utxo_chaining
+          - tests::epoch_21::transition_adds_burn_block_height
+          - tests::epoch_21::transition_fixes_bitcoin_rigidity
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -103,6 +103,12 @@ impl FromRow<SortitionId> for SortitionId {
     }
 }
 
+impl FromRow<BurnchainHeaderHash> for BurnchainHeaderHash {
+    fn from_row<'a>(row: &'a Row) -> Result<BurnchainHeaderHash, db_error> {
+        BurnchainHeaderHash::from_column(row, "burn_header_hash")
+    }
+}
+
 impl FromRow<MissedBlockCommit> for MissedBlockCommit {
     fn from_row<'a>(row: &'a Row) -> Result<MissedBlockCommit, db_error> {
         let intended_sortition = SortitionId::from_column(row, "intended_sortition_id")?;
@@ -613,7 +619,7 @@ const SORTITION_DB_SCHEMA_3: &'static [&'static str] = &[r#"
     );"#];
 
 // update this to add new indexes
-const LAST_SORTITION_DB_INDEX: &'static str = "index_parent_sortition_id";
+const LAST_SORTITION_DB_INDEX: &'static str = "index_parent_burn_header_hash";
 
 const SORTITION_DB_INDEXES: &'static [&'static str] = &[
     "CREATE INDEX IF NOT EXISTS snapshots_block_hashes ON snapshots(block_height,index_root,winning_stacks_block_hash);",
@@ -634,6 +640,8 @@ const SORTITION_DB_INDEXES: &'static [&'static str] = &[
     "CREATE INDEX IF NOT EXISTS index_missed_commits_intended_sortition_id ON missed_commits(intended_sortition_id);",
     "CREATE INDEX IF NOT EXISTS canonical_stacks_blocks ON canonical_accepted_stacks_blocks(tip_consensus_hash,stacks_block_hash);",
     "CREATE INDEX IF NOT EXISTS index_parent_sortition_id ON block_commit_parents(parent_sortition_id);",
+    "CREATE INDEX IF NOT EXISTS index_burn_header_hash ON snapshots(burn_header_hash);",
+    "CREATE INDEX IF NOT EXISTS index_parent_burn_header_hash ON snapshots(parent_burn_header_hash,burn_header_hash);",
 ];
 
 pub struct SortitionDB {
@@ -3162,6 +3170,9 @@ impl SortitionDB {
         }
     }
 
+    /// Get the list of Stack-STX operations processed in a given burnchain block.
+    /// This will be the same list in each PoX fork; it's up to the Stacks block-processing logic
+    /// to reject them.
     pub fn get_stack_stx_ops(
         conn: &Connection,
         burn_header_hash: &BurnchainHeaderHash,
@@ -3173,6 +3184,9 @@ impl SortitionDB {
         )
     }
 
+    /// Get the list of Transfer-STX operations processed in a given burnchain block.
+    /// This will be the same list in each PoX fork; it's up to the Stacks block-processing logic
+    /// to reject them.
     pub fn get_transfer_stx_ops(
         conn: &Connection,
         burn_header_hash: &BurnchainHeaderHash,
@@ -3182,6 +3196,68 @@ impl SortitionDB {
             "SELECT * FROM transfer_stx WHERE burn_header_hash = ?",
             &[burn_header_hash],
         )
+    }
+
+    /// Get the parent burnchain header hash of a given burnchain header hash
+    fn get_parent_burnchain_header_hash(
+        conn: &Connection,
+        burnchain_header_hash: &BurnchainHeaderHash,
+    ) -> Result<Option<BurnchainHeaderHash>, db_error> {
+        let sql = "SELECT parent_burn_header_hash AS burn_header_hash FROM snapshots WHERE burn_header_hash = ?1";
+        let args: &[&dyn ToSql] = &[burnchain_header_hash];
+        let mut rows = query_rows::<BurnchainHeaderHash, _>(conn, sql, args)?;
+
+        // there can be more than one if there was a PoX reorg.  If so, make sure they're _all the
+        // same_ (otherwise we have corruption and must panic)
+        if let Some(bhh) = rows.pop() {
+            for row in rows.into_iter() {
+                if row != bhh {
+                    panic!(
+                        "FATAL: burnchain header hash {} has two parents: {} and {}",
+                        burnchain_header_hash, &bhh, &row
+                    );
+                }
+            }
+            Ok(Some(bhh))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get the last N ancestor burnchain header hashes, given a burnchain header hash.
+    /// This is done without regards to PoX forks.
+    ///
+    /// The returned list will be formatted as follows:
+    ///
+    /// * burn_header_hash
+    /// * 1st ancestor of burn_header_hash
+    /// * 2nd ancestor of burn_header_hash
+    /// ...
+    /// * Nth ancestor of burn_header_hash
+    ///
+    /// That is, the resulting list will have up to N+1 items.
+    ///
+    /// If an ancestor is not found, then return early.
+    /// The returned list always starts with `burn_header_hash`.
+    pub fn get_ancestor_burnchain_header_hashes(
+        conn: &Connection,
+        burn_header_hash: &BurnchainHeaderHash,
+        count: u64,
+    ) -> Result<Vec<BurnchainHeaderHash>, db_error> {
+        let mut ret = vec![burn_header_hash.clone()];
+        for _i in 0..count {
+            let parent_bhh = match SortitionDB::get_parent_burnchain_header_hash(
+                conn,
+                ret.last().expect("FATAL: empty burn header hash list"),
+            )? {
+                Some(bhh) => bhh,
+                None => {
+                    break;
+                }
+            };
+            ret.push(parent_bhh);
+        }
+        Ok(ret)
     }
 
     pub fn index_handle_at_tip<'a>(&'a self) -> SortitionHandleConn<'a> {
@@ -3925,6 +4001,11 @@ impl<'a> SortitionHandleTx<'a> {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub fn mock_insert_stack_stx(&mut self, op: &StackStxOp) -> Result<(), db_error> {
+        self.insert_stack_stx(op)
+    }
+
     /// Insert a transfer-stx op
     fn insert_transfer_stx(&mut self, op: &TransferStxOp) -> Result<(), db_error> {
         let args: &[&dyn ToSql] = &[
@@ -3941,6 +4022,11 @@ impl<'a> SortitionHandleTx<'a> {
         self.execute("REPLACE INTO transfer_stx (txid, vtxindex, block_height, burn_header_hash, sender_addr, recipient_addr, transfered_ustx, memo) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)", args)?;
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn mock_insert_transfer_stx(&mut self, op: &TransferStxOp) -> Result<(), db_error> {
+        self.insert_transfer_stx(op)
     }
 
     /// Insert a leader block commitment.
@@ -8023,5 +8109,77 @@ pub mod tests {
                 db_tx.commit().unwrap();
             }
         }
+    }
+
+    #[test]
+    fn test_get_ancestor_burnchain_header_hashes() {
+        let block_height = 100;
+        let first_burn_hash = BurnchainHeaderHash([0x00; 32]);
+        let mut db = SortitionDB::connect_test(block_height, &first_burn_hash).unwrap();
+        for i in 1..11 {
+            test_append_snapshot(&mut db, BurnchainHeaderHash([i as u8; 32]), &vec![]);
+        }
+
+        // typical
+        let ancestors = SortitionDB::get_ancestor_burnchain_header_hashes(
+            db.conn(),
+            &BurnchainHeaderHash([0x09; 32]),
+            6,
+        )
+        .unwrap();
+        assert_eq!(
+            ancestors,
+            vec![
+                BurnchainHeaderHash([0x09; 32]),
+                BurnchainHeaderHash([0x08; 32]),
+                BurnchainHeaderHash([0x07; 32]),
+                BurnchainHeaderHash([0x06; 32]),
+                BurnchainHeaderHash([0x05; 32]),
+                BurnchainHeaderHash([0x04; 32]),
+                BurnchainHeaderHash([0x03; 32])
+            ]
+        );
+
+        // edge case -- get too many
+        let ancestors = SortitionDB::get_ancestor_burnchain_header_hashes(
+            db.conn(),
+            &BurnchainHeaderHash([0x09; 32]),
+            20,
+        )
+        .unwrap();
+        assert_eq!(
+            ancestors,
+            vec![
+                BurnchainHeaderHash([0x09; 32]),
+                BurnchainHeaderHash([0x08; 32]),
+                BurnchainHeaderHash([0x07; 32]),
+                BurnchainHeaderHash([0x06; 32]),
+                BurnchainHeaderHash([0x05; 32]),
+                BurnchainHeaderHash([0x04; 32]),
+                BurnchainHeaderHash([0x03; 32]),
+                BurnchainHeaderHash([0x02; 32]),
+                BurnchainHeaderHash([0x01; 32]),
+                BurnchainHeaderHash([0x00; 32]),
+                BurnchainHeaderHash([0xff; 32]),
+            ]
+        );
+
+        // edge case -- get none
+        let ancestors = SortitionDB::get_ancestor_burnchain_header_hashes(
+            db.conn(),
+            &BurnchainHeaderHash([0x09; 32]),
+            0,
+        )
+        .unwrap();
+        assert_eq!(ancestors, vec![BurnchainHeaderHash([0x09; 32])]);
+
+        // edge case -- get one that doesn't exist
+        let ancestors = SortitionDB::get_ancestor_burnchain_header_hashes(
+            db.conn(),
+            &BurnchainHeaderHash([0xfe; 32]),
+            0,
+        )
+        .unwrap();
+        assert_eq!(ancestors, vec![BurnchainHeaderHash([0xfe; 32])]);
     }
 }

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -931,6 +931,8 @@ mod test {
             &ExecutionCost::zero(),
             123,
             false,
+            vec![],
+            vec![],
         )
         .unwrap();
         tx.commit().unwrap();

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -171,6 +171,8 @@ pub struct SetupBlockResult<'a, 'b> {
         Option<(MinerReward, Vec<MinerReward>, MinerReward, MinerRewardInfo)>,
     pub evaluated_epoch: StacksEpochId,
     pub applied_epoch_transition: bool,
+    pub burn_stack_stx_ops: Vec<StackStxOp>,
+    pub burn_transfer_stx_ops: Vec<TransferStxOp>,
 }
 
 pub struct DummyEventDispatcher;
@@ -4041,15 +4043,15 @@ impl StacksChainState {
         block: &StacksBlock,
         microblocks: &Vec<StacksMicroblock>,
     ) -> Result<(), Error> {
-        let parent_sn = {
-            let db_handle = sort_ic.as_handle(&snapshot.sortition_id);
-            let sn = match db_handle.get_block_snapshot(&snapshot.parent_burn_header_hash)? {
-                Some(sn) => sn,
-                None => {
-                    return Err(Error::NoSuchBlockError);
-                }
-            };
-            sn
+        let parent_sn = match SortitionDB::get_block_snapshot_for_winning_stacks_block(
+            sort_ic,
+            &snapshot.sortition_id,
+            &block.header.parent_block,
+        )? {
+            Some(sn) => sn,
+            None => {
+                return Err(Error::NoSuchBlockError);
+            }
         };
 
         self.preprocess_anchored_block(
@@ -4599,6 +4601,8 @@ impl StacksChainState {
                                    "txid" => %txid,
                                    "burn_block" => %burn_header_hash,
                                    "contract_call_ecode" => %resp.data);
+                        } else {
+                            debug!("Processed StackStx burn op for {} uSTX for {} cycles starting at {} from {} to pay out to {}", stacked_ustx, num_cycles, block_height, &sender, &reward_addr);
                         }
                         let mut execution_cost = clarity_tx.cost_so_far();
                         execution_cost
@@ -4667,17 +4671,23 @@ impl StacksChainState {
                             )
                         });
                         match result {
-                            Ok((value, _, events)) => Some(StacksTransactionReceipt {
-                                transaction: TransactionOrigin::Burn(txid),
-                                events,
-                                result: value,
-                                post_condition_aborted: false,
-                                stx_burned: 0,
-                                contract_analysis: None,
-                                execution_cost: ExecutionCost::zero(),
-                                microblock_header: None,
-                                tx_index: 0,
-                            }),
+                            Ok((value, _, events)) => {
+                                debug!(
+                                    "Processed TransferStx {} uSTX from {} to {}",
+                                    transfered_ustx, &sender, &recipient
+                                );
+                                Some(StacksTransactionReceipt {
+                                    transaction: TransactionOrigin::Burn(txid),
+                                    events,
+                                    result: value,
+                                    post_condition_aborted: false,
+                                    stx_burned: 0,
+                                    contract_analysis: None,
+                                    execution_cost: ExecutionCost::zero(),
+                                    microblock_header: None,
+                                    tx_index: 0,
+                                })
+                            }
                             Err(e) => {
                                 info!("TransferStx burn op processing error.";
                               "error" => ?e,
@@ -4859,6 +4869,135 @@ impl StacksChainState {
         Ok(parent_miner)
     }
 
+    fn get_stacking_and_transfer_burn_ops_v205(
+        sortdb_conn: &Connection,
+        burn_tip: &BurnchainHeaderHash,
+    ) -> Result<(Vec<StackStxOp>, Vec<TransferStxOp>), Error> {
+        let stacking_burn_ops = SortitionDB::get_stack_stx_ops(sortdb_conn, burn_tip)?;
+        let transfer_burn_ops = SortitionDB::get_transfer_stx_ops(sortdb_conn, burn_tip)?;
+        Ok((stacking_burn_ops, transfer_burn_ops))
+    }
+
+    fn get_stacking_and_transfer_burn_ops_v210<'b>(
+        chainstate_tx: &'b mut ChainstateTx,
+        parent_index_hash: &StacksBlockId,
+        sortdb_conn: &Connection,
+        burn_tip: &BurnchainHeaderHash,
+        burn_tip_height: u64,
+        epoch_start_height: u64,
+    ) -> Result<(Vec<StackStxOp>, Vec<TransferStxOp>), Error> {
+        // only consider transactions in Stacks 2.1
+        let search_window: u8 =
+            if epoch_start_height + (BURNCHAIN_TX_SEARCH_WINDOW as u64) > burn_tip_height {
+                burn_tip_height
+                    .saturating_sub(epoch_start_height)
+                    .try_into()
+                    .expect("FATAL: search window exceeds u8")
+            } else {
+                BURNCHAIN_TX_SEARCH_WINDOW
+            };
+
+        debug!(
+            "Search the last {} sortitions for burnchain-hosted stacks operations before {} ({})",
+            search_window, burn_tip, burn_tip_height
+        );
+        let ancestor_burnchain_header_hashes = SortitionDB::get_ancestor_burnchain_header_hashes(
+            sortdb_conn,
+            burn_tip,
+            search_window.into(),
+        )?;
+        let processed_burnchain_txids = StacksChainState::get_burnchain_txids_in_ancestors(
+            chainstate_tx.deref().deref(),
+            parent_index_hash,
+            search_window.into(),
+        )?;
+
+        // Find the *new* transactions -- the ones that we *haven't* seen in this Stacks
+        // fork yet.  Note that we search for the ones that we have seen by searching back
+        // `BURNCHAIN_TX_SEARCH_WINDOW` *Stacks* blocks, whose sortitions may span more
+        // than `BURNCHAIN_TX_SEARCH_WINDOW` burnchain blocks.  The inclusion of txids for
+        // burnchain transactions in the latter query is not a problem, because these txids
+        // are used to *exclude* transactions from the last `BURNCHAIN_TX_SEARCH_WINDOW`
+        // burnchain blocks.  These excluded txids, if they were mined outside of this
+        // window, are *already* excluded.
+
+        let mut all_stacking_burn_ops = vec![];
+        let mut all_transfer_burn_ops = vec![];
+
+        // go from oldest burn header hash to newest
+        for ancestor_bhh in ancestor_burnchain_header_hashes.iter().rev() {
+            let stacking_ops = SortitionDB::get_stack_stx_ops(sortdb_conn, ancestor_bhh)?;
+            let transfer_ops = SortitionDB::get_transfer_stx_ops(sortdb_conn, ancestor_bhh)?;
+
+            for stacking_op in stacking_ops.into_iter() {
+                if processed_burnchain_txids.contains(&stacking_op.txid) {
+                    continue;
+                }
+                all_stacking_burn_ops.push(stacking_op);
+            }
+
+            for transfer_op in transfer_ops.into_iter() {
+                if processed_burnchain_txids.contains(&transfer_op.txid) {
+                    continue;
+                }
+                all_transfer_burn_ops.push(transfer_op);
+            }
+        }
+        Ok((all_stacking_burn_ops, all_transfer_burn_ops))
+    }
+
+    /// Get the list of burnchain-hosted stacking and transfer operations to apply when evaluating
+    /// the Stacks block that was selected for this burnchain block.
+    /// The rules are different for different epochs:
+    ///
+    /// * In Stacks 2.0/2.05, only the operations in the burnchain block will be considered.
+    /// So if a transaction was mined in burnchain block N, it will be processed in the Stacks
+    /// block mined in burnchain block N (if there is one).
+    ///
+    /// * In Stacks 2.1+, the operations in the last K burnchain blocks that have not yet been
+    /// considered in this Stacks block's fork will be processed in the order in which they are
+    /// mined in the burnchain.  So if a transaction was mined in an burnchain block between N and
+    /// N-K inclusive, it will be processed in each Stacks fork that contains at least one Stacks
+    /// block mined in the same burnchain interval.
+    ///
+    /// The rationale for the new behavior in Stacks 2.1+ is that burnchain-hosted STX operations
+    /// can get picked up in Stacks blocks that only live on short-lived forks, or get mined in
+    /// burnchain blocks in which there was no sortiton.  In either case, the operation does not
+    /// materialize on the canonical Stacks chain.  This is a bad user
+    /// experience, because the act of sending a PreStxOp plus this StackStxOp / TransferStxOp is a
+    /// time-consuming and tedious process that must then be repeated.
+    ///
+    /// The change in Stacks 2.1+ makes it so that it's overwhelmingly likely to work
+    /// the first time -- the choice of K is significantly bigger than the length of short-lived
+    /// forks or periods of time with no sortition than have been observed in practice.
+    fn get_stacking_and_transfer_burn_ops<'b>(
+        chainstate_tx: &'b mut ChainstateTx,
+        parent_index_hash: &StacksBlockId,
+        sortdb_conn: &Connection,
+        burn_tip: &BurnchainHeaderHash,
+        burn_tip_height: u64,
+    ) -> Result<(Vec<StackStxOp>, Vec<TransferStxOp>), Error> {
+        let cur_epoch = SortitionDB::get_stacks_epoch(sortdb_conn, burn_tip_height)?
+            .expect("FATAL: no epoch defined for current burnchain tip height");
+
+        match cur_epoch.epoch_id {
+            StacksEpochId::Epoch10 => {
+                panic!("FATAL: processed a block in Epoch 1.0");
+            }
+            StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
+                StacksChainState::get_stacking_and_transfer_burn_ops_v205(sortdb_conn, burn_tip)
+            }
+            StacksEpochId::Epoch21 => StacksChainState::get_stacking_and_transfer_burn_ops_v210(
+                chainstate_tx,
+                parent_index_hash,
+                sortdb_conn,
+                burn_tip,
+                burn_tip_height,
+                cur_epoch.start_height,
+            ),
+        }
+    }
+
     /// Called in both follower and miner block assembly paths.
     /// Returns clarity_tx, list of receipts, microblock execution cost,
     /// microblock fees, microblock burns, list of microblock tx receipts,
@@ -4895,8 +5034,14 @@ impl StacksChainState {
             (latest_miners, parent_miner)
         };
 
-        let stacking_burn_ops = SortitionDB::get_stack_stx_ops(conn, &burn_tip)?;
-        let transfer_burn_ops = SortitionDB::get_transfer_stx_ops(conn, &burn_tip)?;
+        let (stacking_burn_ops, transfer_burn_ops) =
+            StacksChainState::get_stacking_and_transfer_burn_ops(
+                chainstate_tx,
+                &parent_index_hash,
+                conn,
+                &burn_tip,
+                burn_tip_height.into(),
+            )?;
 
         // load the execution cost of the parent block if the executor is the follower.
         // otherwise, if the executor is the miner, only load the parent cost if the parent
@@ -5011,14 +5156,14 @@ impl StacksChainState {
         let (applied_epoch_transition, mut tx_receipts) =
             StacksChainState::process_epoch_transition(&mut clarity_tx, burn_tip_height)?;
 
-        // process stacking & transfer operations from bitcoin ops
+        // process stacking & transfer operations from burnchain ops
         tx_receipts.extend(StacksChainState::process_stacking_ops(
             &mut clarity_tx,
-            stacking_burn_ops,
+            stacking_burn_ops.clone(),
         ));
         tx_receipts.extend(StacksChainState::process_transfer_ops(
             &mut clarity_tx,
-            transfer_burn_ops,
+            transfer_burn_ops.clone(),
         ));
 
         Ok(SetupBlockResult {
@@ -5031,6 +5176,8 @@ impl StacksChainState {
             matured_miner_rewards_opt,
             evaluated_epoch,
             applied_epoch_transition,
+            burn_stack_stx_ops: stacking_burn_ops,
+            burn_transfer_stx_ops: transfer_burn_ops,
         })
     }
 
@@ -5219,6 +5366,8 @@ impl StacksChainState {
             matured_miner_rewards_opt,
             evaluated_epoch,
             applied_epoch_transition,
+            burn_stack_stx_ops,
+            burn_transfer_stx_ops,
         } = StacksChainState::setup_block(
             chainstate_tx,
             clarity_instance,
@@ -5479,6 +5628,8 @@ impl StacksChainState {
             &block_execution_cost,
             block_size,
             applied_epoch_transition,
+            burn_stack_stx_ops,
+            burn_transfer_stx_ops,
         )
         .expect("FATAL: failed to advance chain tip");
 
@@ -6441,6 +6592,8 @@ pub mod test {
     use crate::cost_estimates::metrics::UnitMetric;
     use crate::cost_estimates::UnitEstimator;
     use crate::types::chainstate::{BlockHeaderHash, StacksWorkScore};
+
+    use crate::burnchains::test::Txid_from_test_data;
 
     use super::*;
 
@@ -11077,6 +11230,557 @@ pub mod test {
             .unwrap()
             .unwrap(),
             mblocks[0..2].to_vec()
+        );
+    }
+
+    fn make_transfer_op(
+        addr: &StacksAddress,
+        recipient_addr: &StacksAddress,
+        burn_height: u64,
+        tenure_id: usize,
+    ) -> TransferStxOp {
+        let transfer_op = TransferStxOp {
+            sender: addr.clone(),
+            recipient: recipient_addr.clone(),
+            transfered_ustx: ((tenure_id + 1) * 1000) as u128,
+            memo: vec![0x00, 0x01, 0x02, 0x03, 0x04, 0x05],
+
+            txid: Txid_from_test_data(
+                tenure_id as u64,
+                1,
+                &BurnchainHeaderHash([tenure_id as u8; 32]),
+                tenure_id as u64,
+            ),
+            vtxindex: (10 + tenure_id) as u32,
+            block_height: burn_height,
+            burn_header_hash: BurnchainHeaderHash([0x00; 32]),
+        };
+        transfer_op
+    }
+
+    #[test]
+    fn test_get_stacking_and_transfer_burn_ops_v210() {
+        let mut peer_config =
+            TestPeerConfig::new("test_stacking_and_transfer_burn_ops_v210", 21315, 21316);
+        let privk = StacksPrivateKey::from_hex(
+            "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
+        )
+        .unwrap();
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk)],
+        )
+        .unwrap();
+
+        let recipient_privk = StacksPrivateKey::new();
+        let recipient_addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&recipient_privk)],
+        )
+        .unwrap();
+
+        let initial_balance = 1000000000;
+        peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
+        peer_config.epochs = Some(StacksEpoch::unit_test_2_1(0));
+
+        let recv_addr =
+            StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let num_blocks = 10;
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let mut last_block_id = StacksBlockId([0x00; 32]);
+        for tenure_id in 0..num_blocks {
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            assert_eq!(
+                tip.block_height,
+                first_stacks_block_height + (tenure_id as u64)
+            );
+
+            // For the first 5 burn blocks, sortition a Stacks block.
+            // For sortitions 6 and 8, don't sortition any Stacks block.
+            // For sortitions 7 and 9, do sortition a Stacks block, and verify that it includes all
+            // burnchain STX operations that got skipped by the missing sortition.
+            let process_stacks_block = tenure_id <= 5 || tenure_id % 2 != 0;
+
+            let (mut burn_ops, stacks_block_opt, microblocks_opt) = if process_stacks_block {
+                let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+                    |ref mut miner,
+                     ref mut sortdb,
+                     ref mut chainstate,
+                     vrf_proof,
+                     ref parent_opt,
+                     ref parent_microblock_header_opt| {
+                        let parent_tip = match parent_opt {
+                            None => {
+                                StacksChainState::get_genesis_header_info(chainstate.db()).unwrap()
+                            }
+                            Some(block) => {
+                                let ic = sortdb.index_conn();
+                                let snapshot =
+                                    SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                                        &ic,
+                                        &tip.sortition_id,
+                                        &block.block_hash(),
+                                    )
+                                    .unwrap()
+                                    .unwrap(); // succeeds because we don't fork
+                                StacksChainState::get_anchored_block_header_info(
+                                    chainstate.db(),
+                                    &snapshot.consensus_hash,
+                                    &snapshot.winning_stacks_block_hash,
+                                )
+                                .unwrap()
+                                .unwrap()
+                            }
+                        };
+
+                        let mut mempool =
+                            MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+                        let coinbase_tx = make_coinbase(miner, tenure_id);
+
+                        let anchored_block = StacksBlockBuilder::build_anchored_block(
+                            chainstate,
+                            &sortdb.index_conn(),
+                            &mut mempool,
+                            &parent_tip,
+                            tip.total_burn,
+                            vrf_proof,
+                            Hash160([tenure_id as u8; 20]),
+                            &coinbase_tx,
+                            BlockBuilderSettings::max_value(),
+                            None,
+                        )
+                        .unwrap();
+
+                        (anchored_block.0, vec![])
+                    },
+                );
+                (burn_ops, Some(stacks_block), Some(microblocks))
+            } else {
+                (vec![], None, None)
+            };
+
+            let mut expected_transfer_ops = if tenure_id == 0 || tenure_id - 1 < 5 {
+                // all contiguous blocks up to now, so only expect this block's stx-transfer
+                vec![make_transfer_op(
+                    &addr,
+                    &recipient_addr,
+                    tip.block_height + 1,
+                    tenure_id,
+                )]
+            } else if (tenure_id - 1) % 2 == 0 {
+                // no sortition in the last burn block, so only expect this block's stx-transfer
+                vec![make_transfer_op(
+                    &addr,
+                    &recipient_addr,
+                    tip.block_height + 1,
+                    tenure_id,
+                )]
+            } else {
+                // last sortition had no block, so expect both the previous block's
+                // stx-transfer *and* this block's stx-transfer
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            };
+
+            // add one stx-transfer burn op per block
+            let mut stx_burn_ops = vec![BlockstackOperationType::TransferStx(make_transfer_op(
+                &addr,
+                &recipient_addr,
+                tip.block_height + 1,
+                tenure_id,
+            ))];
+            burn_ops.append(&mut stx_burn_ops);
+
+            let (_, burn_header_hash, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+
+            match (stacks_block_opt, microblocks_opt) {
+                (Some(stacks_block), Some(microblocks)) => {
+                    peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+                    last_block_id = StacksBlockHeader::make_index_block_hash(
+                        &consensus_hash,
+                        &stacks_block.block_hash(),
+                    );
+                }
+                _ => {}
+            }
+
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            let sortdb = peer.sortdb.take().unwrap();
+            {
+                let chainstate = peer.chainstate();
+                let (mut chainstate_tx, clarity_instance) =
+                    chainstate.chainstate_tx_begin().unwrap();
+                let (stack_stx_ops, transfer_stx_ops) =
+                    StacksChainState::get_stacking_and_transfer_burn_ops_v210(
+                        &mut chainstate_tx,
+                        &last_block_id,
+                        sortdb.conn(),
+                        &tip.burn_header_hash,
+                        tip.block_height,
+                        0
+                    )
+                    .unwrap();
+
+                assert_eq!(transfer_stx_ops.len(), expected_transfer_ops.len());
+
+                // burn header hash will be different, since it's set post-processing.
+                // everything else must be the same though.
+                for i in 0..expected_transfer_ops.len() {
+                    expected_transfer_ops[i].burn_header_hash =
+                        transfer_stx_ops[i].burn_header_hash.clone();
+                }
+
+                assert_eq!(transfer_stx_ops, expected_transfer_ops);
+            }
+            peer.sortdb.replace(sortdb);
+        }
+
+        // all burnchain transactions mined, even if there was no sortition in the burn block in
+        // which they were mined.
+        let sortdb = peer.sortdb.take().unwrap();
+
+        // definitely missing some blocks -- there are empty sortitions
+        let stacks_tip = peer
+            .chainstate()
+            .get_stacks_chain_tip(&sortdb)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stacks_tip.height, 8);
+
+        // but we did process all burnchain operations
+        let (consensus_hash, block_bhh) =
+            SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
+        let tip_hash = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
+        let account = peer
+            .chainstate()
+            .with_read_only_clarity_tx(&sortdb.index_conn(), &tip_hash, |conn| {
+                StacksChainState::get_account(conn, &addr.to_account_principal())
+            })
+            .unwrap();
+        peer.sortdb.replace(sortdb);
+
+        assert_eq!(
+            account.stx_balance.get_total_balance(),
+            1000000000 - (1000 + 2000 + 3000 + 4000 + 5000 + 6000 + 7000 + 8000 + 9000)
+        );
+    }
+
+    #[test]
+    fn test_get_stacking_and_transfer_burn_ops_v210_expiration() {
+        let mut peer_config = TestPeerConfig::new(
+            "test_stacking_and_transfer_burn_ops_v210_expiration",
+            21317,
+            21318,
+        );
+        let privk = StacksPrivateKey::from_hex(
+            "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
+        )
+        .unwrap();
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk)],
+        )
+        .unwrap();
+
+        let recipient_privk = StacksPrivateKey::new();
+        let recipient_addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&recipient_privk)],
+        )
+        .unwrap();
+
+        let initial_balance = 1000000000;
+        peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
+        peer_config.epochs = Some(StacksEpoch::unit_test_2_1(0));
+
+        let recv_addr =
+            StacksAddress::from_string("ST1H1B54MY50RMBRRKS7GV2ZWG79RZ1RQ1ETW4E01").unwrap();
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let num_blocks = 20;
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let mut last_block_id = StacksBlockId([0x00; 32]);
+        for tenure_id in 0..num_blocks {
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            assert_eq!(
+                tip.block_height,
+                first_stacks_block_height + (tenure_id as u64)
+            );
+
+            // For the first 5 burn blocks, sortition a Stacks block.
+            let process_stacks_block = tenure_id <= 5 || tenure_id >= 13;
+
+            let (mut burn_ops, stacks_block_opt, microblocks_opt) = if process_stacks_block {
+                let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+                    |ref mut miner,
+                     ref mut sortdb,
+                     ref mut chainstate,
+                     vrf_proof,
+                     ref parent_opt,
+                     ref parent_microblock_header_opt| {
+                        let parent_tip = match parent_opt {
+                            None => {
+                                StacksChainState::get_genesis_header_info(chainstate.db()).unwrap()
+                            }
+                            Some(block) => {
+                                let ic = sortdb.index_conn();
+                                let snapshot =
+                                    SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                                        &ic,
+                                        &tip.sortition_id,
+                                        &block.block_hash(),
+                                    )
+                                    .unwrap()
+                                    .unwrap(); // succeeds because we don't fork
+                                StacksChainState::get_anchored_block_header_info(
+                                    chainstate.db(),
+                                    &snapshot.consensus_hash,
+                                    &snapshot.winning_stacks_block_hash,
+                                )
+                                .unwrap()
+                                .unwrap()
+                            }
+                        };
+
+                        let mut mempool =
+                            MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+                        let coinbase_tx = make_coinbase(miner, tenure_id);
+
+                        let anchored_block = StacksBlockBuilder::build_anchored_block(
+                            chainstate,
+                            &sortdb.index_conn(),
+                            &mut mempool,
+                            &parent_tip,
+                            tip.total_burn,
+                            vrf_proof,
+                            Hash160([tenure_id as u8; 20]),
+                            &coinbase_tx,
+                            BlockBuilderSettings::max_value(),
+                            None,
+                        )
+                        .unwrap();
+
+                        (anchored_block.0, vec![])
+                    },
+                );
+                (burn_ops, Some(stacks_block), Some(microblocks))
+            } else {
+                (vec![], None, None)
+            };
+
+            let mut expected_transfer_ops = if tenure_id == 0 || tenure_id - 1 < 5 {
+                // all contiguous blocks up to now, so only expect this block's stx-transfer
+                vec![make_transfer_op(
+                    &addr,
+                    &recipient_addr,
+                    tip.block_height + 1,
+                    tenure_id,
+                )]
+            } else if tenure_id - 1 == 5 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else if tenure_id - 1 == 6 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 1, tenure_id - 2),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else if tenure_id - 1 == 7 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 2, tenure_id - 3),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 1, tenure_id - 2),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else if tenure_id - 1 == 8 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 3, tenure_id - 4),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 2, tenure_id - 3),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 1, tenure_id - 2),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else if tenure_id - 1 == 9 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 4, tenure_id - 5),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 3, tenure_id - 4),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 2, tenure_id - 3),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 1, tenure_id - 2),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else if tenure_id - 1 == 10 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 5, tenure_id - 6),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 4, tenure_id - 5),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 3, tenure_id - 4),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 2, tenure_id - 3),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 1, tenure_id - 2),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else if tenure_id - 1 == 11 {
+                vec![
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 5, tenure_id - 6),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 4, tenure_id - 5),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 3, tenure_id - 4),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 2, tenure_id - 3),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height - 1, tenure_id - 2),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height, tenure_id - 1),
+                    make_transfer_op(&addr, &recipient_addr, tip.block_height + 1, tenure_id),
+                ]
+            } else {
+                vec![make_transfer_op(
+                    &addr,
+                    &recipient_addr,
+                    tip.block_height + 1,
+                    tenure_id,
+                )]
+            };
+
+            // add one stx-transfer burn op per block
+            let mut stx_burn_ops = vec![BlockstackOperationType::TransferStx(make_transfer_op(
+                &addr,
+                &recipient_addr,
+                tip.block_height + 1,
+                tenure_id,
+            ))];
+            burn_ops.append(&mut stx_burn_ops);
+
+            let (_, burn_header_hash, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+
+            match (stacks_block_opt, microblocks_opt) {
+                (Some(stacks_block), Some(microblocks)) => {
+                    peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+                    last_block_id = StacksBlockHeader::make_index_block_hash(
+                        &consensus_hash,
+                        &stacks_block.block_hash(),
+                    );
+                }
+                _ => {}
+            }
+
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            let sortdb = peer.sortdb.take().unwrap();
+            {
+                let chainstate = peer.chainstate();
+                let (mut chainstate_tx, clarity_instance) =
+                    chainstate.chainstate_tx_begin().unwrap();
+                let (stack_stx_ops, transfer_stx_ops) =
+                    StacksChainState::get_stacking_and_transfer_burn_ops_v210(
+                        &mut chainstate_tx,
+                        &last_block_id,
+                        sortdb.conn(),
+                        &tip.burn_header_hash,
+                        tip.block_height,
+                        0
+                    )
+                    .unwrap();
+
+                assert_eq!(transfer_stx_ops.len(), expected_transfer_ops.len());
+
+                // burn header hash will be different, since it's set post-processing.
+                // everything else must be the same though.
+                for i in 0..expected_transfer_ops.len() {
+                    expected_transfer_ops[i].burn_header_hash =
+                        transfer_stx_ops[i].burn_header_hash.clone();
+                }
+
+                assert_eq!(transfer_stx_ops, expected_transfer_ops);
+            }
+            peer.sortdb.replace(sortdb);
+        }
+
+        // all burnchain transactions mined, even if there was no sortition in the burn block in
+        // which they were mined.
+        let sortdb = peer.sortdb.take().unwrap();
+
+        // definitely missing some blocks -- there are empty sortitions
+        let stacks_tip = peer
+            .chainstate()
+            .get_stacks_chain_tip(&sortdb)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stacks_tip.height, 13);
+
+        // but we did process all burnchain operations
+        let (consensus_hash, block_bhh) =
+            SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
+        let tip_hash = StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
+        let account = peer
+            .chainstate()
+            .with_read_only_clarity_tx(&sortdb.index_conn(), &tip_hash, |conn| {
+                StacksChainState::get_account(conn, &addr.to_account_principal())
+            })
+            .unwrap();
+        peer.sortdb.replace(sortdb);
+
+        // skipped tenure 6's TransferSTX
+        assert_eq!(
+            account.stx_balance.get_total_balance(),
+            1000000000
+                - (1000
+                    + 2000
+                    + 3000
+                    + 4000
+                    + 5000
+                    + 7000
+                    + 8000
+                    + 9000
+                    + 10000
+                    + 11000
+                    + 12000
+                    + 13000
+                    + 14000
+                    + 15000
+                    + 16000
+                    + 17000
+                    + 18000
+                    + 19000)
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -66,6 +66,9 @@ pub const NETWORK_P2P_PORT: u16 = 6265;
 // its current block-commit in a sortition
 pub const MINING_COMMITMENT_WINDOW: u8 = 6;
 
+// Number of previous burnchain blocks to search to find burnchain-hosted Stacks operations
+pub const BURNCHAIN_TX_SEARCH_WINDOW: u8 = 6;
+
 // This controls a miner heuristic for dropping a transaction from repeated consideration
 //  in the mempool. If the transaction caused the block limit to be reached when the block
 //  was previously `TX_BLOCK_LIMIT_PROPORTION_HEURISTIC`% full, the transaction will be dropped

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -727,7 +727,7 @@ fn most_recent_utxo_integration_test() {
     channel.stop_chains_coordinator();
 }
 
-fn get_balance<F: std::fmt::Display>(http_origin: &str, account: &F) -> u128 {
+pub fn get_balance<F: std::fmt::Display>(http_origin: &str, account: &F) -> u128 {
     get_account(http_origin, account).balance
 }
 


### PR DESCRIPTION
This PR addresses #2094 by making it so that when we process a Stacks block, we search the 6 prior burnchain blocks for unprocessed `TransferStx` and `StackStx` transactions and try to apply them in this block.  This tracking is handled by mapping each Stacks block's index block hash to the list of burnchain transaction IDs it handled.  Then, to process a new Stacks block, we simply do the following:

1.  find all burnchain operations in the past 6 burnchain blocks
2.  find all burnchain operations processed in the past 6 Stacks blocks (which covers _at least_ 6 burnchain blocks in the past)
3.  remove all burnchain operations in (2) from the list in (1)
4.  process the remaining operations from (3) in blockchain order
