### PR TITLE
fix: add logging for some tx outcomes that were missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ## [2.05.0.2.0]
 
+- Updates to the logging of transaction events (#3139).
+
 ### IMPORTANT! READ THIS FIRST
 
 Please read the following **WARNINGs** in their entirety before upgrading.

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -890,11 +890,12 @@ impl<'a> StacksMicroblockBuilder<'a> {
                                 "Microblock miner deadline exceeded ({} ms)",
                                 self.settings.max_miner_time_ms
                             );
-                            return Ok(false);
+                            return Ok(None);
                         }
 
                         if considered.contains(&mempool_tx.tx.txid()) {
-                            return Ok(true);
+                            return Ok(Some(TransactionResult::skipped(
+                                &mempool_tx.tx, "Transaction already considered.".to_string()).convert_to_event()));
                         } else {
                             considered.insert(mempool_tx.tx.txid());
                         }
@@ -907,6 +908,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                             &block_limit_hit,
                         ) {
                             Ok(tx_result) => {
+                        let result_event = tx_result.convert_to_event();
                                 tx_events.push(tx_result.convert_to_event());
                                 match tx_result {
                                     TransactionResult::Success(TransactionSuccess {
@@ -937,7 +939,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                                         num_txs += 1;
                                         num_added += 1;
                                         num_selected += 1;
-                                        Ok(true)
+                                        Ok(Some(result_event))
                                     }
                                     TransactionResult::Skipped(TransactionSkipped {
                                         error,
@@ -963,7 +965,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                                                     debug!("Block budget exceeded while mining microblock"; 
                                                         "tx" => %mempool_tx.tx.txid(), "next_behavior" => "Stop mining microblock");
                                                     block_limit_hit = BlockLimitFunction::LIMIT_REACHED;
-                                                    return Ok(false);
+                                                    return Ok(None);
                                                 }
                                             }
                                             Error::TransactionTooBigError => {
@@ -971,7 +973,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                                             }
                                             _ => {}
                                         }
-                                        return Ok(true)
+                                        return Ok(Some(result_event))
                                     }
                                 }
                             }
@@ -1995,28 +1997,49 @@ impl StacksBlockBuilder {
                         let update_estimator = to_consider.update_estimate;
 
                         if block_limit_hit == BlockLimitFunction::LIMIT_REACHED {
-                            return Ok(false);
+                            return Ok(None);
                         }
                         if get_epoch_time_ms() >= deadline {
                             debug!("Miner mining time exceeded ({} ms)", max_miner_time_ms);
-                            return Ok(false);
+                            return Ok(None);
                         }
 
                         // skip transactions early if we can
                         if considered.contains(&txinfo.tx.txid()) {
-                            return Ok(true);
+                            return Ok(Some(
+                                TransactionResult::skipped(
+                                    &txinfo.tx,
+                                    "Transaction already considered.".to_string(),
+                                )
+                                .convert_to_event(),
+                            ));
                         }
 
                         if let Some(nonce) = mined_origin_nonces.get(&txinfo.tx.origin_address()) {
                             if *nonce >= txinfo.tx.get_origin_nonce() {
-                                return Ok(true);
+                                let message = format!(
+                                    "Bad origin nonce, tx nonce {} versus {}.",
+                                    txinfo.tx.get_origin_nonce(),
+                                    *nonce
+                                );
+                                return Ok(Some(
+                                    TransactionResult::skipped(&txinfo.tx, message)
+                                        .convert_to_event(),
+                                ));
                             }
                         }
                         if let Some(sponsor_addr) = txinfo.tx.sponsor_address() {
                             if let Some(nonce) = mined_sponsor_nonces.get(&sponsor_addr) {
                                 if let Some(sponsor_nonce) = txinfo.tx.get_sponsor_nonce() {
                                     if *nonce >= sponsor_nonce {
-                                        return Ok(true);
+                                        let message = format!(
+                                            "Bad sponsor nonce, tx nonce {} versus {}.",
+                                            sponsor_nonce, *nonce
+                                        );
+                                        return Ok(Some(
+                                            TransactionResult::skipped(&txinfo.tx, message)
+                                                .convert_to_event(),
+                                        ));
                                     }
                                 }
                             }
@@ -2033,6 +2056,7 @@ impl StacksBlockBuilder {
                         );
                         tx_events.push(tx_result.convert_to_event());
 
+                        let result_event = tx_result.convert_to_event();
                         match tx_result {
                             TransactionResult::Success(TransactionSuccess { receipt, .. }) => {
                                 num_txs += 1;
@@ -2079,7 +2103,7 @@ impl StacksBlockBuilder {
                                                 "Stop mining anchored block due to limit exceeded"
                                             );
                                             block_limit_hit = BlockLimitFunction::LIMIT_REACHED;
-                                            return Ok(false);
+                                            return Ok(Some(result_event));
                                         }
                                     }
                                     Error::TransactionTooBigError => {
@@ -2090,13 +2114,13 @@ impl StacksBlockBuilder {
                                     }
                                     e => {
                                         warn!("Failed to apply tx {}: {:?}", &txinfo.tx.txid(), &e);
-                                        return Ok(true);
+                                        return Ok(Some(result_event));
                                     }
                                 }
                             }
                         }
 
-                        Ok(true)
+                        Ok(Some(result_event))
                     },
                 );
 

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -879,6 +879,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                 let mut num_added = 0;
                 intermediate_result = mem_pool.iterate_candidates(
                     &mut clarity_tx,
+                    &mut tx_events,
                     self.anchor_block_height,
                     mempool_settings.clone(),
                     |clarity_tx, to_consider, estimator| {
@@ -908,8 +909,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                             &block_limit_hit,
                         ) {
                             Ok(tx_result) => {
-                        let result_event = tx_result.convert_to_event();
-                                tx_events.push(tx_result.convert_to_event());
+                                let result_event = tx_result.convert_to_event();
                                 match tx_result {
                                     TransactionResult::Success(TransactionSuccess {
                                         receipt,
@@ -1990,6 +1990,7 @@ impl StacksBlockBuilder {
                 let mut num_considered = 0;
                 intermediate_result = mempool.iterate_candidates(
                     &mut epoch_tx,
+                    &mut tx_events,
                     tip_height,
                     mempool_settings.clone(),
                     |epoch_tx, to_consider, estimator| {
@@ -2054,7 +2055,6 @@ impl StacksBlockBuilder {
                             txinfo.metadata.len,
                             &block_limit_hit,
                         );
-                        tx_events.push(tx_result.convert_to_event());
 
                         let result_event = tx_result.convert_to_event();
                         match tx_result {

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -2018,14 +2018,16 @@ impl StacksBlockBuilder {
 
                         if let Some(nonce) = mined_origin_nonces.get(&txinfo.tx.origin_address()) {
                             if *nonce >= txinfo.tx.get_origin_nonce() {
-                                let message = format!(
-                                    "Bad origin nonce, tx nonce {} versus {}.",
-                                    txinfo.tx.get_origin_nonce(),
-                                    *nonce
-                                );
                                 return Ok(Some(
-                                    TransactionResult::skipped(&txinfo.tx, message)
-                                        .convert_to_event(),
+                                    TransactionResult::skipped(
+                                        &txinfo.tx,
+                                        format!(
+                                            "Bad origin nonce, tx nonce {} versus {}.",
+                                            txinfo.tx.get_origin_nonce(),
+                                            *nonce
+                                        ),
+                                    )
+                                    .convert_to_event(),
                                 ));
                             }
                         }
@@ -2033,13 +2035,15 @@ impl StacksBlockBuilder {
                             if let Some(nonce) = mined_sponsor_nonces.get(&sponsor_addr) {
                                 if let Some(sponsor_nonce) = txinfo.tx.get_sponsor_nonce() {
                                     if *nonce >= sponsor_nonce {
-                                        let message = format!(
-                                            "Bad sponsor nonce, tx nonce {} versus {}.",
-                                            sponsor_nonce, *nonce
-                                        );
                                         return Ok(Some(
-                                            TransactionResult::skipped(&txinfo.tx, message)
-                                                .convert_to_event(),
+                                            TransactionResult::skipped(
+                                                &txinfo.tx,
+                                                format!(
+                                                    "Bad sponsor nonce, tx nonce {} versus {}.",
+                                                    sponsor_nonce, *nonce
+                                                ),
+                                            )
+                                            .convert_to_event(),
                                         ));
                                     }
                                 }
@@ -2103,7 +2107,7 @@ impl StacksBlockBuilder {
                                                 "Stop mining anchored block due to limit exceeded"
                                             );
                                             block_limit_hit = BlockLimitFunction::LIMIT_REACHED;
-                                            return Ok(Some(result_event));
+                                            return Ok(None);
                                         }
                                     }
                                     Error::TransactionTooBigError => {

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1011,7 +1011,7 @@ impl MemPoolDB {
     ///
     ///  `todo` returns an option to a `TransactionEvent` representing the outcome, or None if we
     ///  hit an error that wasn't transaction specific.
-    /// 
+    ///
     /// `output_events` is modified in place, adding all substantive transaction events output by `todo`.
     pub fn iterate_candidates<F, E, C>(
         &mut self,

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1009,8 +1009,8 @@ impl MemPoolDB {
     ///  highest-fee-first order.  This method is interruptable -- in the `settings` struct, the
     ///  caller may choose how long to spend iterating before this method stops.
     ///
-    ///  `todo` returns an option to a `TransactionEvent` representing the outcome, or None if we
-    ///  hit an error that wasn't transaction specific.
+    ///  `todo` returns an option to a `TransactionEvent` representing the outcome, or None to indicate
+    ///  that iteration through the mempool should be halted.
     ///
     /// `output_events` is modified in place, adding all substantive transaction events output by `todo`.
     pub fn iterate_candidates<F, E, C>(

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -275,7 +275,7 @@ fn mempool_walk_over_fork() {
 
     let mut mempool_settings = MemPoolWalkSettings::default();
     mempool_settings.min_tx_fee = 10;
-
+    let mut tx_events = Vec::new();
     chainstate.with_read_only_clarity_tx(
         &TEST_BURN_STATE_DB,
         &StacksBlockHeader::make_index_block_hash(&b_2.0, &b_2.1),
@@ -284,6 +284,7 @@ fn mempool_walk_over_fork() {
             mempool
                 .iterate_candidates::<_, ChainstateError, _>(
                     clarity_conn,
+                    &mut tx_events,
                     2,
                     mempool_settings.clone(),
                     |_, available_tx, _| {
@@ -315,6 +316,7 @@ fn mempool_walk_over_fork() {
             mempool
                 .iterate_candidates::<_, ChainstateError, _>(
                     clarity_conn,
+                    &mut tx_events,
                     2,
                     mempool_settings.clone(),
                     |_, available_tx, _| {
@@ -345,6 +347,7 @@ fn mempool_walk_over_fork() {
             mempool
                 .iterate_candidates::<_, ChainstateError, _>(
                     clarity_conn,
+                    &mut tx_events,
                     3,
                     mempool_settings.clone(),
                     |_, available_tx, _| {
@@ -380,6 +383,7 @@ fn mempool_walk_over_fork() {
             mempool
                 .iterate_candidates::<_, ChainstateError, _>(
                     clarity_conn,
+                    &mut tx_events,
                     2,
                     mempool_settings.clone(),
                     |_, available_tx, _| {
@@ -413,6 +417,7 @@ fn mempool_walk_over_fork() {
             mempool
                 .iterate_candidates::<_, ChainstateError, _>(
                     clarity_conn,
+                    &mut tx_events,
                     3,
                     mempool_settings.clone(),
                     |_, available_tx, _| {

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -25,6 +25,7 @@ use crate::chainstate::stacks::db::test::chainstate_path;
 use crate::chainstate::stacks::db::test::instantiate_chainstate;
 use crate::chainstate::stacks::db::test::instantiate_chainstate_with_balances;
 use crate::chainstate::stacks::db::StreamCursor;
+use crate::chainstate::stacks::miner::TransactionResult;
 use crate::chainstate::stacks::test::codec_all_transactions;
 use crate::chainstate::stacks::{
     db::blocks::MemPoolRejection, db::StacksChainState, index::MarfTrieId, CoinbasePayload,
@@ -287,7 +288,13 @@ fn mempool_walk_over_fork() {
                     mempool_settings.clone(),
                     |_, available_tx, _| {
                         count_txs += 1;
-                        Ok(true)
+                        Ok(Some(
+                            TransactionResult::skipped(
+                                &available_tx.tx.tx,
+                                "event not relevant to test".to_string(),
+                            )
+                            .convert_to_event(),
+                        ))
                     },
                 )
                 .unwrap();
@@ -312,7 +319,13 @@ fn mempool_walk_over_fork() {
                     mempool_settings.clone(),
                     |_, available_tx, _| {
                         count_txs += 1;
-                        Ok(true)
+                        Ok(Some(
+                            TransactionResult::skipped(
+                                &available_tx.tx.tx,
+                                "event not relevant to test".to_string(),
+                            )
+                            .convert_to_event(),
+                        ))
                     },
                 )
                 .unwrap();
@@ -336,7 +349,13 @@ fn mempool_walk_over_fork() {
                     mempool_settings.clone(),
                     |_, available_tx, _| {
                         count_txs += 1;
-                        Ok(true)
+                        Ok(Some(
+                            TransactionResult::skipped(
+                                &available_tx.tx.tx,
+                                "event not relevant to test".to_string(),
+                            )
+                            .convert_to_event(),
+                        ))
                     },
                 )
                 .unwrap();
@@ -365,7 +384,13 @@ fn mempool_walk_over_fork() {
                     mempool_settings.clone(),
                     |_, available_tx, _| {
                         count_txs += 1;
-                        Ok(true)
+                        Ok(Some(
+                            TransactionResult::skipped(
+                                &available_tx.tx.tx,
+                                "event not relevant to test".to_string(),
+                            )
+                            .convert_to_event(),
+                        ))
                     },
                 )
                 .unwrap();
@@ -392,7 +417,13 @@ fn mempool_walk_over_fork() {
                     mempool_settings.clone(),
                     |_, available_tx, _| {
                         count_txs += 1;
-                        Ok(true)
+                        Ok(Some(
+                            TransactionResult::skipped(
+                                &available_tx.tx.tx,
+                                "event not relevant to test".to_string(),
+                            )
+                            .convert_to_event(),
+                        ))
                     },
                 )
                 .unwrap();


### PR DESCRIPTION
### Description
#2975 added "compiler-enforced logging" to the mining paths, to make sure each transaction outcome was logged. The idea with "compiler-enforced logging" is that the type system is used to make it very hard/impossible to forget to log a transaction outcome.

However, there were still some changes for outcomes to not be logged.

This PR moves the requirement to output a "transaction outcome" object up a level, to `MemPoolDB::iterate_candidates`, to which the `todo` function must now return an `Option<TransactionEvent>`, which are then collected and output by `iterate_candidates`.

Now there be no chance to forget to log an outcome, except for the "drawback" listed below.

### Applicable issues
- fixes #3130

### Additional info (benefits, drawbacks, caveats)

Drawback:
* `iterate_candidate` asks that `todo` return an `Option<TransactionEvent>`, returning `None` if the outcome was an error that wasn't transaction-specific (e.g. block limit reached). This was done to avoid introducing a new event type for "non-transaction-specific error". However, the ability to return `None` does mean that the user has a chance to forget to log a meaningful outcome, by just outputting `None`, because the type system won't stop them.


### Checklist
- [x] Test coverage for new or modified code paths (using existing tests)
- [x] Changelog is updated
