### PR TITLE
chore: TOML config parser improvements

### DIFF
--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -102,16 +102,18 @@ mod tests {
             .unwrap_err()
         );
 
+        let expected_err_prefix = "Invalid burnchain.peer_host: failed to lookup address information:";
+        let actual_err_msg = Config::from_config_file(
+            ConfigFile::from_str(
+                r#"
+                [burnchain]
+                peer_host = "bitcoin2.blockstack.com"
+                "#,
+            ).unwrap()
+        ).unwrap_err();
         assert_eq!(
-            format!("Invalid burnchain.peer_host: failed to lookup address information: nodename nor servname provided, or not known"),
-            Config::from_config_file(
-                ConfigFile::from_str(
-                    r#"
-                    [burnchain]
-                    peer_host = "bitcoin2.blockstack.com"
-                    "#,
-                ).unwrap()
-            ).unwrap_err()
+            expected_err_prefix,
+            &actual_err_msg[..expected_err_prefix.len()]
         );
 
         assert!(Config::from_config_file(ConfigFile::from_str("").unwrap()).is_ok());

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -102,21 +102,16 @@ mod tests {
             .unwrap_err()
         );
 
-        let expected_err_prefix =
-            "Invalid burnchain.peer_host: failed to lookup address information:";
-        let actual_err_msg = Config::from_config_file(
-            ConfigFile::from_str(
-                r#"
-                [burnchain]
-                peer_host = "bitcoin2.blockstack.com"
-                "#,
-            )
-            .unwrap(),
-        )
-        .unwrap_err();
         assert_eq!(
-            expected_err_prefix,
-            &actual_err_msg[..expected_err_prefix.len()]
+            format!("Invalid burnchain.peer_host: failed to lookup address information: nodename nor servname provided, or not known"),
+            Config::from_config_file(
+                ConfigFile::from_str(
+                    r#"
+                    [burnchain]
+                    peer_host = "bitcoin2.blockstack.com"
+                    "#,
+                ).unwrap()
+            ).unwrap_err()
         );
 
         assert!(Config::from_config_file(ConfigFile::from_str("").unwrap()).is_ok());
@@ -511,7 +506,7 @@ impl Config {
                             // Using std::net::LookupHost would be preferable, but it's
                             // unfortunately unstable at this point.
                             // https://doc.rust-lang.org/1.6.0/std/net/struct.LookupHost.html
-                            let mut sock_addrs = format!("{}::1", &peer_host)
+                            let mut sock_addrs = format!("{}:1", &peer_host)
                                 .to_socket_addrs()
                                 .map_err(|e| format!("Invalid burnchain.peer_host: {}", &e))?;
                             let sock_addr = match sock_addrs.next() {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -102,16 +102,21 @@ mod tests {
             .unwrap_err()
         );
 
+        let expected_err_prefix =
+            "Invalid burnchain.peer_host: failed to lookup address information:";
+        let actual_err_msg = Config::from_config_file(
+            ConfigFile::from_str(
+                r#"
+                [burnchain]
+                peer_host = "bitcoin2.blockstack.com"
+                "#,
+            )
+            .unwrap(),
+        )
+        .unwrap_err();
         assert_eq!(
-            format!("Invalid burnchain.peer_host: failed to lookup address information: nodename nor servname provided, or not known"),
-            Config::from_config_file(
-                ConfigFile::from_str(
-                    r#"
-                    [burnchain]
-                    peer_host = "bitcoin2.blockstack.com"
-                    "#,
-                ).unwrap()
-            ).unwrap_err()
+            expected_err_prefix,
+            &actual_err_msg[..expected_err_prefix.len()]
         );
 
         assert!(Config::from_config_file(ConfigFile::from_str("").unwrap()).is_ok());

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -102,15 +102,18 @@ mod tests {
             .unwrap_err()
         );
 
-        let expected_err_prefix = "Invalid burnchain.peer_host: failed to lookup address information:";
+        let expected_err_prefix =
+            "Invalid burnchain.peer_host: failed to lookup address information:";
         let actual_err_msg = Config::from_config_file(
             ConfigFile::from_str(
                 r#"
                 [burnchain]
                 peer_host = "bitcoin2.blockstack.com"
                 "#,
-            ).unwrap()
-        ).unwrap_err();
+            )
+            .unwrap(),
+        )
+        .unwrap_err();
         assert_eq!(
             expected_err_prefix,
             &actual_err_msg[..expected_err_prefix.len()]

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn test_config() {
         assert_eq!(
-            format!("[node]seed should be a hex encoded string"),
+            format!("node.seed should be a hex encoded string"),
             Config::from_config_file(
                 ConfigFile::from_str(
                     r#"
@@ -89,7 +89,7 @@ mod tests {
         );
 
         assert_eq!(
-            format!("[node]local_peer_seed should be a hex encoded string"),
+            format!("node.local_peer_seed should be a hex encoded string"),
             Config::from_config_file(
                 ConfigFile::from_str(
                     r#"
@@ -103,7 +103,7 @@ mod tests {
         );
 
         assert_eq!(
-            format!("Invalid [burnchain]peer_host: failed to lookup address information: nodename nor servname provided, or not known"),
+            format!("Invalid burnchain.peer_host: failed to lookup address information: nodename nor servname provided, or not known"),
             Config::from_config_file(
                 ConfigFile::from_str(
                     r#"
@@ -396,7 +396,7 @@ impl Config {
                     name: node.name.unwrap_or(default_node_config.name),
                     seed: match node.seed {
                         Some(seed) => hex_bytes(&seed)
-                            .map_err(|e| format!("[node]seed should be a hex encoded string"))?,
+                            .map_err(|e| format!("node.seed should be a hex encoded string"))?,
                         None => default_node_config.seed,
                     },
                     working_dir: node.working_dir.unwrap_or(default_node_config.working_dir),
@@ -411,7 +411,7 @@ impl Config {
                     },
                     local_peer_seed: match node.local_peer_seed {
                         Some(seed) => hex_bytes(&seed).map_err(|e| {
-                            format!("[node]local_peer_seed should be a hex encoded string")
+                            format!("node.local_peer_seed should be a hex encoded string")
                         })?,
                         None => default_node_config.local_peer_seed,
                     },
@@ -508,7 +508,7 @@ impl Config {
                             // https://doc.rust-lang.org/1.6.0/std/net/struct.LookupHost.html
                             let mut sock_addrs = format!("{}::1", &peer_host)
                                 .to_socket_addrs()
-                                .map_err(|e| format!("Invalid [burnchain]peer_host: {}", &e))?;
+                                .map_err(|e| format!("Invalid burnchain.peer_host: {}", &e))?;
                             let sock_addr = match sock_addrs.next() {
                                 Some(addr) => addr,
                                 None => {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -82,8 +82,10 @@ mod tests {
                     [node]
                     seed = "invalid-hex-value"
                     "#,
-                ).unwrap()
-            ).unwrap_err()
+                )
+                .unwrap()
+            )
+            .unwrap_err()
         );
 
         assert_eq!(
@@ -94,8 +96,10 @@ mod tests {
                     [node]
                     local_peer_seed = "invalid-hex-value"
                     "#,
-                ).unwrap()
-            ).unwrap_err()
+                )
+                .unwrap()
+            )
+            .unwrap_err()
         );
 
         assert_eq!(
@@ -391,7 +395,8 @@ impl Config {
                 let node_config = NodeConfig {
                     name: node.name.unwrap_or(default_node_config.name),
                     seed: match node.seed {
-                        Some(seed) => hex_bytes(&seed).map_err(|e| format!("[node]seed should be a hex encoded string"))?,
+                        Some(seed) => hex_bytes(&seed)
+                            .map_err(|e| format!("[node]seed should be a hex encoded string"))?,
                         None => default_node_config.seed,
                     },
                     working_dir: node.working_dir.unwrap_or(default_node_config.working_dir),
@@ -405,7 +410,9 @@ impl Config {
                         None => format!("http://{}", rpc_bind),
                     },
                     local_peer_seed: match node.local_peer_seed {
-                        Some(seed) => hex_bytes(&seed).map_err(|e| format!("[node]local_peer_seed should be a hex encoded string"))?,
+                        Some(seed) => hex_bytes(&seed).map_err(|e| {
+                            format!("[node]local_peer_seed should be a hex encoded string")
+                        })?,
                         None => default_node_config.local_peer_seed,
                     },
                     miner: node.miner.unwrap_or(default_node_config.miner),
@@ -499,11 +506,16 @@ impl Config {
                             // Using std::net::LookupHost would be preferable, but it's
                             // unfortunately unstable at this point.
                             // https://doc.rust-lang.org/1.6.0/std/net/struct.LookupHost.html
-                            let mut sock_addrs = format!("{}::1", &peer_host).to_socket_addrs().map_err(|e| format!("Invalid [burnchain]peer_host: {}", &e))?;
+                            let mut sock_addrs = format!("{}::1", &peer_host)
+                                .to_socket_addrs()
+                                .map_err(|e| format!("Invalid [burnchain]peer_host: {}", &e))?;
                             let sock_addr = match sock_addrs.next() {
                                 Some(addr) => addr,
                                 None => {
-                                    return Err(format!("No IP address could be queried for '{}'", &peer_host));
+                                    return Err(format!(
+                                        "No IP address could be queried for '{}'",
+                                        &peer_host
+                                    ));
                                 }
                             };
                             format!("{}", sock_addr.ip())

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -113,16 +113,23 @@ fn main() {
             let config_path: String = args.value_from_str("--config").unwrap();
             args.finish().unwrap();
             info!("Loading config at path {}", config_path);
-            match ConfigFile::from_path(&config_path) {
-                Ok(config_file) => {
-                    info!("Loaded config!");
-                    process::exit(0);
-                },
+            let config_file = match ConfigFile::from_path(&config_path) {
+                Ok(config_file) => config_file,
                 Err(e) => {
                     warn!("Invalid config file: {}", e);
                     process::exit(1);
                 }
-            }
+            };
+            let conf = match Config::from_config_file(config_file) {
+                Ok(conf) => {
+                    info!("Loaded config!");
+                    process::exit(0);
+                },
+                Err(e) => {
+                    warn!("Invalid config: {}", e);
+                    process::exit(1);
+                }
+            };
         }
         "start" => {
             let config_path: String = args.value_from_str("--config").unwrap();

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -113,7 +113,12 @@ fn main() {
             let config_path: String = args.value_from_str("--config").unwrap();
             args.finish().unwrap();
             info!("Loading config at path {}", config_path);
-            ConfigFile::from_path(&config_path)
+            let config_file_result = ConfigFile::from_path(&config_path);
+            if config_file_result.is_err() {
+                warn!("Invalid config file: {}", config_file_result.err().unwrap());
+                process::exit(1);        
+            }
+            config_file_result.unwrap()
         }
         "version" => {
             println!("{}", &version());
@@ -123,7 +128,7 @@ fn main() {
             let seed = {
                 let config_path: Option<String> = args.opt_value_from_str("--config").unwrap();
                 if let Some(config_path) = config_path {
-                    let conf = Config::from_config_file(ConfigFile::from_path(&config_path));
+                    let conf = Config::from_config_file(ConfigFile::from_path(&config_path).unwrap()).unwrap();
                     args.finish().unwrap();
                     conf.node.seed
                 } else {
@@ -151,7 +156,12 @@ fn main() {
         }
     };
 
-    let conf = Config::from_config_file(config_file);
+    let conf_result = Config::from_config_file(config_file);
+    if conf_result.is_err() {
+        warn!("Invalid config: {}", conf_result.err().unwrap());
+        process::exit(1);
+    }
+    let conf = conf_result.unwrap();
     debug!("node configuration {:?}", &conf.node);
     debug!("burnchain configuration {:?}", &conf.burnchain);
     debug!("connection configuration {:?}", &conf.connection_options);

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -124,7 +124,7 @@ fn main() {
                 Ok(conf) => {
                     info!("Loaded config!");
                     process::exit(0);
-                },
+                }
                 Err(e) => {
                     warn!("Invalid config: {}", e);
                     process::exit(1);
@@ -151,7 +151,9 @@ fn main() {
             let seed = {
                 let config_path: Option<String> = args.opt_value_from_str("--config").unwrap();
                 if let Some(config_path) = config_path {
-                    let conf = Config::from_config_file(ConfigFile::from_path(&config_path).unwrap()).unwrap();
+                    let conf =
+                        Config::from_config_file(ConfigFile::from_path(&config_path).unwrap())
+                            .unwrap();
                     args.finish().unwrap();
                     conf.node.seed
                 } else {

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -109,16 +109,32 @@ fn main() {
             args.finish().unwrap();
             ConfigFile::mainnet()
         }
+        "check-config" => {
+            let config_path: String = args.value_from_str("--config").unwrap();
+            args.finish().unwrap();
+            info!("Loading config at path {}", config_path);
+            match ConfigFile::from_path(&config_path) {
+                Ok(config_file) => {
+                    info!("Loaded config!");
+                    process::exit(0);
+                },
+                Err(e) => {
+                    warn!("Invalid config file: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
         "start" => {
             let config_path: String = args.value_from_str("--config").unwrap();
             args.finish().unwrap();
             info!("Loading config at path {}", config_path);
-            let config_file_result = ConfigFile::from_path(&config_path);
-            if config_file_result.is_err() {
-                warn!("Invalid config file: {}", config_file_result.err().unwrap());
-                process::exit(1);        
+            match ConfigFile::from_path(&config_path) {
+                Ok(config_file) => config_file,
+                Err(e) => {
+                    warn!("Invalid config file: {}", e);
+                    process::exit(1);
+                }
             }
-            config_file_result.unwrap()
         }
         "version" => {
             println!("{}", &version());
@@ -156,12 +172,13 @@ fn main() {
         }
     };
 
-    let conf_result = Config::from_config_file(config_file);
-    if conf_result.is_err() {
-        warn!("Invalid config: {}", conf_result.err().unwrap());
-        process::exit(1);
-    }
-    let conf = conf_result.unwrap();
+    let conf = match Config::from_config_file(config_file) {
+        Ok(conf) => conf,
+        Err(e) => {
+            warn!("Invalid config: {}", e);
+            process::exit(1);
+        }
+    };
     debug!("node configuration {:?}", &conf.node);
     debug!("burnchain configuration {:?}", &conf.burnchain);
     debug!("connection configuration {:?}", &conf.connection_options);

--- a/testnet/stacks-node/src/main.rs
+++ b/testnet/stacks-node/src/main.rs
@@ -253,6 +253,8 @@ start\t\tStart a node with a config of your own. Can be used for joining a netwo
 \t\tExample:
 \t\t  stacks-node start --config=/path/to/config.toml
 
+check-config\t\tValidates the config file without starting up the node. Uses same arguments as start subcommand.
+
 version\t\tDisplay information about the current version and our release cycle.
 
 key-for-seed\tOutput the associated secret key for a burnchain signer created with a given seed.

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -100,7 +100,7 @@ pub fn neon_integration_test_conf() -> (Config, StacksAddress) {
     conf.burnchain.commit_anchor_block_within = 0;
 
     // test to make sure config file parsing is correct
-    let magic_bytes = Config::from_config_file(ConfigFile::xenon())
+    let magic_bytes = Config::from_config_file(ConfigFile::xenon()).unwrap()
         .burnchain
         .magic_bytes;
     assert_eq!(magic_bytes.as_bytes(), &['T' as u8, '2' as u8]);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -100,7 +100,8 @@ pub fn neon_integration_test_conf() -> (Config, StacksAddress) {
     conf.burnchain.commit_anchor_block_within = 0;
 
     // test to make sure config file parsing is correct
-    let magic_bytes = Config::from_config_file(ConfigFile::xenon()).unwrap()
+    let magic_bytes = Config::from_config_file(ConfigFile::xenon())
+        .unwrap()
         .burnchain
         .magic_bytes;
     assert_eq!(magic_bytes.as_bytes(), &['T' as u8, '2' as u8]);


### PR DESCRIPTION
- Address TOML config parsing issues from https://github.com/stacks-network/stacks-blockchain/issues/2511
- Added a new subcommand `check-config` to enforce config parsing without starting the node.

Example config parsing error:
```
$ cargo stacks-node check-config --config=config-test.toml
INFO [1655834280.871193] [testnet/stacks-node/src/main.rs:82] [main] stacks-node 0.1.0 (validate-config:892d64c5c, debug build, macos [aarch64])
INFO [1655834280.872547] [testnet/stacks-node/src/main.rs:115] [main] Loading config at path config-test.toml
WARN [1655834280.875656] [testnet/stacks-node/src/main.rs:129] [main] Invalid config: node.seed should be a hex encoded string
```

where `config-test.toml` is
```
[node]
seed = "bad-hex-string"
```