### PR TITLE
chore: update vscode rust-analyzer extension ID

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "matklad.rust-analyzer",
+        "rust-lang.rust-analyzer",
         "vadimcn.vscode-lldb",
         "serayuzgur.crates",
         "editorconfig.editorconfig",


### PR DESCRIPTION
The `matklad.rust-analyzer` vscode rust extension changed its ID to `rust-lang.rust-analyzer` in Feb 2022.
See https://blog.rust-lang.org/2022/02/21/rust-analyzer-joins-rust-org.html

This fixes the vscode error prompt due to the no longer existent plugin ID being specified.

![image](https://user-images.githubusercontent.com/1447546/170074225-2ff6f2e5-87c1-426d-bca2-80a3000cb3ea.png)

