### PR TITLE
feat: Add tx/block to prometheus outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
-## [2.05.0.2.0]
+## Upcoming
 
 - Updates to the logging of transaction events (#3139).
+- Added prometheus output for "transactions in last block" (#3138).
+
+## [2.05.0.2.0]
 
 ### IMPORTANT! READ THIS FIRST
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -82,7 +82,7 @@ use crate::chainstate::coordinator::BlockEventDispatcher;
 use crate::chainstate::stacks::address::StacksAddressExtensions;
 use crate::chainstate::stacks::StacksBlockHeader;
 use crate::chainstate::stacks::StacksMicroblockHeader;
-use crate::monitoring::set_last_execution_cost_observed;
+use crate::monitoring::{set_last_block_transaction_count, set_last_execution_cost_observed};
 use crate::util_lib::boot::boot_code_id;
 use crate::{types, util};
 use stacks_common::types::chainstate::BurnchainHeaderHash;
@@ -5463,6 +5463,7 @@ impl StacksChainState {
 
         chainstate_tx.log_transactions_processed(&new_tip.index_block_hash(), &tx_receipts);
 
+        set_last_block_transaction_count(block.txs.len() as u64);
         set_last_execution_cost_observed(&block_execution_cost, &block_limit);
 
         let epoch_receipt = StacksEpochReceipt {

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -125,6 +125,13 @@ pub fn set_last_execution_cost_observed(
     }
 }
 
+/// Log the number of transactions in the latest block.
+#[allow(unused_variables)]
+pub fn set_last_block_transaction_count(transactions_in_block: u64) {
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_BLOCK_TRANSACTION_COUNT.set(transactions_in_block as f64);
+}
+
 pub fn increment_btc_ops_sent_counter() {
     #[cfg(feature = "monitoring_prom")]
     prometheus::BTC_OPS_SENT_COUNTER.inc();

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -116,7 +116,7 @@ lazy_static! {
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_BLOCK_TRANSACTION_COUNT: IntGauge = register_gauge!(opts!(
+    pub static ref LAST_BLOCK_TRANSACTION_COUNT: IntGauge = register_int_gauge!(opts!(
         "stacks_node_last_block_transaction_count",
         "Number of transactions in the last block."
     )).unwrap();

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -116,7 +116,7 @@ lazy_static! {
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();
 
-    pub static ref LAST_BLOCK_TRANSACTION_COUNT: Gauge = register_gauge!(opts!(
+    pub static ref LAST_BLOCK_TRANSACTION_COUNT: IntGauge = register_gauge!(opts!(
         "stacks_node_last_block_transaction_count",
         "Number of transactions in the last block."
     )).unwrap();

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -116,6 +116,11 @@ lazy_static! {
         "`execution_cost_runtime` for the last block observed."
     )).unwrap();
 
+    pub static ref LAST_BLOCK_TRANSACTION_COUNT: Gauge = register_gauge!(opts!(
+        "stacks_node_last_block_transaction_count",
+        "Number of transactions in the last block."
+    )).unwrap();
+
     pub static ref ACTIVE_MINERS_COUNT_GAUGE: IntGauge = register_int_gauge!(opts!(
         "stacks_node_active_miners_total",
         "Total number of active miners"


### PR DESCRIPTION
### Description

Adds output to prometheus for "transactions in last block".

We don't currently have any way to get this value from existing outputs, and want to add it to the dash.

### Checklist
- [x] No tests for this!
- [x] Changelog is updated

