### PR TITLE
feat/remove-pox-sunset

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -115,7 +115,6 @@ impl BurnchainStateTransition {
         parent_snapshot: &BlockSnapshot,
         block_ops: &Vec<BlockstackOperationType>,
         missed_commits: &Vec<MissedBlockCommit>,
-        sunset_end: u64,
     ) -> Result<BurnchainStateTransition, burnchain_error> {
         // block commits and support burns discovered in this block.
         let mut block_commits: Vec<LeaderBlockCommitOp> = vec![];
@@ -167,9 +166,7 @@ impl BurnchainStateTransition {
         let mut windowed_block_commits = vec![block_commits];
         let mut windowed_missed_commits = vec![];
 
-        if !burnchain.is_in_prepare_phase(parent_snapshot.block_height + 1)
-            && parent_snapshot.block_height + 1 <= burnchain.pox_constants.sunset_end
-        {
+        if !burnchain.is_in_prepare_phase(parent_snapshot.block_height + 1) {
             // PoX reward-phase is active!
             // build a map of intended sortition -> missed commit for the missed commits
             //   discovered in this block.
@@ -212,7 +209,7 @@ impl BurnchainStateTransition {
         } else {
             // PoX reward-phase is not active
             debug!(
-                "Block {} is in a prepare phase or post-PoX sunset, so no windowing will take place",
+                "Block {} is in a prepare phase, so no windowing will take place",
                 parent_snapshot.block_height + 1
             );
 
@@ -224,18 +221,14 @@ impl BurnchainStateTransition {
         windowed_block_commits.reverse();
         windowed_missed_commits.reverse();
 
-        // figure out if the PoX sunset finished during the window,
-        // and/or which sortitions must be PoB due to them falling in a prepare phase.
+        // figure out which sortitions must be PoB due to them falling in a prepare phase.
         let window_end_height = parent_snapshot.block_height + 1;
         let window_start_height = window_end_height + 1 - (windowed_block_commits.len() as u64);
         let mut burn_blocks = vec![false; windowed_block_commits.len()];
 
-        // set burn_blocks flags to accomodate prepare phases and PoX sunset
+        // set burn_blocks flags to accomodate prepare phases
         for (i, b) in burn_blocks.iter_mut().enumerate() {
-            if sunset_end <= window_start_height + (i as u64) {
-                // past PoX sunset, so must burn
-                *b = true;
-            } else if burnchain.is_in_prepare_phase(window_start_height + (i as u64)) {
+            if burnchain.is_in_prepare_phase(window_start_height + (i as u64)) {
                 // must burn
                 *b = true;
             } else {
@@ -460,40 +453,6 @@ impl Burnchain {
 
     pub fn is_mainnet(&self) -> bool {
         self.network_id == NETWORK_ID_MAINNET
-    }
-
-    /// the expected sunset burn is:
-    ///   total_commit * (progress through sunset phase) / (sunset phase duration)
-    pub fn expected_sunset_burn(&self, burn_height: u64, total_commit: u64) -> u64 {
-        if burn_height < self.pox_constants.sunset_start
-            || burn_height >= self.pox_constants.sunset_end
-        {
-            return 0;
-        }
-
-        // no sunset burn needed in prepare phase -- it's already getting burnt
-        if self.is_in_prepare_phase(burn_height) {
-            return 0;
-        }
-
-        let reward_cycle_height = self.reward_cycle_to_block_height(
-            self.block_height_to_reward_cycle(burn_height)
-                .expect("BUG: Sunset start is less than first_block_height"),
-        );
-
-        if reward_cycle_height <= self.pox_constants.sunset_start {
-            return 0;
-        }
-
-        let sunset_duration =
-            (self.pox_constants.sunset_end - self.pox_constants.sunset_start) as u128;
-        let sunset_progress = (reward_cycle_height - self.pox_constants.sunset_start) as u128;
-
-        // use u128 to avoid any possibilities of overflowing in the calculation here.
-        let expected_u128 = (total_commit as u128) * (sunset_progress) / sunset_duration;
-        u64::try_from(expected_u128)
-            // should never be possible, because sunset_burn is <= total_commit, which is a u64
-            .expect("Overflowed u64 in calculating expected sunset_burn")
     }
 
     pub fn is_reward_cycle_start(&self, burn_height: u64) -> bool {
@@ -743,20 +702,18 @@ impl Burnchain {
                     }
                 }
             }
-            x if x == Opcodes::PreStx as u8 => {
-                match PreStxOp::from_tx(block_header, burn_tx, burnchain.pox_constants.sunset_end) {
-                    Ok(op) => Some(BlockstackOperationType::PreStx(op)),
-                    Err(e) => {
-                        warn!(
-                            "Failed to parse pre stack stx tx";
-                            "txid" => %burn_tx.txid(),
-                            "data" => %to_hex(&burn_tx.data()),
-                            "error" => ?e,
-                        );
-                        None
-                    }
+            x if x == Opcodes::PreStx as u8 => match PreStxOp::from_tx(block_header, burn_tx) {
+                Ok(op) => Some(BlockstackOperationType::PreStx(op)),
+                Err(e) => {
+                    warn!(
+                        "Failed to parse pre stack stx tx";
+                        "txid" => %burn_tx.txid(),
+                        "data" => %to_hex(&burn_tx.data()),
+                        "error" => ?e,
+                    );
+                    None
                 }
-            }
+            },
             x if x == Opcodes::TransferStx as u8 => {
                 let pre_stx_txid = TransferStxOp::get_sender_txid(burn_tx).ok()?;
                 let pre_stx_tx = match pre_stx_op_map.get(&pre_stx_txid) {
@@ -794,12 +751,7 @@ impl Burnchain {
                 };
                 if let Some(BlockstackOperationType::PreStx(pre_stack_stx)) = pre_stx_tx {
                     let sender = &pre_stack_stx.output;
-                    match StackStxOp::from_tx(
-                        block_header,
-                        burn_tx,
-                        sender,
-                        burnchain.pox_constants.sunset_end,
-                    ) {
+                    match StackStxOp::from_tx(block_header, burn_tx, sender) {
                         Ok(op) => Some(BlockstackOperationType::StackStx(op)),
                         Err(e) => {
                             warn!(
@@ -1864,7 +1816,6 @@ pub mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
@@ -1905,7 +1856,6 @@ pub mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
@@ -1946,7 +1896,6 @@ pub mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
@@ -2509,7 +2458,6 @@ pub mod tests {
             // insert block commit paired to previous round's leader key, as well as a user burn
             if i > 0 {
                 let next_block_commit = LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     commit_outs: vec![],
                     block_header_hash: BlockHeaderHash::from_bytes(&vec![
                         i, i, i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/burnchains/db.rs
+++ b/src/burnchains/db.rs
@@ -430,8 +430,6 @@ mod tests {
 
         let mut burnchain = Burnchain::regtest(":memory:");
         burnchain.pox_constants = PoxConstants::test_default();
-        burnchain.pox_constants.sunset_start = 999;
-        burnchain.pox_constants.sunset_end = 1000;
 
         let first_block_header = burnchain_db.get_canonical_chain_tip().unwrap();
         assert_eq!(&first_block_header.block_hash, &first_bhh);
@@ -542,8 +540,6 @@ mod tests {
 
         let mut burnchain = Burnchain::regtest(":memory:");
         burnchain.pox_constants = PoxConstants::test_default();
-        burnchain.pox_constants.sunset_start = 999;
-        burnchain.pox_constants.sunset_end = 1000;
 
         let first_block_header = burnchain_db.get_canonical_chain_tip().unwrap();
         assert_eq!(&first_block_header.block_hash, &first_bhh);

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -301,10 +301,6 @@ pub struct PoxConstants {
     /// percentage of liquid STX that must participate for PoX
     ///  to occur
     pub pox_participation_threshold_pct: u64,
-    /// last+1 block height of sunset phase
-    pub sunset_end: u64,
-    /// first block height of sunset phase
-    pub sunset_start: u64,
     /// The auto unlock height for PoX v1 lockups before transition to PoX v2. This
     /// also defines the burn height at which PoX reward sets are calculated using
     /// PoX v2 rather than v1
@@ -319,13 +315,10 @@ impl PoxConstants {
         anchor_threshold: u32,
         pox_rejection_fraction: u64,
         pox_participation_threshold_pct: u64,
-        sunset_start: u64,
-        sunset_end: u64,
         v1_unlock_height: u32,
     ) -> PoxConstants {
         assert!(anchor_threshold > (prepare_length / 2));
         assert!(prepare_length < reward_cycle_length);
-        assert!(sunset_start <= sunset_end);
 
         PoxConstants {
             reward_cycle_length,
@@ -333,8 +326,6 @@ impl PoxConstants {
             anchor_threshold,
             pox_rejection_fraction,
             pox_participation_threshold_pct,
-            sunset_start,
-            sunset_end,
             v1_unlock_height,
             _shadow: PhantomData,
         }
@@ -342,7 +333,7 @@ impl PoxConstants {
     #[cfg(test)]
     pub fn test_default() -> PoxConstants {
         // 20 reward slots; 10 prepare-phase slots
-        PoxConstants::new(10, 5, 3, 25, 5, 5000, 10000, u32::max_value())
+        PoxConstants::new(10, 5, 3, 25, 5, u32::max_value())
     }
 
     /// Returns the PoX contract that is "active" at the given burn block height
@@ -375,8 +366,6 @@ impl PoxConstants {
             80,
             25,
             5,
-            BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,
-            BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_END,
             POX_V1_MAINNET_EARLY_UNLOCK_HEIGHT,
         )
     }
@@ -388,23 +377,12 @@ impl PoxConstants {
             40,
             12,
             2,
-            BITCOIN_TESTNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,
-            BITCOIN_TESTNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_END,
             POX_V1_TESTNET_EARLY_UNLOCK_HEIGHT,
         ) // total liquid supply is 40000000000000000 µSTX
     }
 
     pub fn regtest_default() -> PoxConstants {
-        PoxConstants::new(
-            5,
-            1,
-            1,
-            3333333333333333,
-            1,
-            BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,
-            BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT + POX_SUNSET_END,
-            1_000_000,
-        )
+        PoxConstants::new(5, 1, 1, 3333333333333333, 1, 1_000_000)
     }
 }
 

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -116,7 +116,7 @@ impl<'a> SortitionHandleTx<'a> {
         let this_block_hash = block_header.block_hash.clone();
 
         // make the burn distribution, and in doing so, identify the user burns that we'll keep
-        let state_transition = BurnchainStateTransition::from_block_ops(self, burnchain, parent_snapshot, this_block_ops, missed_commits, burnchain.pox_constants.sunset_end)
+        let state_transition = BurnchainStateTransition::from_block_ops(self, burnchain, parent_snapshot, this_block_ops, missed_commits)
             .map_err(|e| {
                 error!("TRANSACTION ABORTED when converting {} blockstack operations in block {} ({}) to a burn distribution: {:?}", this_block_ops.len(), this_block_height, &this_block_hash, e);
                 e
@@ -412,7 +412,6 @@ mod tests {
         };
 
         let block_commit = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed::from_hex(
                 "3333333333333333333333333333333333333333333333333333333333333333",

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -243,7 +243,6 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
         let burn_fee_str: String = row.get_unwrap("burn_fee");
         let input_json: String = row.get_unwrap("input");
         let apparent_sender_json: String = row.get_unwrap("apparent_sender");
-        let sunset_burn_str: String = row.get_unwrap("sunset_burn");
 
         let commit_outs = serde_json::from_value(row.get_unwrap("commit_outs"))
             .expect("Unparseable value stored to database");
@@ -260,11 +259,7 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
 
         let burn_fee = burn_fee_str
             .parse::<u64>()
-            .expect("DB Corruption: Sunset burn is not parseable as u64");
-
-        let sunset_burn = sunset_burn_str
-            .parse::<u64>()
-            .expect("DB Corruption: Sunset burn is not parseable as u64");
+            .expect("DB Corruption: burn is not parseable as u64");
 
         let burn_parent_modulus: u8 = row.get_unwrap("burn_parent_modulus");
 
@@ -282,7 +277,6 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
             input,
             apparent_sender,
             commit_outs,
-            sunset_burn,
             txid,
             vtxindex,
             block_height,
@@ -516,7 +510,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         memo TEXT,
         commit_outs TEXT,
         burn_fee TEXT NOT NULL,     -- use text to encode really big numbers
-        sunset_burn TEXT NOT NULL,     -- use text to encode really big numbers
+        sunset_burn TEXT NOT NULL,     -- use text to encode really big numbers (OBSOLETE; IGNORED)
         input TEXT NOT NULL,
         apparent_sender TEXT NOT NULL,
         burn_parent_modulus INTEGER NOT NULL,
@@ -2939,16 +2933,12 @@ impl SortitionDB {
             .sortition_hash
             .mix_burn_header(&parent_snapshot.burn_header_hash);
 
-        let reward_set_info = if burn_header.block_height >= burnchain.pox_constants.sunset_end {
-            None
-        } else {
-            sortition_db_handle.pick_recipients(
-                burnchain,
-                burn_header.block_height,
-                &reward_set_vrf_hash,
-                next_pox_info.as_ref(),
-            )?
-        };
+        let reward_set_info = sortition_db_handle.pick_recipients(
+            burnchain,
+            burn_header.block_height,
+            &reward_set_vrf_hash,
+            next_pox_info.as_ref(),
+        )?;
 
         // Get any initial mining bonus which would be due to the winner of this block.
         let bonus_remaining =
@@ -3007,16 +2997,13 @@ impl SortitionDB {
 
         let mut sortition_db_handle =
             SortitionHandleTx::begin(self, &parent_snapshot.sortition_id)?;
-        if parent_snapshot.block_height + 1 >= burnchain.pox_constants.sunset_end {
-            Ok(None)
-        } else {
-            sortition_db_handle.pick_recipients(
-                burnchain,
-                parent_snapshot.block_height + 1,
-                &reward_set_vrf_hash,
-                next_pox_info,
-            )
-        }
+
+        sortition_db_handle.pick_recipients(
+            burnchain,
+            parent_snapshot.block_height + 1,
+            &reward_set_vrf_hash,
+            next_pox_info,
+        )
     }
 
     pub fn is_stacks_block_in_sortition_set(
@@ -3992,7 +3979,7 @@ impl<'a> SortitionHandleTx<'a> {
             &tx_input_str,
             sort_id,
             &serde_json::to_value(&block_commit.commit_outs).unwrap(),
-            &block_commit.sunset_burn.to_string(),
+            &0i64,
             &apparent_sender_str,
             &block_commit.burn_parent_modulus,
         ];
@@ -4720,7 +4707,6 @@ pub mod tests {
         };
 
         let block_commit = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -5542,7 +5528,6 @@ pub mod tests {
         };
 
         let block_commit = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -7670,7 +7655,6 @@ pub mod tests {
         };
 
         let genesis_block_commit = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222221")
                     .unwrap(),
@@ -7713,7 +7697,6 @@ pub mod tests {
 
         // descends from genesis
         let block_commit_1 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -7755,7 +7738,6 @@ pub mod tests {
 
         // descends from block_commit_1
         let block_commit_1_1 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
                     .unwrap(),
@@ -7797,7 +7779,6 @@ pub mod tests {
 
         // descends from genesis_block_commit
         let block_commit_2 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
                     .unwrap(),

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -126,8 +126,8 @@ impl BurnSamplePoint {
     ///
     /// All operations need to be supplied in an ordered Vec of Vecs containing
     ///   the ops at each block height in a mining commit window.  Normally, this window
-    ///   is the constant `MINING_COMMITMENT_WINDOW`, except during prepare-phases and post-PoX
-    ///   sunset.  In either of these two cases, the window is only one block.  The code does not
+    ///   is the constant `MINING_COMMITMENT_WINDOW`, except during prepare-phases.
+    ///   In this particular case, the window is only one block.  The code does not
     ///   consider which window is active; it merely deduces it by inspecting the length of the
     ///   given `block_commits` argument.
     ///
@@ -150,7 +150,7 @@ impl BurnSamplePoint {
     ///     `missed_commits.len() = block_commits.len() - 1`
     /// * `burn_blocks`: this is a vector of booleans that indicate whether or not a block-commit
     ///     occurred during a PoB-only sortition or a possibly-PoX sortition.  The former occurs
-    ///     during either a prepare phase or after PoX sunset, and must have only one (burn) output.
+    ///     during a prepare phase, and must have only one (burn) output.
     ///     The latter occurs everywhere else, and must have `OUTPUTS_PER_COMMIT` outputs after the
     ///     `OP_RETURN` payload.  The length of this vector must be equal to the length of the
     ///     `block_commits` vector.  `burn_blocks[i]` is `true` if the `ith` block-commit must be PoB.
@@ -519,7 +519,6 @@ mod tests {
             input: (input_txid, 3),
             apparent_sender: BurnchainSigner::new_p2pkh(&StacksPublicKey::new()),
             commit_outs: vec![],
-            sunset_burn: 0,
             txid,
             vtxindex: 0,
             block_height: block_ht,
@@ -530,111 +529,6 @@ mod tests {
             },
             burn_header_hash: BurnchainHeaderHash([0; 32]),
         }
-    }
-
-    #[test]
-    fn make_mean_min_median_sunset_in_window() {
-        //    miner 1:  3 4 5 4 5 4
-        //       ub  :  1 0 0 0 0 0
-        //                    | sunset end
-        //    miner 2:  1 3 3 3 3 3
-        //       ub  :  1 0 0 0 0 0
-        //              0 1 0 0 0 0
-        //                   ..
-
-        // miner 1 => min = 1, median = 1, last_burn = 4
-        // miner 2 => min = 1, median = 1, last_burn = 3
-
-        let mut commits = vec![
-            vec![
-                make_block_commit(3, 1, 1, 1, None, 1),
-                make_block_commit(1, 2, 2, 2, None, 1),
-            ],
-            vec![
-                make_block_commit(4, 3, 3, 3, Some(1), 2),
-                make_block_commit(3, 4, 4, 4, Some(2), 2),
-            ],
-            vec![
-                make_block_commit(5, 5, 5, 5, Some(3), 3),
-                make_block_commit(3, 6, 6, 6, Some(4), 3),
-            ],
-            vec![
-                make_block_commit(4, 7, 7, 7, Some(5), 4),
-                make_block_commit(3, 8, 8, 8, Some(6), 4),
-            ],
-            vec![
-                make_block_commit(5, 9, 9, 9, Some(7), 5),
-                make_block_commit(3, 10, 10, 10, Some(8), 5),
-            ],
-            vec![
-                make_block_commit(4, 11, 11, 11, Some(9), 6),
-                make_block_commit(3, 12, 12, 12, Some(10), 6),
-            ],
-        ];
-        let user_burns = vec![
-            vec![make_user_burn(1, 1, 1, 1, 1), make_user_burn(1, 2, 2, 2, 1)],
-            vec![make_user_burn(1, 4, 4, 4, 2)],
-            vec![make_user_burn(1, 6, 6, 6, 3)],
-            vec![make_user_burn(1, 8, 8, 8, 4)],
-            vec![make_user_burn(1, 10, 10, 10, 5)],
-            vec![make_user_burn(1, 12, 12, 12, 6)],
-        ];
-
-        let mut result = BurnSamplePoint::make_min_median_distribution(
-            commits.clone(),
-            vec![vec![]; (MINING_COMMITMENT_WINDOW - 1) as usize],
-            vec![false, false, false, true, true, true],
-        );
-
-        assert_eq!(result.len(), 2, "Should be two miners");
-
-        result.sort_by_key(|sample| sample.candidate.txid);
-
-        // block-commits are currently malformed -- the post-sunset commits spend the wrong UTXO.
-        assert_eq!(result[0].burns, 1);
-        assert_eq!(result[1].burns, 1);
-
-        // make sure that we're associating with the last commit in the window.
-        assert_eq!(result[0].candidate.txid, commits[5][0].txid);
-        assert_eq!(result[1].candidate.txid, commits[5][1].txid);
-
-        assert_eq!(result[0].user_burns.len(), 0);
-        assert_eq!(result[1].user_burns.len(), 0);
-
-        // now correct the back pointers so that they point
-        //   at the correct UTXO position *post-sunset*
-        for (ix, window_slice) in commits.iter_mut().enumerate() {
-            if ix >= 4 {
-                for commit in window_slice.iter_mut() {
-                    commit.input.1 = 2;
-                }
-            }
-        }
-
-        //    miner 1:  3 4 5 4 5 4
-        //    miner 2:  1 3 3 3 3 3
-        // miner 1 => min = 3, median = 4, last_burn = 4
-        // miner 2 => min = 1, median = 3, last_burn = 3
-
-        let mut result = BurnSamplePoint::make_min_median_distribution(
-            commits.clone(),
-            vec![vec![]; (MINING_COMMITMENT_WINDOW - 1) as usize],
-            vec![false, false, false, true, true, true],
-        );
-
-        assert_eq!(result.len(), 2, "Should be two miners");
-
-        result.sort_by_key(|sample| sample.candidate.txid);
-
-        assert_eq!(result[0].burns, 4);
-        assert_eq!(result[1].burns, 3);
-
-        // make sure that we're associating with the last commit in the window.
-        assert_eq!(result[0].candidate.txid, commits[5][0].txid);
-        assert_eq!(result[1].candidate.txid, commits[5][1].txid);
-
-        assert_eq!(result[0].user_burns.len(), 0);
-        assert_eq!(result[1].user_burns.len(), 0);
     }
 
     #[test]
@@ -1124,7 +1018,6 @@ mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -1169,7 +1062,6 @@ mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
                     .unwrap(),
@@ -1214,7 +1106,6 @@ mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
                     .unwrap(),

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -72,7 +72,6 @@ impl LeaderBlockCommitOp {
         apparent_sender: &BurnchainSigner,
     ) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_height: block_height,
             burn_parent_modulus: if block_height > 0 {
                 ((block_height - 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8
@@ -111,7 +110,6 @@ impl LeaderBlockCommitOp {
         apparent_sender: &BurnchainSigner,
     ) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
-            sunset_burn: 0,
             new_seed: new_seed.clone(),
             key_block_ptr: key_block_ptr,
             key_vtxindex: key_vtxindex,
@@ -146,7 +144,7 @@ impl LeaderBlockCommitOp {
 
     pub fn expected_chained_utxo(burn_only: bool) -> u32 {
         if burn_only {
-            2 // if sunset has occurred, or we're in the prepare phase, then chained commits should spend the output after the burn commit
+            2 // if we're in the prepare phase, then chained commits should spend the output after the burn commit
         } else {
             // otherwise, it's the output after the last PoX output
             (OUTPUTS_PER_COMMIT as u32) + 1
@@ -224,7 +222,6 @@ impl LeaderBlockCommitOp {
     }
 
     /// parse a LeaderBlockCommitOp
-    /// `pox_sunset_ht` is the height at which PoX *disables*
     pub fn parse_from_tx(
         burnchain: &Burnchain,
         block_height: u64,
@@ -293,28 +290,15 @@ impl LeaderBlockCommitOp {
             return Err(op_error::ParseError);
         }
 
-        // check if we've reached PoX disable
-        let (commit_outs, sunset_burn, burn_fee) = if block_height
-            >= burnchain.pox_constants.sunset_end
-        {
+        let (commit_outs, burn_fee) = if burnchain.is_in_prepare_phase(block_height) {
+            // check if we're in a prepare phase
             // should be only one burn output
             if !outputs[0].address.is_burn() {
                 return Err(op_error::BlockCommitBadOutputs);
             }
             let BurnchainRecipient { address, amount } = outputs.remove(0);
-            (vec![address], 0, amount)
-        // check if we're in a prepare phase
-        } else if burnchain.is_in_prepare_phase(block_height) {
-            // should be only one burn output
-            if !outputs[0].address.is_burn() {
-                return Err(op_error::BlockCommitBadOutputs);
-            }
-            let BurnchainRecipient { address, amount } = outputs.remove(0);
-            (vec![address], 0, amount)
+            (vec![address], amount)
         } else {
-            // check if this transaction provided a sunset burn
-            let sunset_burn = tx.get_burn_amount();
-
             let mut commit_outs = vec![];
             let mut pox_fee = None;
             for (ix, output) in outputs.into_iter().enumerate() {
@@ -351,7 +335,7 @@ impl LeaderBlockCommitOp {
                 return Err(op_error::ParseError);
             }
 
-            (commit_outs, sunset_burn, burn_fee)
+            (commit_outs, burn_fee)
         };
 
         let input = tx
@@ -374,7 +358,6 @@ impl LeaderBlockCommitOp {
             burn_parent_modulus: data.burn_parent_modulus,
 
             commit_outs,
-            sunset_burn,
             burn_fee,
             input,
             apparent_sender,
@@ -493,20 +476,6 @@ impl LeaderBlockCommitOp {
     ) -> Result<(), op_error> {
         let parent_block_height = self.parent_block_ptr as u64;
 
-        let total_committed = self
-            .burn_fee
-            .checked_add(self.sunset_burn)
-            .expect("BUG: Overflow in total committed calculation");
-        let expected_sunset_burn =
-            burnchain.expected_sunset_burn(self.block_height, total_committed);
-        if self.sunset_burn < expected_sunset_burn {
-            warn!(
-                "Invalid block commit: should have included sunset burn amount of {}, found {}",
-                expected_sunset_burn, self.sunset_burn
-            );
-            return Err(op_error::BlockCommitBadOutputs);
-        }
-
         /////////////////////////////////////////////////////////////////////////////////////
         // This tx must have the expected commit or burn outputs:
         //    * if there is a known anchor block for the current reward cycle, and this
@@ -622,18 +591,14 @@ impl LeaderBlockCommitOp {
 
     fn check_single_burn_output(&self) -> Result<(), op_error> {
         if self.commit_outs.len() != 1 {
-            warn!("Invalid post-sunset block commit, should have 1 commit out");
+            warn!("Invalid block commit, should have 1 commit out");
             return Err(op_error::BlockCommitBadOutputs);
         }
         if !self.commit_outs[0].is_burn() {
-            warn!("Invalid post-sunset block commit, should have burn address output");
+            warn!("Invalid block commit, should have burn address output");
             return Err(op_error::BlockCommitBadOutputs);
         }
         Ok(())
-    }
-
-    fn check_after_pox_sunset(&self) -> Result<(), op_error> {
-        self.check_single_burn_output()
     }
 
     fn check_prepare_commit_burn(&self) -> Result<(), op_error> {
@@ -724,20 +689,12 @@ impl LeaderBlockCommitOp {
             return Err(op_error::MissedBlockCommit(missed_data));
         }
 
-        if self.block_height >= burnchain.pox_constants.sunset_end {
-            self.check_after_pox_sunset().map_err(|e| {
-                warn!("Invalid block-commit: bad PoX after sunset: {:?}", &e;
-                          "apparent_sender" => %apparent_sender_address);
+        self.check_pox(burnchain, tx, reward_set_info)
+            .map_err(|e| {
+                warn!("Invalid block-commit: bad PoX: {:?}", &e;
+                      "apparent_sender" => %apparent_sender_address);
                 e
             })?;
-        } else {
-            self.check_pox(burnchain, tx, reward_set_info)
-                .map_err(|e| {
-                    warn!("Invalid block-commit: bad PoX: {:?}", &e;
-                          "apparent_sender" => %apparent_sender_address);
-                    e
-                })?;
-        }
 
         /////////////////////////////////////////////////////////////////////////////////////
         // This tx must occur after the start of the network
@@ -939,123 +896,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_sunset_end() {
-        let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
-            data_amt: 0,
-            txid: Txid([0; 32]),
-            vtxindex: 0,
-            opcode: Opcodes::LeaderBlockCommit as u8,
-            data: vec![1; 80],
-            inputs: vec![BitcoinTxInput {
-                keys: vec![],
-                num_required: 0,
-                in_type: BitcoinInputType::Standard,
-                tx_ref: (Txid([0; 32]), 0),
-            }],
-            outputs: vec![
-                BitcoinTxOutput {
-                    units: 10,
-                    address: BitcoinAddress {
-                        addrtype: BitcoinAddressType::PublicKeyHash,
-                        network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([1; 20]),
-                    },
-                },
-                BitcoinTxOutput {
-                    units: 10,
-                    address: BitcoinAddress {
-                        addrtype: BitcoinAddressType::PublicKeyHash,
-                        network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([2; 20]),
-                    },
-                },
-                BitcoinTxOutput {
-                    units: 30,
-                    address: BitcoinAddress {
-                        addrtype: BitcoinAddressType::PublicKeyHash,
-                        network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([0; 20]),
-                    },
-                },
-            ],
-        });
-
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843021;
-        burnchain.pox_constants.sunset_end = 16843022;
-
-        let err = LeaderBlockCommitOp::parse_from_tx(
-            &burnchain,
-            16843022,
-            &BurnchainHeaderHash([0; 32]),
-            &tx,
-        )
-        .unwrap_err();
-
-        assert!(if let op_error::BlockCommitBadOutputs = err {
-            true
-        } else {
-            false
-        });
-
-        let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
-            data_amt: 0,
-            txid: Txid([0; 32]),
-            vtxindex: 0,
-            opcode: Opcodes::LeaderBlockCommit as u8,
-            data: vec![1; 80],
-            inputs: vec![BitcoinTxInput {
-                keys: vec![],
-                num_required: 0,
-                in_type: BitcoinInputType::Standard,
-                tx_ref: (Txid([0; 32]), 0),
-            }],
-            outputs: vec![
-                BitcoinTxOutput {
-                    units: 10,
-                    address: BitcoinAddress {
-                        addrtype: BitcoinAddressType::PublicKeyHash,
-                        network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([0; 20]),
-                    },
-                },
-                BitcoinTxOutput {
-                    units: 10,
-                    address: BitcoinAddress {
-                        addrtype: BitcoinAddressType::PublicKeyHash,
-                        network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([2; 20]),
-                    },
-                },
-                BitcoinTxOutput {
-                    units: 30,
-                    address: BitcoinAddress {
-                        addrtype: BitcoinAddressType::PublicKeyHash,
-                        network_id: BitcoinNetworkType::Mainnet,
-                        bytes: Hash160([0; 20]),
-                    },
-                },
-            ],
-        });
-
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843021;
-        burnchain.pox_constants.sunset_end = 16843022;
-
-        let op = LeaderBlockCommitOp::parse_from_tx(
-            &burnchain,
-            16843022,
-            &BurnchainHeaderHash([0; 32]),
-            &tx,
-        )
-        .unwrap();
-
-        assert_eq!(op.commit_outs.len(), 1);
-        assert!(op.commit_outs[0].is_burn());
-        assert_eq!(op.burn_fee, 10);
-    }
-
-    #[test]
     fn test_parse_pox_commits() {
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
             data_amt: 30,
@@ -1097,9 +937,7 @@ mod tests {
             ],
         });
 
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843019;
-        burnchain.pox_constants.sunset_end = 16843020;
+        let burnchain = Burnchain::regtest("nope");
 
         let op = LeaderBlockCommitOp::parse_from_tx(
             &burnchain,
@@ -1112,8 +950,6 @@ mod tests {
         // should have 2 commit outputs, summing to 20 burned units
         assert_eq!(op.commit_outs.len(), 2);
         assert_eq!(op.burn_fee, 20);
-        // the third output, because it's a burn, should have counted as a sunset_burn
-        assert_eq!(op.sunset_burn, 30);
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
             data_amt: 0,
@@ -1147,9 +983,7 @@ mod tests {
             ],
         });
 
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843019;
-        burnchain.pox_constants.sunset_end = 16843020;
+        let burnchain = Burnchain::regtest("nope");
 
         // burn amount should have been 10, not 9
         match LeaderBlockCommitOp::parse_from_tx(
@@ -1220,9 +1054,7 @@ mod tests {
             ],
         });
 
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843019;
-        burnchain.pox_constants.sunset_end = 16843020;
+        let burnchain = Burnchain::regtest("nope");
 
         let op = LeaderBlockCommitOp::parse_from_tx(
             &burnchain,
@@ -1235,8 +1067,6 @@ mod tests {
         // should have 2 commit outputs
         assert_eq!(op.commit_outs.len(), 2);
         assert_eq!(op.burn_fee, 26);
-        // the third output, because it's not a burn, should not have counted as a sunset_burn
-        assert_eq!(op.sunset_burn, 0);
 
         let tx = BurnchainTransaction::Bitcoin(BitcoinTransaction {
             data_amt: 0,
@@ -1260,9 +1090,7 @@ mod tests {
             }],
         });
 
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843019;
-        burnchain.pox_constants.sunset_end = 16843020;
+        let burnchain = Burnchain::regtest("nope");
 
         // not enough PoX outputs
         match LeaderBlockCommitOp::parse_from_tx(
@@ -1309,9 +1137,7 @@ mod tests {
             ],
         });
 
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843019;
-        burnchain.pox_constants.sunset_end = 16843020;
+        let burnchain = Burnchain::regtest("nope");
 
         // unequal PoX outputs
         match LeaderBlockCommitOp::parse_from_tx(
@@ -1382,9 +1208,7 @@ mod tests {
             ],
         });
 
-        let mut burnchain = Burnchain::regtest("nope");
-        burnchain.pox_constants.sunset_start = 16843019;
-        burnchain.pox_constants.sunset_end = 16843020;
+        let burnchain = Burnchain::regtest("nope");
 
         // 0 total burn
         match LeaderBlockCommitOp::parse_from_tx(
@@ -1415,7 +1239,6 @@ mod tests {
                 txstr: "01000000011111111111111111111111111111111111111111111111111111111111111111000000006b483045022100eba8c0a57c1eb71cdfba0874de63cf37b3aace1e56dcbd61701548194a79af34022041dd191256f3f8a45562e5d60956bb871421ba69db605716250554b23b08277b012102d8015134d9db8178ac93acbc43170a2f20febba5087a5b0437058765ad5133d000000000040000000000000000536a4c5069645b22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333404142435051606162637071fa39300000000000001976a914000000000000000000000000000000000000000088ac39300000000000001976a914000000000000000000000000000000000000000088aca05b0000000000001976a9140be3e286a15ea85882761618e366586b5574100d88ac00000000".into(),
                 opstr: "69645b22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333404142435051606162637071fa".to_string(),
                 result: Some(LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(&hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap()).unwrap(),
                     new_seed: VRFSeed::from_bytes(&hex_bytes("3333333333333333333333333333333333333333333333333333333333333333").unwrap()).unwrap(),
                     parent_block_ptr: 0x40414243,
@@ -1501,9 +1324,7 @@ mod tests {
             let burnchain_tx =
                 BurnchainTransaction::Bitcoin(parser.parse_tx(&tx, vtxindex as usize).unwrap());
 
-            let mut burnchain = Burnchain::regtest("nope");
-            burnchain.pox_constants.sunset_start = block_height;
-            burnchain.pox_constants.sunset_end = block_height + 1;
+            let burnchain = Burnchain::regtest("nope");
 
             let op = LeaderBlockCommitOp::from_tx(&burnchain, &header, &burnchain_tx);
 
@@ -1573,7 +1394,7 @@ mod tests {
         ];
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, u32::max_value()),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -1647,7 +1468,6 @@ mod tests {
 
         // consumes leader_key_1
         let block_commit_1 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -1798,7 +1618,6 @@ mod tests {
             CheckFixture {
                 // accept -- consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -1848,7 +1667,6 @@ mod tests {
             CheckFixture {
                 // accept -- builds directly off of genesis block and consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -1898,7 +1716,6 @@ mod tests {
             CheckFixture {
                 // accept -- also consumes leader_key_1
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -1948,7 +1765,6 @@ mod tests {
             CheckFixture {
                 // reject -- bad burn parent modulus
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2010,7 +1826,6 @@ mod tests {
             CheckFixture {
                 // reject -- bad burn parent modulus
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2130,7 +1945,7 @@ mod tests {
         ];
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, u32::max_value()),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -2204,7 +2019,6 @@ mod tests {
 
         // consumes leader_key_1
         let block_commit_1 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -2352,7 +2166,6 @@ mod tests {
             CheckFixture {
                 // reject -- predates start block
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2402,7 +2215,6 @@ mod tests {
             CheckFixture {
                 // reject -- no such leader key
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2452,7 +2264,6 @@ mod tests {
             CheckFixture {
                 // reject -- previous block must exist
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2502,7 +2313,6 @@ mod tests {
             CheckFixture {
                 // reject -- previous block must exist in a different block
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2552,7 +2362,6 @@ mod tests {
             CheckFixture {
                 // reject -- tx input does not match any leader keys
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2602,7 +2411,6 @@ mod tests {
             CheckFixture {
                 // reject -- fee is 0
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2652,7 +2460,6 @@ mod tests {
             CheckFixture {
                 // accept -- consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2702,7 +2509,6 @@ mod tests {
             CheckFixture {
                 // accept -- builds directly off of genesis block and consumes leader_key_2
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2752,7 +2558,6 @@ mod tests {
             CheckFixture {
                 // accept -- also consumes leader_key_1
                 op: LeaderBlockCommitOp {
-                    sunset_burn: 0,
                     block_header_hash: BlockHeaderHash::from_bytes(
                         &hex_bytes(
                             "2222222222222222222222222222222222222222222222222222222222222222",
@@ -2831,7 +2636,7 @@ mod tests {
         .unwrap();
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, u32::max_value()),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -2905,7 +2710,6 @@ mod tests {
         };
 
         let block_commit_pre_2_05 = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x02; 32]),
             new_seed: VRFSeed([0x03; 32]),
             parent_block_ptr: 0,
@@ -2934,7 +2738,6 @@ mod tests {
         };
 
         let block_commit_post_2_05_valid = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x03; 32]),
             new_seed: VRFSeed([0x04; 32]),
             parent_block_ptr: 0,
@@ -2963,7 +2766,6 @@ mod tests {
         };
 
         let block_commit_post_2_05_valid_bigger_epoch = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x03; 32]),
             new_seed: VRFSeed([0x04; 32]),
             parent_block_ptr: 0,
@@ -2992,7 +2794,6 @@ mod tests {
         };
 
         let block_commit_post_2_05_invalid_bad_memo = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x04; 32]),
             new_seed: VRFSeed([0x05; 32]),
             parent_block_ptr: 0,
@@ -3021,7 +2822,6 @@ mod tests {
         };
 
         let block_commit_post_2_05_invalid_no_memo = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x05; 32]),
             new_seed: VRFSeed([0x06; 32]),
             parent_block_ptr: 0,

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -230,8 +230,6 @@ pub struct LeaderBlockCommitOp {
 
     /// PoX/Burn outputs
     pub commit_outs: Vec<StacksAddress>,
-    /// how much sunset burn this block performed
-    pub sunset_burn: u64,
 
     // common to all transactions
     pub txid: Txid,                            // transaction ID

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -443,12 +443,6 @@ pub fn get_reward_cycle_info<U: RewardSetProvider>(
     provider: &U,
 ) -> Result<Option<RewardCycleInfo>, Error> {
     if burnchain.is_reward_cycle_start(burn_height) {
-        if burn_height >= burnchain.pox_constants.sunset_end {
-            return Ok(Some(RewardCycleInfo {
-                anchor_status: PoxAnchorBlockStatus::NotSelected,
-            }));
-        }
-
         debug!("Beginning reward cycle";
               "burn_height" => burn_height,
               "reward_cycle_length" => burnchain.pox_constants.reward_cycle_length,

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1320,7 +1320,6 @@ mod test {
         };
 
         let mut block_commit = LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash: header.block_hash(),
             new_seed: VRFSeed::from_proof(&header.proof),
             parent_block_ptr: 0,

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -515,7 +515,7 @@ pub mod test {
 
     #[test]
     fn get_reward_threshold_units() {
-        let test_pox_constants = PoxConstants::new(501, 1, 1, 1, 5, 5000, 10000, u32::max_value());
+        let test_pox_constants = PoxConstants::new(501, 1, 1, 1, 5, u32::max_value());
         // when the liquid amount = the threshold step,
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3086,16 +3086,7 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants = PoxConstants::new(
-            5,
-            3,
-            3,
-            25,
-            5,
-            u64::max_value(),
-            u64::max_value(),
-            u32::max_value(),
-        );
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u32::max_value());
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -3113,16 +3104,7 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants = PoxConstants::new(
-            5,
-            3,
-            3,
-            25,
-            5,
-            u64::max_value(),
-            u64::max_value(),
-            u32::max_value(),
-        );
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u32::max_value());
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2412,16 +2412,7 @@ pub mod test {
                 .unwrap(),
             );
 
-            burnchain.pox_constants = PoxConstants::new(
-                5,
-                3,
-                3,
-                25,
-                5,
-                u64::max_value(),
-                u64::max_value(),
-                u32::max_value(),
-            );
+            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u32::max_value());
 
             let mut spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -96,7 +96,6 @@ impl OngoingBlockCommit {
 
 #[derive(Clone)]
 struct LeaderBlockCommitFees {
-    sunset_fee: u64,
     fee_rate: u64,
     sortition_fee: u64,
     outputs_len: u64,
@@ -124,12 +123,6 @@ impl LeaderBlockCommitFees {
         payload: &LeaderBlockCommitOp,
         config: &Config,
     ) -> LeaderBlockCommitFees {
-        let sunset_fee = if payload.sunset_burn > 0 {
-            cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT)
-        } else {
-            0
-        };
-
         let number_of_transfers = payload.commit_outs.len() as u64;
         let value_per_transfer = payload.burn_fee / number_of_transfers;
         let sortition_fee = value_per_transfer * number_of_transfers;
@@ -138,7 +131,6 @@ impl LeaderBlockCommitFees {
         let default_tx_size = config.burnchain.block_commit_tx_estimated_size;
 
         LeaderBlockCommitFees {
-            sunset_fee,
             fee_rate,
             sortition_fee,
             outputs_len: number_of_transfers,
@@ -162,14 +154,11 @@ impl LeaderBlockCommitFees {
     }
 
     pub fn estimated_amount_required(&self) -> u64 {
-        self.estimated_miner_fee() + self.rbf_fee() + self.sunset_fee + self.sortition_fee
+        self.estimated_miner_fee() + self.rbf_fee() + self.sortition_fee
     }
 
     pub fn total_spent(&self) -> u64 {
-        self.fee_rate * self.final_size
-            + self.spent_in_attempts
-            + self.sunset_fee
-            + self.sortition_fee
+        self.fee_rate * self.final_size + self.spent_in_attempts + self.sortition_fee
     }
 
     pub fn amount_per_output(&self) -> u64 {
@@ -177,7 +166,7 @@ impl LeaderBlockCommitFees {
     }
 
     pub fn total_spent_in_outputs(&self) -> u64 {
-        self.sunset_fee + self.sortition_fee
+        self.sortition_fee
     }
 
     pub fn min_tx_size(&self) -> u64 {
@@ -971,7 +960,7 @@ impl BitcoinRegtestController {
         };
 
         let consensus_output = TxOut {
-            value: estimated_fees.sunset_fee,
+            value: 0,
             script_pubkey: Builder::new()
                 .push_opcode(opcodes::All::OP_RETURN)
                 .push_slice(&op_bytes)

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -184,7 +184,6 @@ impl BurnchainController for MocknetController {
                 }
                 BlockstackOperationType::LeaderBlockCommit(payload) => {
                     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-                        sunset_burn: 0,
                         block_header_hash: payload.block_header_hash,
                         new_seed: payload.new_seed,
                         parent_block_ptr: payload.parent_block_ptr,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -1045,19 +1045,16 @@ impl Node {
         };
 
         let burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
-        let commit_outs = if burnchain_tip.block_snapshot.block_height + 1
-            < burnchain.pox_constants.sunset_end
-            && !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1)
-        {
-            RewardSetInfo::into_commit_outs(None, self.config.is_mainnet())
-        } else {
-            vec![StacksAddress::burn_address(self.config.is_mainnet())]
-        };
+        let commit_outs =
+            if !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1) {
+                RewardSetInfo::into_commit_outs(None, self.config.is_mainnet())
+            } else {
+                vec![StacksAddress::burn_address(self.config.is_mainnet())]
+            };
         let burn_parent_modulus =
             (burnchain_tip.block_snapshot.block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
 
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-            sunset_burn: 0,
             block_header_hash,
             burn_fee,
             input: (Txid([0; 32]), 0),

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -587,13 +587,8 @@ fn transition_empty_blocks() {
 
         if tip_info.burn_block_height + 1 >= epoch_2_05 {
             let burn_fee_cap = 100000000; // 1 BTC
-            let sunset_burn =
-                burnchain.expected_sunset_burn(tip_info.burn_block_height + 1, burn_fee_cap);
-            let rest_commit = burn_fee_cap - sunset_burn;
 
-            let commit_outs = if tip_info.burn_block_height + 1 < burnchain.pox_constants.sunset_end
-                && !burnchain.is_in_prepare_phase(tip_info.burn_block_height + 1)
-            {
+            let commit_outs = if !burnchain.is_in_prepare_phase(tip_info.burn_block_height + 1) {
                 vec![
                     StacksAddress::burn_address(conf.is_mainnet()),
                     StacksAddress::burn_address(conf.is_mainnet()),
@@ -606,9 +601,8 @@ fn transition_empty_blocks() {
             let burn_parent_modulus =
                 (tip_info.burn_block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
-                sunset_burn,
                 block_header_hash: BlockHeaderHash([0xff; 32]),
-                burn_fee: rest_commit,
+                burn_fee: burn_fee_cap,
                 input: (Txid([0; 32]), 0),
                 apparent_sender: keychain.get_burnchain_signer(),
                 key_block_ptr,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -74,8 +74,6 @@ fn advance_to_2_1(
         4 * prepare_phase_len / 5,
         5,
         15,
-        (16 * reward_cycle_len - 1).into(),
-        (17 * reward_cycle_len).into(),
         u32::max_value(),
     );
     burnchain_config.pox_constants = pox_constants.clone();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -4829,8 +4829,6 @@ fn pox_integration_test() {
         4 * prepare_phase_len / 5,
         5,
         15,
-        (16 * reward_cycle_len - 1).into(),
-        (17 * reward_cycle_len).into(),
         u32::max_value(),
     );
     burnchain_config.pox_constants = pox_constants.clone();
@@ -5123,7 +5121,6 @@ fn pox_integration_test() {
     // let's test the reward information in the observer
     test_observer::clear();
 
-    // before sunset
     // mine until the end of the next reward cycle,
     //   the participation threshold now should be met.
     while sort_height < ((16 * pox_constants.reward_cycle_length) - 1).into() {
@@ -5211,53 +5208,6 @@ fn pox_integration_test() {
 
     eprintln!("Stacks tip is now {}", tip_info.stacks_tip_height);
     assert_eq!(tip_info.stacks_tip_height, 36);
-
-    // now let's mine into the sunset
-    while sort_height < ((17 * pox_constants.reward_cycle_length) - 1).into() {
-        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
-        sort_height = channel.get_sortitions_processed();
-        eprintln!("Sort height: {}", sort_height);
-    }
-
-    // get the canonical chain tip
-    let tip_info = get_chain_info(&conf);
-
-    eprintln!("Stacks tip is now {}", tip_info.stacks_tip_height);
-    assert_eq!(tip_info.stacks_tip_height, 51);
-
-    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
-
-    // should receive more rewards during this cycle...
-    eprintln!("Got UTXOs: {}", utxos.len());
-    assert_eq!(
-        utxos.len(),
-        14,
-        "Should have received more outputs during the sunsetting PoX reward cycle"
-    );
-
-    // and after sunset
-    while sort_height < ((18 * pox_constants.reward_cycle_length) - 1).into() {
-        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
-        sort_height = channel.get_sortitions_processed();
-        eprintln!("Sort height: {}", sort_height);
-    }
-
-    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
-
-    // should *not* receive more rewards during the after sunset cycle...
-    eprintln!("Got UTXOs: {}", utxos.len());
-    assert_eq!(
-        utxos.len(),
-        14,
-        "Should have received no more outputs after sunset PoX reward cycle"
-    );
-
-    // should have progressed the chain, though!
-    // get the canonical chain tip
-    let tip_info = get_chain_info(&conf);
-
-    eprintln!("Stacks tip is now {}", tip_info.stacks_tip_height);
-    assert_eq!(tip_info.stacks_tip_height, 66);
 
     test_observer::clear();
     channel.stop_chains_coordinator();


### PR DESCRIPTION
This PR partially fixes #2613 by removing the PoX sunset altogether.  It does not attempt to gate the PoX sunset code.  If we can merge `next` to `master` before Bitcoin block 766050 (which is in just over 200 days), then no gating will be needed, since the sunset code will never be reached.

This PR does not address capping discount mining, which is the other part of #2613.  I'll work on that as a branch off of this branch. I'm just trying to get this fix into `next` ASAP.