### PR TITLE
fix: use latest clarinet test lib

### DIFF
--- a/contrib/core-contract-tests/tests/bns/name_register_test.ts
+++ b/contrib/core-contract-tests/tests/bns/name_register_test.ts
@@ -1,4 +1,4 @@
-import { Clarinet, Tx, Chain, Account, Contract, types } from 'https://deno.land/x/clarinet@v0.16.0/index.ts';
+import { Clarinet, Tx, Chain, Account, Contract, types } from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
 import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
 import { createHash } from "https://deno.land/std@0.107.0/hash/mod.ts";
 


### PR DESCRIPTION
The latest version of clarinet (that this repo is using, by using the tag `latest`) is not backward compatible with previous versions of the typescript bridge.
This PR is updating the version of the library being imported.