### PR TITLE
Feat/btc stx exchange rate

### DIFF
--- a/clarity/src/vm/analysis/type_checker/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/natives/mod.rs
@@ -554,9 +554,10 @@ fn check_get_block_info(
         .ok_or(CheckError::new(CheckErrors::GetBlockInfoExpectPropertyName))?;
 
     let block_info_prop =
-        BlockInfoProperty::lookup_by_name(block_info_prop_str).ok_or(CheckError::new(
-            CheckErrors::NoSuchBlockInfoProperty(block_info_prop_str.to_string()),
-        ))?;
+        BlockInfoProperty::lookup_by_name_at_version(block_info_prop_str, &checker.clarity_version)
+            .ok_or(CheckError::new(CheckErrors::NoSuchBlockInfoProperty(
+                block_info_prop_str.to_string(),
+            )))?;
 
     checker.type_check_expects(&args[1], &context, &TypeSignature::UIntType)?;
 

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2244,6 +2244,20 @@ mod test {
         fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
             None
         }
+        fn get_burnchain_tokens_spent_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+            Some(12345)
+        }
+
+        fn get_burnchain_tokens_spent_for_winning_block(
+            &self,
+            id_bhh: &StacksBlockId,
+        ) -> Option<u128> {
+            Some(2345)
+        }
+
+        fn get_tokens_earned_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+            Some(12000)
+        }
     }
 
     struct DocBurnStateDB {}

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -1459,21 +1459,35 @@ const GET_BLOCK_INFO_API: SpecialAPI = SpecialAPI {
     description: "The `get-block-info?` function fetches data for a block of the given *Stacks* block height. The
 value and type returned are determined by the specified `BlockInfoPropertyName`. If the provided `block-height` does
 not correspond to an existing block prior to the current block, the function returns `none`. The currently available property names
-are `time`, `header-hash`, `burnchain-header-hash`, `id-header-hash`, `miner-address`, and `vrf-seed`.
+are as follows:
 
-The `time` property returns an integer value of the block header time field. This is a Unix epoch timestamp in seconds
+`burnchain-header-hash`: This property returns a `(buff 32)` value containing the header hash of the burnchain (Bitcoin) block that selected the 
+Stacks block at the given Stacks chain height.
+
+`id-header-hash`: This property returns a `(buff 32)` value containing the _index block hash_ of a Stacks block.   This hash is globally unique, and is derived
+from the block hash and the history of accepted PoX operations.  This is also the block hash value you would pass into `(at-block)`.
+
+`header-hash`: This property returns a `(buff 32)` value containing the header hash of a Stacks block, given a Stacks chain height.  **WARNING* this hash is
+not guaranteed to be globally unique, since the same Stacks block can be mined in different PoX forks.  If you need global uniqueness, you should use `id-header-hash`.
+
+`miner-address`: This property returns a `principal` value corresponding to the miner of the given block.
+
+`time`: This property returns a `uint` value of the block header time field. This is a Unix epoch timestamp in seconds
 which roughly corresponds to when the block was mined. **Warning**: this does not increase monotonically with each block
 and block times are accurate only to within two hours. See [BIP113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) for more information.
 
-The `header-hash`, `burnchain-header-hash`, `id-header-hash`, and `vrf-seed` properties return a 32-byte buffer.
+New in Stacks 2.1:
 
-`header-hash` returns the header hash of a Stacks node, given a Stacks chain height.
+`block-reward`: This property returns a `uint` value for the total block reward of the indicated Stacks block.  This value is only available once the reward for 
+the block matures.  That is, the latest `block-reward` value available is at least 101 Stacks blocks in the past (on mainnet).  The reward includes the coinbase,
+the anchored block's transaction fees, and the shares of the confirmed and produced microblock transaction fees earned by this block's miner.  Note that this value may 
+be smaller than the Stacks coinbase at this height, because the miner may have been punished with a valid `PoisonMicroblock` transaction in the event that the miner
+published two or more microblock stream forks.
 
-`burnchain-header-hash` returns header hash of the burnchain (Bitcoin) node corresponding to the given Stacks chain height.
+`miner-spend-total`: This property returns a `uint` value for the total number of burnchain tokens (i.e. satoshis) spent by all miners trying to win this block.
 
-The `miner-address` property returns a `principal` corresponding to the miner of the given block.
-
-The `id-header-hash` is the block identifier value that must be used as input to the `at-block` function.
+`miner-spend-winner`: This property returns a `uint` value for the number of burnchain tokens (i.e. satoshis) spent by the winning miner for this Stacks block.  Note that
+this value is less than or equal to the value for `miner-spend-total` at the same block height.
 ",
     example: "(get-block-info? time u0) ;; Returns (some u1557860301)
 (get-block-info? header-hash u0) ;; Returns (some 0x374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb)

--- a/clarity/src/vm/test_util/mod.rs
+++ b/clarity/src/vm/test_util/mod.rs
@@ -142,6 +142,7 @@ impl HeadersDB for UnitTestHeaderDB {
     fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         None
     }
+
     fn get_consensus_hash_for_block(&self, id_bhh: &StacksBlockId) -> Option<ConsensusHash> {
         if *id_bhh == StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH)
         {
@@ -149,6 +150,21 @@ impl HeadersDB for UnitTestHeaderDB {
         } else {
             None
         }
+    }
+
+    fn get_burnchain_tokens_spent_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        self.get_burn_block_height_for_block(id_bhh).map(|_| 2000)
+    }
+
+    fn get_burnchain_tokens_spent_for_winning_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        self.get_burn_block_height_for_block(id_bhh).map(|_| 1000)
+    }
+
+    fn get_tokens_earned_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        self.get_burn_block_height_for_block(id_bhh).map(|_| 3000)
     }
 }
 

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -490,6 +490,21 @@ impl HeadersDB for TestSimHeadersDB {
     fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         Some(MINER_ADDR.clone())
     }
+
+    fn get_burnchain_tokens_spent_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        self.get_burn_block_height_for_block(id_bhh).map(|_| 2000)
+    }
+
+    fn get_burnchain_tokens_spent_for_winning_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        self.get_burn_block_height_for_block(id_bhh).map(|_| 1000)
+    }
+
+    fn get_tokens_earned_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        self.get_burn_block_height_for_block(id_bhh).map(|_| 3000)
+    }
 }
 
 #[test]

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -161,6 +161,8 @@ pub struct StacksHeaderInfo {
 pub struct MinerRewardInfo {
     pub from_block_consensus_hash: ConsensusHash,
     pub from_stacks_block_hash: BlockHeaderHash,
+    pub from_parent_block_consensus_hash: ConsensusHash,
+    pub from_parent_stacks_block_hash: BlockHeaderHash,
 }
 
 /// This is the block receipt for a Stacks block
@@ -579,7 +581,7 @@ pub struct TxStreamData {
     pub corked: bool,
 }
 
-pub const CHAINSTATE_VERSION: &'static str = "2";
+pub const CHAINSTATE_VERSION: &'static str = "3";
 
 const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
     "PRAGMA foreign_keys = ON;",
@@ -732,6 +734,43 @@ const CHAINSTATE_SCHEMA_2: &'static [&'static str] = &[
     "#,
 ];
 
+const CHAINSTATE_SCHEMA_3: &'static [&'static str] = &[
+    // new in epoch 2.1 (schema version 3)
+    // track mature miner rewards paid out, so we can report them in Clarity.
+    r#"
+    -- table for MinerRewards.
+    -- For each block within in a fork, there will be exactly two miner records:
+    -- * one that records the coinbase, anchored tx fee, and confirmed streamed tx fees, and
+    -- * one that records only the produced streamed tx fees.
+    -- The latter is determined once this block's stream gets subsequently confirmed.
+    -- You query this table by passing both the parent and the child block hashes, since both the 
+    -- parent and child blocks determine the full reward for the parent block.
+    CREATE TABLE matured_rewards(
+        recipient TEXT NOT NULL,
+        vtxindex INTEGER NOT NULL,  -- will be 0 if this is the miner, >0 if this is a user burn support
+        coinbase TEXT NOT NULL,
+        tx_fees_anchored TEXT NOT NULL,
+        tx_fees_streamed_confirmed TEXT NOT NULL,
+        tx_fees_streamed_produced TEXT NOT NULL,
+
+        -- fork identifier 
+        child_index_block_hash TEXT NOT NULL,
+        parent_index_block_hash TEXT NOT NULL,
+
+        -- there are two rewards records per (parent,child) pair. One will have a non-zero coinbase; the other will have a 0 coinbase.
+        PRIMARY KEY(parent_index_block_hash,child_index_block_hash,coinbase)
+    );"#,
+    r#"
+    CREATE INDEX IF NOT EXISTS index_matured_rewards_by_vtxindex ON matured_rewards(parent_index_block_hash,child_index_block_hash,vtxindex);
+    "#,
+    r#"
+    CREATE INDEX IF NOT EXISTS index_parent_block_id_by_block_id ON block_headers(index_block_hash,parent_block_id);
+    "#,
+    r#"
+    UPDATE db_config SET version = "3";
+    "#,
+];
+
 const CHAINSTATE_INDEXES: &'static [&'static str] = &[
     "CREATE INDEX IF NOT EXISTS index_block_hash_to_primary_key ON block_headers(index_block_hash,consensus_hash,block_hash);",
     "CREATE INDEX IF NOT EXISTS block_headers_hash_index ON block_headers(block_hash,block_height);",
@@ -756,11 +795,7 @@ const CHAINSTATE_INDEXES: &'static [&'static str] = &[
     "CREATE INDEX IF NOT EXISTS index_block_hash_tx_index ON transactions(index_block_hash);",
 ];
 
-#[cfg(test)]
-pub const MINER_REWARD_MATURITY: u64 = 2; // small for testing purposes
-
-#[cfg(not(test))]
-pub const MINER_REWARD_MATURITY: u64 = 100;
+pub use stacks_common::consts::MINER_REWARD_MATURITY;
 
 pub const MINER_FEE_MINIMUM_BLOCK_USAGE: u64 = 80; // miner must share the first F% of the anchored block tx fees, and gets 100% - F% exclusively
 
@@ -899,7 +934,7 @@ impl StacksChainState {
         StacksChainState::load_db_config(marf.sqlite_conn())
     }
 
-    fn load_db_config(conn: &DBConn) -> Result<DBConfig, db_error> {
+    pub fn load_db_config(conn: &DBConn) -> Result<DBConfig, db_error> {
         let config = query_row::<DBConfig, _>(
             conn,
             &"SELECT * FROM db_config LIMIT 1".to_string(),
@@ -939,6 +974,13 @@ impl StacksChainState {
                         // migrate to 2
                         info!("Migrating chainstate schema from version 1 to 2");
                         for cmd in CHAINSTATE_SCHEMA_2.iter() {
+                            tx.execute_batch(cmd)?;
+                        }
+                    }
+                    "2" => {
+                        // migrate to 3
+                        info!("Migrating chainstate schema from version 2 to 3");
+                        for cmd in CHAINSTATE_SCHEMA_3.iter() {
                             tx.execute_batch(cmd)?;
                         }
                     }
@@ -2119,6 +2161,8 @@ impl StacksChainState {
         microblock_tail_opt: Option<StacksMicroblockHeader>,
         block_reward: &MinerPaymentSchedule,
         user_burns: &Vec<StagingUserBurnSupport>,
+        mature_miner_payouts: Option<(MinerReward, Vec<MinerReward>, MinerReward)>, // (miner, [users], parent)
+        mature_rewards_info: Option<MinerRewardInfo>,
         anchor_block_cost: &ExecutionCost,
         anchor_block_size: u64,
         applied_epoch_transition: bool,
@@ -2181,6 +2225,41 @@ impl StacksChainState {
             block_reward,
             user_burns,
         )?;
+
+        if let Some((miner_payout, user_payouts, parent_payout)) = mature_miner_payouts {
+            let reward_info =
+                mature_rewards_info.expect("FATAL: have mature payouts but no rewards info");
+
+            let rewarded_miner_block_id = StacksBlockHeader::make_index_block_hash(
+                &reward_info.from_block_consensus_hash,
+                &reward_info.from_stacks_block_hash,
+            );
+            let rewarded_parent_miner_block_id = StacksBlockHeader::make_index_block_hash(
+                &reward_info.from_parent_block_consensus_hash,
+                &reward_info.from_parent_stacks_block_hash,
+            );
+
+            StacksChainState::insert_matured_child_miner_reward(
+                headers_tx.deref_mut(),
+                &rewarded_parent_miner_block_id,
+                &rewarded_miner_block_id,
+                &miner_payout,
+            )?;
+            for user_payout in user_payouts.into_iter() {
+                StacksChainState::insert_matured_child_user_reward(
+                    headers_tx.deref_mut(),
+                    &rewarded_parent_miner_block_id,
+                    &rewarded_miner_block_id,
+                    &user_payout,
+                )?;
+            }
+            StacksChainState::insert_matured_parent_miner_reward(
+                headers_tx.deref_mut(),
+                &rewarded_parent_miner_block_id,
+                &rewarded_miner_block_id,
+                &parent_payout,
+            )?;
+        }
 
         if applied_epoch_transition {
             debug!("Block {} applied an epoch transition", &index_block_hash);

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1508,7 +1508,7 @@ impl StacksBlockBuilder {
         assert!(!self.anchored_done);
         StacksChainState::finish_block(
             clarity_tx,
-            self.miner_payouts.clone(),
+            self.miner_payouts.as_ref(),
             self.header.total_work.work as u32,
             self.header.microblock_pubkey_hash,
         )
@@ -2207,6 +2207,8 @@ pub mod test {
     use crate::cost_estimates::UnitEstimator;
     use crate::types::chainstate::SortitionId;
     use crate::util_lib::boot::boot_code_addr;
+
+    use clarity::vm::costs::LimitedCostTracker;
 
     use super::*;
 
@@ -10143,6 +10145,357 @@ pub mod test {
                     .unwrap()
             })
             .unwrap();
+        }
+    }
+
+    #[test]
+    fn test_get_block_info_v210() {
+        let privk = StacksPrivateKey::from_hex(
+            "42faca653724860da7a41bfcef7e6ba78db55146f6900de8cb2a9f760ffac70c01",
+        )
+        .unwrap();
+        let privk_anchored = StacksPrivateKey::from_hex(
+            "f67c7437f948ca1834602b28595c12ac744f287a4efaf70d437042a6afed81bc01",
+        )
+        .unwrap();
+
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk)],
+        )
+        .unwrap();
+
+        let addr_anchored = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk_anchored)],
+        )
+        .unwrap();
+
+        let mut peer_config = TestPeerConfig::new("test_get_block_info_v210", 2018, 2019);
+        peer_config.initial_balances = vec![
+            (addr.to_account_principal(), 1000000000),
+            (addr_anchored.to_account_principal(), 1000000000),
+        ];
+
+        let epochs = vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 1, // NOTE: the first 25 burnchain blocks have no sortition
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 1,
+                end_height: 2, // NOTE: the first 25 burnchain blocks have no sortition
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: 2, // effectively already in 2.1
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+        ];
+        peer_config.epochs = Some(epochs);
+
+        let num_blocks = 10;
+        let mut anchored_sender_nonce = 0;
+
+        let mut mblock_privks = vec![];
+        for _ in 0..num_blocks {
+            let mblock_privk = StacksPrivateKey::new();
+            mblock_privks.push(mblock_privk);
+        }
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
+        let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+
+        for tenure_id in 0..num_blocks {
+            // send transactions to the mempool
+            let tip =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+
+            let acct = get_stacks_account(&mut peer, &addr.to_account_principal());
+
+            let (mut burn_ops, stacks_block, microblocks) = peer.make_tenure(
+                |ref mut miner,
+                 ref mut sortdb,
+                 ref mut chainstate,
+                 vrf_proof,
+                 ref parent_opt,
+                 ref parent_microblock_header_opt| {
+                    let parent_tip = match parent_opt {
+                        None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                        Some(block) => {
+                            let ic = sortdb.index_conn();
+                            let snapshot =
+                                SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                                    &ic,
+                                    &tip.sortition_id,
+                                    &block.block_hash(),
+                                )
+                                .unwrap()
+                                .unwrap(); // succeeds because we don't fork
+                            StacksChainState::get_anchored_block_header_info(
+                                chainstate.db(),
+                                &snapshot.consensus_hash,
+                                &snapshot.winning_stacks_block_hash,
+                            )
+                            .unwrap()
+                            .unwrap()
+                        }
+                    };
+
+                    let parent_header_hash = parent_tip.anchored_header.block_hash();
+                    let parent_consensus_hash = parent_tip.consensus_hash.clone();
+                    let parent_index_hash = StacksBlockHeader::make_index_block_hash(
+                        &parent_consensus_hash,
+                        &parent_header_hash,
+                    );
+
+                    let coinbase_tx =
+                        // alternate between the miner and a random key, so you can look at the DBs
+                        // and logs and see that the parent miner gets the produced streamed tx
+                        // fees and the child miner gets the confirmed streamed tx fees.
+                        if tenure_id % 2 == 0 {
+                            make_coinbase(miner, tenure_id / 2)
+                        }
+                        else {
+                            let pk = StacksPrivateKey::new();
+                            let mut tx_coinbase = StacksTransaction::new(
+                                TransactionVersion::Testnet,
+                                TransactionAuth::from_p2pkh(&pk).unwrap(),
+                                TransactionPayload::Coinbase(CoinbasePayload([0x00; 32])),
+                            );
+                            tx_coinbase.chain_id = 0x80000000;
+                            tx_coinbase.anchor_mode = TransactionAnchorMode::OnChainOnly;
+                            tx_coinbase.auth.set_origin_nonce(0);
+
+                            let mut tx_signer = StacksTransactionSigner::new(&tx_coinbase);
+                            tx_signer.sign_origin(&pk).unwrap();
+                            let tx_coinbase_signed = tx_signer.get_tx().unwrap();
+                            tx_coinbase_signed
+                        };
+
+                    let mut anchored_txs = vec![coinbase_tx];
+
+                    // send an anchored tx
+                    if tenure_id > 0 {
+                        let fee = 2000 + (1000 * tenure_id as u64);
+                        let stx_transfer = make_user_stacks_transfer(
+                            &privk_anchored,
+                            anchored_sender_nonce,
+                            fee,
+                            &recipient.to_account_principal(),
+                            1,
+                        );
+                        anchored_sender_nonce += 1;
+                        anchored_txs.push(stx_transfer);
+                    }
+
+                    let sort_ic = sortdb.index_conn();
+                    let (parent_mblock_stream, mblock_pubkey_hash) = {
+                        if tenure_id > 0 {
+                            chainstate
+                                .reload_unconfirmed_state(&sort_ic, parent_index_hash.clone())
+                                .unwrap();
+
+                            let parent_microblock_privkey = mblock_privks[tenure_id - 1].clone();
+                            // produce the microblock stream for the parent, which this tenure's anchor
+                            // block will confirm.
+                            let mut microblock_builder = StacksMicroblockBuilder::new(
+                                parent_header_hash.clone(),
+                                parent_consensus_hash.clone(),
+                                chainstate,
+                                &sort_ic,
+                                BlockBuilderSettings::max_value(),
+                            )
+                            .unwrap();
+
+                            let mut microblocks = vec![];
+
+                            // different fee each time
+                            let fee = 200 + (100 * tenure_id as u64);
+                            let mblock_tx = make_user_stacks_transfer(
+                                &privk,
+                                acct.nonce,
+                                fee,
+                                &recipient.to_account_principal(),
+                                1,
+                            );
+
+                            let mblock_tx_len = {
+                                let mut bytes = vec![];
+                                mblock_tx.consensus_serialize(&mut bytes).unwrap();
+                                bytes.len() as u64
+                            };
+
+                            test_debug!(
+                                "Make microblock parent stream for block in tenure {}",
+                                tenure_id
+                            );
+                            let mblock = microblock_builder
+                                .mine_next_microblock_from_txs(
+                                    vec![(mblock_tx, mblock_tx_len)],
+                                    &parent_microblock_privkey,
+                                )
+                                .unwrap();
+                            microblocks.push(mblock);
+
+                            let microblock_privkey = mblock_privks[tenure_id].clone();
+                            let mblock_pubkey_hash = Hash160::from_node_public_key(
+                                &StacksPublicKey::from_private(&microblock_privkey),
+                            );
+                            (microblocks, mblock_pubkey_hash)
+                        } else {
+                            let parent_microblock_privkey = mblock_privks[tenure_id].clone();
+                            let mblock_pubkey_hash = Hash160::from_node_public_key(
+                                &StacksPublicKey::from_private(&parent_microblock_privkey),
+                            );
+                            (vec![], mblock_pubkey_hash)
+                        }
+                    };
+
+                    test_debug!("Store parent microblocks for tenure {}", tenure_id);
+                    for mblock in parent_mblock_stream.iter() {
+                        let stored = chainstate
+                            .preprocess_streamed_microblock(
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                mblock,
+                            )
+                            .unwrap();
+                        assert!(stored);
+                    }
+
+                    let builder = StacksBlockBuilder::make_block_builder(
+                        chainstate.mainnet,
+                        &parent_tip,
+                        vrf_proof,
+                        tip.total_burn,
+                        mblock_pubkey_hash,
+                    )
+                    .unwrap();
+
+                    let anchored_block = StacksBlockBuilder::make_anchored_block_from_txs(
+                        builder,
+                        chainstate,
+                        &sort_ic,
+                        anchored_txs,
+                    )
+                    .unwrap();
+
+                    // coinbase
+                    (anchored_block.0, parent_mblock_stream)
+                },
+            );
+
+            test_debug!("Process tenure {}", tenure_id);
+
+            // make each block-commit unique
+            for burn_op in burn_ops.iter_mut() {
+                if let BlockstackOperationType::LeaderBlockCommit(ref mut op) = burn_op {
+                    op.burn_fee += tenure_id as u64;
+                }
+            }
+
+            // should always succeed
+            peer.next_burnchain_block(burn_ops.clone());
+            peer.process_stacks_epoch_at_tip_checked(&stacks_block, &vec![])
+                .unwrap();
+        }
+
+        for i in 0..num_blocks {
+            let sortdb = peer.sortdb.take().unwrap();
+            let (consensus_hash, block_bhh) =
+                SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn()).unwrap();
+            let stacks_block_id =
+                StacksBlockHeader::make_index_block_hash(&consensus_hash, &block_bhh);
+
+            peer
+                .chainstate()
+                .with_read_only_clarity_tx(
+                    &sortdb.index_conn(),
+                    &stacks_block_id,
+                    |clarity_tx| {
+                        let list_val = clarity_tx.with_readonly_clarity_env(
+                            false,
+                            CHAIN_ID_TESTNET,
+                            PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
+                            None,
+                            LimitedCostTracker::new_free(),
+                            |env| env.eval_raw(&format!("(list
+                                (get-block-info? block-reward u{})
+                                (get-block-info? miner-spend-winner u{})
+                                (get-block-info? miner-spend-total u{})
+                            )", i, i, i))
+                        )
+                        .unwrap();
+
+                        let list = list_val.expect_list();
+                        let block_reward_opt = list.get(0).cloned().unwrap().expect_optional();
+                        let miner_spend_winner = list.get(1).cloned().unwrap().expect_optional().unwrap().expect_u128();
+                        let miner_spend_total = list.get(2).cloned().unwrap().expect_optional().unwrap().expect_u128();
+
+                        eprintln!("i = {}, block_reward = {:?}, miner_spend_winner = {:?}, miner_spend_total = {:?}", i, &block_reward_opt, &miner_spend_winner, &miner_spend_total);
+
+                        if i >= 1 {
+                            assert_eq!(miner_spend_winner, (1000 + i - 1) as u128);
+                            assert_eq!(miner_spend_total, (1000 + i - 1) as u128);
+                        }
+                        else {
+                            // genesis
+                            assert_eq!(miner_spend_winner, 0);
+                            assert_eq!(miner_spend_total, 0);
+                        }
+
+                        if i > 0 && i < num_blocks - (MINER_REWARD_MATURITY as usize) - 1 {
+                            // NOTE: the value here is wrong (see #3140), but there should be *a*
+                            // value
+                            assert!(block_reward_opt.is_some());
+                        }
+                        else {
+                            // genesis, or not yet mature
+                            assert!(block_reward_opt.is_none());
+                        }
+                    }
+                )
+                .unwrap();
+
+            peer.sortdb = Some(sortdb);
         }
     }
 

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -670,6 +670,21 @@ impl HeadersDB for CLIHeadersDB {
     fn get_miner_address(&self, _id_bhh: &StacksBlockId) -> Option<StacksAddress> {
         None
     }
+
+    fn get_burnchain_tokens_spent_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        get_cli_block_height(&self.conn(), id_bhh).map(|_| 2000)
+    }
+
+    fn get_burnchain_tokens_spent_for_winning_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        get_cli_block_height(&self.conn(), id_bhh).map(|_| 1000)
+    }
+
+    fn get_tokens_earned_for_block(&self, id_bhh: &StacksBlockId) -> Option<u128> {
+        // if the block is defined at all, then return a constant
+        get_cli_block_height(&self.conn(), id_bhh).map(|_| 3000)
+    }
 }
 
 fn get_eval_input(invoked_by: &str, args: &[String]) -> EvalInput {

--- a/src/clarity_vm/tests/contracts.rs
+++ b/src/clarity_vm/tests/contracts.rs
@@ -152,3 +152,111 @@ fn test_get_burn_block_info_eval() {
         );
     });
 }
+
+#[test]
+fn test_get_block_info_eval_v210() {
+    let mut sim = ClarityTestSim::new();
+    sim.epoch_bounds = vec![0, 2, 4];
+
+    // Advance at least one block because 'get-block-info' only works after the first block.
+    sim.execute_next_block(|_env| {});
+    // Advance another block so we get to Stacks 2.05.
+    sim.execute_next_block_as_conn(|conn| {
+        let contract_identifier = QualifiedContractIdentifier::local("test-contract-1").unwrap();
+        let contract =
+            "(define-private (test-func (height uint)) (get-block-info? block-reward height))";
+        conn.as_transaction(|clarity_db| {
+            let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
+            if let Err(ClarityError::Analysis(check_error)) = res {
+                if let CheckErrors::NoSuchBlockInfoProperty(name) = check_error.err {
+                    assert_eq!(name, "block-reward");
+                } else {
+                    panic!("Bad analysis error: {:?}", &check_error);
+                }
+            } else {
+                panic!("Bad analysis result: {:?}", &res);
+            }
+        });
+    });
+    // Advance another block so we get to Stacks 2.1. This is the last block in 2.05
+    sim.execute_next_block_as_conn(|conn| {
+        let contract_identifier = QualifiedContractIdentifier::local("test-contract-2").unwrap();
+        let contract =
+            "(define-private (test-func (height uint)) (get-block-info? block-reward height))";
+        conn.as_transaction(|clarity_db| {
+            let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
+            if let Err(ClarityError::Analysis(check_error)) = res {
+                if let CheckErrors::NoSuchBlockInfoProperty(name) = check_error.err {
+                    assert_eq!(name, "block-reward");
+                } else {
+                    panic!("Bad analysis error: {:?}", &check_error);
+                }
+            } else {
+                panic!("Bad analysis result: {:?}", &res);
+            }
+        });
+    });
+    // now in Stacks 2.1, so this should work!
+    sim.execute_next_block_as_conn(|conn| {
+        let contract_identifier = QualifiedContractIdentifier::local("test-contract-3").unwrap();
+        let contract =
+            "(define-private (test-func-1 (height uint)) (get-block-info? block-reward height)) 
+             (define-private (test-func-2 (height uint)) (get-block-info? miner-spend-winner height))
+             (define-private (test-func-3 (height uint)) (get-block-info? miner-spend-total height))";
+        conn.as_transaction(|clarity_db| {
+            let (ast, _) = clarity_db
+                .analyze_smart_contract(&contract_identifier, contract)
+                .unwrap();
+            clarity_db
+                .initialize_smart_contract(&contract_identifier, &ast, contract, None, |_, _| false)
+                .unwrap();
+        });
+        let mut tx = conn.start_transaction_processing();
+        assert_eq!(
+            Value::some(Value::UInt(3000)).unwrap(),
+            tx.eval_read_only(&contract_identifier, "(test-func-1 u0)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::some(Value::UInt(1000)).unwrap(),
+            tx.eval_read_only(&contract_identifier, "(test-func-2 u0)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::some(Value::UInt(2000)).unwrap(),
+            tx.eval_read_only(&contract_identifier, "(test-func-3 u0)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::none(),
+            tx.eval_read_only(&contract_identifier, "(test-func-1 u103)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::none(),
+            tx.eval_read_only(&contract_identifier, "(test-func-2 u103)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::none(),
+            tx.eval_read_only(&contract_identifier, "(test-func-3 u103)")
+                .unwrap()
+        );
+        // only works on parent blocks and earlier
+        assert_eq!(
+            Value::none(),
+            tx.eval_read_only(&contract_identifier, "(test-func-1 block-height)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::none(),
+            tx.eval_read_only(&contract_identifier, "(test-func-2 block-height)")
+                .unwrap()
+        );
+        assert_eq!(
+            Value::none(),
+            tx.eval_read_only(&contract_identifier, "(test-func-3 block-height)")
+                .unwrap()
+        );
+    });
+}

--- a/stacks-common/src/libcommon.rs
+++ b/stacks-common/src/libcommon.rs
@@ -62,4 +62,10 @@ pub mod consts {
 
     pub const CHAIN_ID_MAINNET: u32 = 0x00000001;
     pub const CHAIN_ID_TESTNET: u32 = 0x80000000;
+
+    #[cfg(any(test, feature = "testing"))]
+    pub const MINER_REWARD_MATURITY: u64 = 2; // small for testing purposes
+
+    #[cfg(not(any(test, feature = "testing")))]
+    pub const MINER_REWARD_MATURITY: u64 = 100;
 }


### PR DESCRIPTION
This PR addresses #3043 by adding the following new fields to `get-block-info?` in Stacks 2.1:

* `block-reward`: returns the total number of uSTX awarded to the miner once the block reward matures.

* `miner-spend-total`: returns the total number of satoshis spent by all Stacks miners trying to win this block.

* `miner-spend-winner`: returns the number of satoshis spent by the winning miner on this block.

The `block-reward` value is only `(some ..)` after the queried block receives `MINER_REWARD_MATURITY + 1` confirmations.  This is because the block reward can be slashed within the first `MINER_REWARD_MATURITY` blocks by a `PoisonMicroblock` transaction, should the miner publish two or more conflicting microblock streams during their tenure.  Therefore, the system cannot reliably report the block reward until it is no longer possible to publish a `PoisonMicroblock` transaction.

The Stacks chainstate is **not backwards-compatible** with this PR.  Specifically:

* In order for this PR to faithfully report the `block-reward`, I had to make it so that the system stores the `MinerReward` structs that mature once a block is appended to the chainstate.  The actual number of tokens credited to the miner isn't recorded anywhere; we just directly pay to the miner's account when processing matured rewards.

* In order to get `miner-spend-total` to work, I had to fix #2492 to store the right sortition burn for a Stacks block.  While I don't _believe_ this is a consensus-breaking change, since we don't appear to use the value anywhere, the fact that this value is _different_ than what we have now means that we're gonna need to recalculate it.

I could go back and add schema migration code for these two things, but I'm hesitant to do so, since the time taken to write, test, and review the migration code will likely exceed the time to just boot up a 2.1 node from genesis.