### PR TITLE
feat: add coverage flags to clarity-cli

### DIFF
--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -431,7 +431,11 @@ pub fn vm_execute(program: &str) -> Result<Option<Value>, Error> {
     })
 }
 
-fn save_coverage(coverage_folder: Option<String>, coverage: Option<CoverageReporter>, prefix: &str) {
+fn save_coverage(
+    coverage_folder: Option<String>,
+    coverage: Option<CoverageReporter>,
+    prefix: &str,
+) {
     match (coverage_folder, coverage) {
         (Some(coverage_folder), Some(coverage)) => {
             let mut coverage_file = PathBuf::from(coverage_folder);

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -1484,7 +1484,6 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                                         vm_env.take_coverage_reporter(),
                                     )
                                 });
-                            // let (result)
                             let ((result, coverage), cost) = result_and_cost;
                             (header_db, marf, Ok((analysis, (result, cost, coverage))))
                         }


### PR DESCRIPTION
This PR adds support for a `--c` flag to gather code coverage when using `clarity-cli`. I'm really just re-adding functionality that got squashed when https://github.com/stacks-network/stacks-blockchain/pull/2592 was merged.

Requesting review from @kantai , as I'm mainly copying the code from his PR.

This also closes #3160.