### PR TITLE
Feat/explicit-contract-version

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -2,6 +2,8 @@ FROM rust:bullseye AS test
 
 WORKDIR /build
 
+ENV CARGO_MANIFEST_DIR="$(pwd)"
+
 RUN rustup override set nightly-2022-01-14 && \
     rustup component add llvm-tools-preview && \
     cargo install grcov

--- a/clarity/src/vm/analysis/analysis_db.rs
+++ b/clarity/src/vm/analysis/analysis_db.rs
@@ -25,6 +25,8 @@ use crate::vm::representations::ClarityName;
 use crate::vm::types::signatures::FunctionSignature;
 use crate::vm::types::{FunctionType, QualifiedContractIdentifier, TraitIdentifier, TypeSignature};
 
+use crate::vm::ClarityVersion;
+
 pub struct AnalysisDatabase<'a> {
     store: RollbackWrapper<'a>,
 }
@@ -108,6 +110,20 @@ impl<'a> AnalysisDatabase<'a> {
         self.store
             .insert_metadata(contract_identifier, key, &contract.serialize());
         Ok(())
+    }
+
+    pub fn get_clarity_version(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+    ) -> CheckResult<ClarityVersion> {
+        // TODO: this function loads the whole contract to obtain the function type.
+        //         but it doesn't need to -- rather this information can just be
+        //         stored as its own entry. the analysis cost tracking currently only
+        //         charges based on the function type size.
+        let contract = self
+            .load_contract(contract_identifier)
+            .ok_or(CheckErrors::NoSuchContract(contract_identifier.to_string()))?;
+        Ok(contract.clarity_version)
     }
 
     pub fn get_public_function_type(

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1077,7 +1077,6 @@ impl<'a, 'b> Environment<'a, 'b> {
 
         finally_drop_memory!(self.global_context, contract_size; {
             let contract = self.global_context.database.get_contract(contract_identifier)?;
-            debug!("Contract-call to {}.{} version {}", &contract_identifier, tx_name, &contract.contract_context.clarity_version);
 
             let func = contract.contract_context.lookup_function(tx_name)
                 .ok_or_else(|| { CheckErrors::UndefinedFunction(tx_name.to_string()) })?;

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2577,11 +2577,21 @@ mod test {
                 )
                 .unwrap();
 
-                env.initialize_contract(contract_id, &token_contract_content, None)
-                    .unwrap();
+                env.initialize_contract(
+                    contract_id,
+                    ClarityVersion::Clarity2,
+                    &token_contract_content,
+                    None,
+                )
+                .unwrap();
 
-                env.initialize_contract(trait_def_id, super::DEFINE_TRAIT_API.example, None)
-                    .unwrap();
+                env.initialize_contract(
+                    trait_def_id,
+                    ClarityVersion::Clarity2,
+                    super::DEFINE_TRAIT_API.example,
+                    None,
+                )
+                .unwrap();
             }
 
             let example = &func_api.example;

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2577,21 +2577,11 @@ mod test {
                 )
                 .unwrap();
 
-                env.initialize_contract(
-                    contract_id,
-                    ClarityVersion::Clarity2,
-                    &token_contract_content,
-                    None,
-                )
-                .unwrap();
+                env.initialize_contract(contract_id, &token_contract_content, None)
+                    .unwrap();
 
-                env.initialize_contract(
-                    trait_def_id,
-                    ClarityVersion::Clarity2,
-                    super::DEFINE_TRAIT_API.example,
-                    None,
-                )
-                .unwrap();
+                env.initialize_contract(trait_def_id, super::DEFINE_TRAIT_API.example, None)
+                    .unwrap();
             }
 
             let example = &func_api.example;

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2560,6 +2560,7 @@ mod test {
                 env.execute_in_env::<_, _, ()>(
                     QualifiedContractIdentifier::local("tokens").unwrap().into(),
                     None,
+                    None,
                     |e| {
                         let mut snapshot = e
                             .global_context

--- a/clarity/src/vm/test_util/mod.rs
+++ b/clarity/src/vm/test_util/mod.rs
@@ -27,6 +27,9 @@ pub const TEST_HEADER_DB: UnitTestHeaderDB = UnitTestHeaderDB {};
 pub const TEST_BURN_STATE_DB: UnitTestBurnStateDB = UnitTestBurnStateDB {
     epoch_id: StacksEpochId::Epoch20,
 };
+pub const TEST_BURN_STATE_DB_21: UnitTestBurnStateDB = UnitTestBurnStateDB {
+    epoch_id: StacksEpochId::Epoch21,
+};
 
 pub fn execute(s: &str) -> Value {
     vm_execute(s).unwrap().unwrap()

--- a/clarity/src/vm/tests/assets.rs
+++ b/clarity/src/vm/tests/assets.rs
@@ -26,6 +26,8 @@ use crate::vm::tests::{
 use crate::vm::types::{
     AssetIdentifier, PrincipalData, QualifiedContractIdentifier, ResponseData, Value,
 };
+use crate::vm::version::ClarityVersion;
+use crate::vm::ContractContext;
 use stacks_common::util::hash::hex_bytes;
 
 const FIRST_CLASS_TOKENS: &str = "(define-fungible-token stackaroos)
@@ -942,6 +944,11 @@ fn test_simple_naming_system(owned_env: &mut OwnedEnvironment) {
         _ => panic!(),
     };
 
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity2,
+    );
+
     let tokens_contract_id =
         QualifiedContractIdentifier::new(p1_std_principal_data.clone(), "tokens".into());
 
@@ -1031,7 +1038,7 @@ fn test_simple_naming_system(owned_env: &mut OwnedEnvironment) {
     assert!(is_committed(&result));
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         assert_eq!(
             env.eval_read_only(&names_contract_id.clone(), "(nft-get-owner? names 1)")
                 .unwrap(),
@@ -1271,7 +1278,7 @@ fn test_simple_naming_system(owned_env: &mut OwnedEnvironment) {
     assert_eq!(asset_map.to_table().len(), 0);
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         assert_eq!(
             env.eval_read_only(&names_contract_id.clone(), "(nft-get-owner? names 5)")
                 .unwrap(),

--- a/clarity/src/vm/tests/simple_apply_eval.rs
+++ b/clarity/src/vm/tests/simple_apply_eval.rs
@@ -92,6 +92,10 @@ fn test_simple_let(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId
                              (+ z y))
                         x))";
     let contract_id = QualifiedContractIdentifier::transient();
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity2,
+    );
     if let Ok(parsed_program) = parse(&contract_id, &program, version, epoch) {
         let context = LocalContext::new();
         let mut marf = MemoryBackingStore::new();
@@ -101,7 +105,7 @@ fn test_simple_let(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId
             Ok(Value::Int(7)),
             eval(
                 &parsed_program[0],
-                &mut env.get_exec_environment(None, None),
+                &mut env.get_exec_environment(None, None, &mut placeholder_context),
                 &context
             )
         );

--- a/clarity/src/vm/tests/traits.rs
+++ b/clarity/src/vm/tests/traits.rs
@@ -24,6 +24,8 @@ use crate::vm::types::{
 use std::convert::TryInto;
 
 use crate::vm::tests::{execute, symbols_from_values, with_memory_environment};
+use crate::vm::version::ClarityVersion;
+use crate::vm::ContractContext;
 
 #[test]
 fn test_all() {
@@ -64,9 +66,13 @@ fn test_dynamic_dispatch_by_defining_trait(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -83,7 +89,11 @@ fn test_dynamic_dispatch_by_defining_trait(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -108,9 +118,13 @@ fn test_dynamic_dispatch_pass_trait_nested_in_let(owned_env: &mut OwnedEnvironme
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -127,7 +141,11 @@ fn test_dynamic_dispatch_pass_trait_nested_in_let(owned_env: &mut OwnedEnvironme
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -151,9 +169,13 @@ fn test_dynamic_dispatch_pass_trait(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -170,7 +192,11 @@ fn test_dynamic_dispatch_pass_trait(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -193,9 +219,13 @@ fn test_dynamic_dispatch_intra_contract_call(owned_env: &mut OwnedEnvironment) {
         (define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("contract-defining-trait").unwrap(),
             contract_defining_trait,
@@ -212,7 +242,11 @@ fn test_dynamic_dispatch_intra_contract_call(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         let err_result = env
             .execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -238,9 +272,13 @@ fn test_dynamic_dispatch_by_implementing_imported_trait(owned_env: &mut OwnedEnv
         (define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("contract-defining-trait").unwrap(),
             contract_defining_trait,
@@ -262,7 +300,11 @@ fn test_dynamic_dispatch_by_implementing_imported_trait(owned_env: &mut OwnedEnv
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -290,9 +332,13 @@ fn test_dynamic_dispatch_by_implementing_imported_trait_mul_funcs(
         (define-public (get-2 (x uint)) (ok u2))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("contract-defining-trait").unwrap(),
             contract_defining_trait,
@@ -314,7 +360,11 @@ fn test_dynamic_dispatch_by_implementing_imported_trait_mul_funcs(
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -337,9 +387,13 @@ fn test_dynamic_dispatch_by_importing_trait(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("contract-defining-trait").unwrap(),
             contract_defining_trait,
@@ -361,7 +415,11 @@ fn test_dynamic_dispatch_by_importing_trait(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -391,9 +449,13 @@ fn test_dynamic_dispatch_including_nested_trait(owned_env: &mut OwnedEnvironment
     let target_nested_contract = "(define-public (get-a (x uint)) (ok u99))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("contract-defining-nested-trait").unwrap(),
             contract_defining_nested_trait,
@@ -428,7 +490,11 @@ fn test_dynamic_dispatch_including_nested_trait(owned_env: &mut OwnedEnvironment
         let target_nested_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-nested-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -450,9 +516,13 @@ fn test_dynamic_dispatch_mismatched_args(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x int)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -469,7 +539,11 @@ fn test_dynamic_dispatch_mismatched_args(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         let err_result = env
             .execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -493,9 +567,13 @@ fn test_dynamic_dispatch_mismatched_returned(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x uint)) (ok 1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -512,7 +590,11 @@ fn test_dynamic_dispatch_mismatched_returned(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         let err_result = env
             .execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -539,9 +621,13 @@ fn test_reentrant_dynamic_dispatch(owned_env: &mut OwnedEnvironment) {
         "(define-public (get-1 (x uint)) (contract-call? .dispatching-contract wrapped-get-1 .target-contract))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -558,7 +644,11 @@ fn test_reentrant_dynamic_dispatch(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         let err_result = env
             .execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -582,9 +672,13 @@ fn test_readwrite_dynamic_dispatch(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-read-only (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -601,7 +695,11 @@ fn test_readwrite_dynamic_dispatch(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         let err_result = env
             .execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -625,9 +723,13 @@ fn test_readwrite_violation_dynamic_dispatch(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -644,7 +746,11 @@ fn test_readwrite_violation_dynamic_dispatch(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         let err_result = env
             .execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -675,9 +781,13 @@ fn test_bad_call_with_trait(owned_env: &mut OwnedEnvironment) {
         (contract-call? .dispatch wrapped-get-1 contract))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("defun").unwrap(),
             contract_defining_trait,
@@ -701,7 +811,11 @@ fn test_bad_call_with_trait(owned_env: &mut OwnedEnvironment) {
     }
 
     {
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("call").unwrap(),
@@ -727,9 +841,13 @@ fn test_good_call_with_trait(owned_env: &mut OwnedEnvironment) {
         (contract-call? .dispatch wrapped-get-1 .implem))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("defun").unwrap(),
             contract_defining_trait,
@@ -753,7 +871,11 @@ fn test_good_call_with_trait(owned_env: &mut OwnedEnvironment) {
     }
 
     {
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("call").unwrap(),
@@ -780,9 +902,13 @@ fn test_good_call_2_with_trait(owned_env: &mut OwnedEnvironment) {
             (contract-call? .dispatch wrapped-get-1 contract))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("defun").unwrap(),
             contract_defining_trait,
@@ -809,7 +935,11 @@ fn test_good_call_2_with_trait(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("implem").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
 
         assert_eq!(
             env.execute_contract(
@@ -837,9 +967,13 @@ fn test_dynamic_dispatch_pass_literal_principal_as_trait_in_user_defined_functio
         (define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("contract-defining-trait").unwrap(),
             contract_defining_trait,
@@ -861,7 +995,11 @@ fn test_dynamic_dispatch_pass_literal_principal_as_trait_in_user_defined_functio
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -885,9 +1023,13 @@ fn test_contract_of_value(owned_env: &mut OwnedEnvironment) {
         (define-public (get-1 (x uint)) (ok u99))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("defun").unwrap(),
             contract_defining_trait,
@@ -910,7 +1052,11 @@ fn test_contract_of_value(owned_env: &mut OwnedEnvironment) {
             QualifiedContractIdentifier::local("implem").unwrap(),
         ));
         let result_contract = target_contract.clone();
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
 
         assert_eq!(
             env.execute_contract(
@@ -937,9 +1083,13 @@ fn test_contract_of_no_impl(owned_env: &mut OwnedEnvironment) {
         (define-public (get-1 (x uint)) (ok u99))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("defun").unwrap(),
             contract_defining_trait,
@@ -962,7 +1112,11 @@ fn test_contract_of_no_impl(owned_env: &mut OwnedEnvironment) {
             QualifiedContractIdentifier::local("implem").unwrap(),
         ));
         let result_contract = target_contract.clone();
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
 
         assert_eq!(
             env.execute_contract(
@@ -987,9 +1141,13 @@ fn test_return_trait_with_contract_of_wrapped_in_begin(owned_env: &mut OwnedEnvi
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -1006,7 +1164,11 @@ fn test_return_trait_with_contract_of_wrapped_in_begin(owned_env: &mut OwnedEnvi
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -1030,9 +1192,13 @@ fn test_return_trait_with_contract_of_wrapped_in_let(owned_env: &mut OwnedEnviro
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -1049,7 +1215,11 @@ fn test_return_trait_with_contract_of_wrapped_in_let(owned_env: &mut OwnedEnviro
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
@@ -1071,9 +1241,13 @@ fn test_return_trait_with_contract_of(owned_env: &mut OwnedEnvironment) {
     let target_contract = "(define-public (get-1 (x uint)) (ok u1))";
 
     let p1 = execute("'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR");
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(
             QualifiedContractIdentifier::local("dispatching-contract").unwrap(),
             dispatching_contract,
@@ -1090,7 +1264,11 @@ fn test_return_trait_with_contract_of(owned_env: &mut OwnedEnvironment) {
         let target_contract = Value::from(PrincipalData::Contract(
             QualifiedContractIdentifier::local("target-contract").unwrap(),
         ));
-        let mut env = owned_env.get_exec_environment(Some(p1.clone().expect_principal()), None);
+        let mut env = owned_env.get_exec_environment(
+            Some(p1.clone().expect_principal()),
+            None,
+            &mut placeholder_context,
+        );
         assert_eq!(
             env.execute_contract(
                 &QualifiedContractIdentifier::local("dispatching-contract").unwrap(),

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -272,24 +272,22 @@ pub fn setup_states(
             let contract = boot_code_id("pox", false);
             let sender = PrincipalData::from(contract.clone());
 
-            clarity_tx
-                .connection()
-                .as_transaction(ClarityVersion::Clarity1, |conn| {
-                    conn.run_contract_call(
-                        &sender,
-                        None,
-                        &contract,
-                        "set-burnchain-parameters",
-                        &[
-                            Value::UInt(burnchain.first_block_height as u128),
-                            Value::UInt(burnchain.pox_constants.prepare_length as u128),
-                            Value::UInt(burnchain.pox_constants.reward_cycle_length as u128),
-                            Value::UInt(burnchain.pox_constants.pox_rejection_fraction as u128),
-                        ],
-                        |_, _| false,
-                    )
-                    .expect("Failed to set burnchain parameters in PoX contract");
-                });
+            clarity_tx.connection().as_transaction(|conn| {
+                conn.run_contract_call(
+                    &sender,
+                    None,
+                    &contract,
+                    "set-burnchain-parameters",
+                    &[
+                        Value::UInt(burnchain.first_block_height as u128),
+                        Value::UInt(burnchain.pox_constants.prepare_length as u128),
+                        Value::UInt(burnchain.pox_constants.reward_cycle_length as u128),
+                        Value::UInt(burnchain.pox_constants.pox_rejection_fraction as u128),
+                    ],
+                    |_, _| false,
+                )
+                .expect("Failed to set burnchain parameters in PoX contract");
+            });
         };
 
         boot_data.post_flight_callback = Some(Box::new(post_flight_callback));

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -57,6 +57,7 @@ use crate::util_lib::boot::boot_code_id;
 use crate::{types, util};
 use clarity::vm::clarity::TransactionConnection;
 use clarity::vm::database::BurnStateDB;
+use clarity::vm::ClarityVersion;
 use rand::RngCore;
 use stacks_common::types::chainstate::StacksBlockId;
 use stacks_common::types::chainstate::TrieHash;
@@ -271,22 +272,24 @@ pub fn setup_states(
             let contract = boot_code_id("pox", false);
             let sender = PrincipalData::from(contract.clone());
 
-            clarity_tx.connection().as_transaction(|conn| {
-                conn.run_contract_call(
-                    &sender,
-                    None,
-                    &contract,
-                    "set-burnchain-parameters",
-                    &[
-                        Value::UInt(burnchain.first_block_height as u128),
-                        Value::UInt(burnchain.pox_constants.prepare_length as u128),
-                        Value::UInt(burnchain.pox_constants.reward_cycle_length as u128),
-                        Value::UInt(burnchain.pox_constants.pox_rejection_fraction as u128),
-                    ],
-                    |_, _| false,
-                )
-                .expect("Failed to set burnchain parameters in PoX contract");
-            });
+            clarity_tx
+                .connection()
+                .as_transaction(ClarityVersion::Clarity1, |conn| {
+                    conn.run_contract_call(
+                        &sender,
+                        None,
+                        &contract,
+                        "set-burnchain-parameters",
+                        &[
+                            Value::UInt(burnchain.first_block_height as u128),
+                            Value::UInt(burnchain.pox_constants.prepare_length as u128),
+                            Value::UInt(burnchain.pox_constants.reward_cycle_length as u128),
+                            Value::UInt(burnchain.pox_constants.pox_rejection_fraction as u128),
+                        ],
+                        |_, _| false,
+                    )
+                    .expect("Failed to set burnchain parameters in PoX contract");
+                });
         };
 
         boot_data.post_flight_callback = Some(Box::new(post_flight_callback));
@@ -983,6 +986,7 @@ fn missed_block_commits() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1153,6 +1157,7 @@ fn test_simple_setup() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1460,6 +1465,7 @@ fn test_sortition_with_reward_set() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1702,6 +1708,7 @@ fn test_sortition_with_burner_reward_set() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1955,6 +1962,7 @@ fn test_pox_btc_ops() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -2247,6 +2255,7 @@ fn test_stx_transfer_btc_ops() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -2475,6 +2484,7 @@ fn test_initial_coinbase_reward_distributions() {
                     .with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity1,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -3502,6 +3512,7 @@ fn eval_at_chain_tip(chainstate_path: &str, sort_db: &SortitionDB, eval: &str) -
                 conn.with_readonly_clarity_env(
                     false,
                     CHAIN_ID_TESTNET,
+                    ClarityVersion::Clarity1,
                     PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                     None,
                     LimitedCostTracker::new_free(),

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -747,8 +747,13 @@ fn pox_2_lock_extend_units() {
     sim.execute_next_block(|_env| {});
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(POX_2_CONTRACT_TESTNET.clone(), &POX_2_TESTNET_CODE, None)
-            .unwrap();
+        env.initialize_versioned_contract(
+            POX_2_CONTRACT_TESTNET.clone(),
+            ClarityVersion::Clarity2,
+            &POX_2_TESTNET_CODE,
+            None,
+        )
+        .unwrap();
         env.execute_in_env(boot_code_addr(false).into(), None, None, |env| {
             env.execute_contract(
                 POX_2_CONTRACT_TESTNET.deref(),
@@ -1625,8 +1630,13 @@ fn recency_tests() {
     let delegator = StacksPrivateKey::new();
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(POX_CONTRACT_TESTNET.clone(), &BOOT_CODE_POX_TESTNET, None)
-            .unwrap()
+        env.initialize_versioned_contract(
+            POX_CONTRACT_TESTNET.clone(),
+            ClarityVersion::Clarity2,
+            &BOOT_CODE_POX_TESTNET,
+            None,
+        )
+        .unwrap()
     });
     sim.execute_next_block(|env| {
         // try to issue a far future stacking tx
@@ -1697,8 +1707,13 @@ fn delegation_tests() {
     const REWARD_CYCLE_LENGTH: u128 = 1050;
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(POX_CONTRACT_TESTNET.clone(), &BOOT_CODE_POX_TESTNET, None)
-            .unwrap()
+        env.initialize_versioned_contract(
+            POX_CONTRACT_TESTNET.clone(),
+            ClarityVersion::Clarity2,
+            &BOOT_CODE_POX_TESTNET,
+            None,
+        )
+        .unwrap()
     });
     sim.execute_next_block(|env| {
         assert_eq!(
@@ -2269,8 +2284,9 @@ fn test_vote_withdrawal() {
     let mut sim = ClarityTestSim::new();
 
     sim.execute_next_block(|env| {
-        env.initialize_contract(
+        env.initialize_versioned_contract(
             COST_VOTING_CONTRACT_TESTNET.clone(),
+            ClarityVersion::Clarity1,
             &BOOT_CODE_COST_VOTING,
             None,
         )

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -991,7 +991,7 @@ fn pox_2_delegate_extend_units() {
         test_deploy_smart_contract(conn, &POX_2_CONTRACT_TESTNET, &POX_2_TESTNET_CODE).unwrap();
 
         // set burnchain params based on old testnet settings (< 2.0.11.0)
-        conn.as_transaction(|tx| {
+        conn.as_transaction(ClarityVersion::Clarity1, |tx| {
             tx.run_contract_call(
                 &boot_code_addr(false).into(),
                 None,
@@ -1582,7 +1582,7 @@ fn test_deploy_smart_contract(
     contract_id: &QualifiedContractIdentifier,
     content: &str,
 ) -> std::result::Result<(), ClarityError> {
-    block.as_transaction(|tx| {
+    block.as_transaction(ClarityVersion::Clarity1, |tx| {
         let (ast, analysis) = tx.analyze_smart_contract(&contract_id, content)?;
         tx.initialize_smart_contract(&contract_id, &ast, content, None, |_, _| false)?;
         tx.save_analysis(&contract_id, &analysis)?;

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -749,7 +749,7 @@ fn pox_2_lock_extend_units() {
     sim.execute_next_block(|env| {
         env.initialize_contract(POX_2_CONTRACT_TESTNET.clone(), &POX_2_TESTNET_CODE, None)
             .unwrap();
-        env.execute_in_env(boot_code_addr(false).into(), None, |env| {
+        env.execute_in_env(boot_code_addr(false).into(), None, None, |env| {
             env.execute_contract(
                 POX_2_CONTRACT_TESTNET.deref(),
                 "set-burnchain-parameters",
@@ -999,7 +999,7 @@ fn pox_2_delegate_extend_units() {
         .unwrap();
 
         // set burnchain params based on old testnet settings (< 2.0.11.0)
-        conn.as_transaction(ClarityVersion::Clarity1, |tx| {
+        conn.as_transaction(|tx| {
             tx.run_contract_call(
                 &boot_code_addr(false).into(),
                 None,
@@ -1611,9 +1611,9 @@ fn test_deploy_smart_contract(
     content: &str,
     version: ClarityVersion,
 ) -> std::result::Result<(), ClarityError> {
-    block.as_transaction(version, |tx| {
-        let (ast, analysis) = tx.analyze_smart_contract(&contract_id, content)?;
-        tx.initialize_smart_contract(&contract_id, &ast, content, None, |_, _| false)?;
+    block.as_transaction(|tx| {
+        let (ast, analysis) = tx.analyze_smart_contract(&contract_id, version, content)?;
+        tx.initialize_smart_contract(&contract_id, version, &ast, content, None, |_, _| false)?;
         tx.save_analysis(&contract_id, &analysis)?;
         return Ok(());
     })

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -50,6 +50,7 @@ use crate::types::chainstate::StacksAddress;
 use crate::types::chainstate::StacksBlockId;
 use crate::util_lib::boot;
 use crate::vm::{costs::LimitedCostTracker, SymbolicExpression};
+use clarity::vm::ClarityVersion;
 
 const BOOT_CODE_POX_BODY: &'static str = std::include_str!("pox.clar");
 const BOOT_CODE_POX_TESTNET_CONSTS: &'static str = std::include_str!("pox-testnet.clar");
@@ -214,6 +215,7 @@ impl StacksChainState {
                 clarity_tx.with_readonly_clarity_env(
                     mainnet,
                     chain_id,
+                    ClarityVersion::Clarity1,
                     sender,
                     None,
                     cost_track,
@@ -1026,7 +1028,7 @@ pub mod test {
         name: &str,
         code: &str,
     ) -> StacksTransaction {
-        let payload = TransactionPayload::new_smart_contract(name, code).unwrap();
+        let payload = TransactionPayload::new_smart_contract(name, code, None).unwrap();
         make_tx(key, nonce, tx_fee, payload)
     }
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4619,23 +4619,21 @@ impl StacksChainState {
                 burn_header_hash,
                 ..
             } = stack_stx_op;
-            let result = clarity_tx
-                .connection()
-                .as_transaction(ClarityVersion::Clarity1, |tx| {
-                    tx.run_contract_call(
-                        &sender.into(),
-                        None,
-                        &boot_code_id("pox", mainnet),
-                        "stack-stx",
-                        &[
-                            Value::UInt(stacked_ustx),
-                            reward_addr.as_clarity_tuple().into(),
-                            Value::UInt(u128::from(block_height)),
-                            Value::UInt(u128::from(num_cycles)),
-                        ],
-                        |_, _| false,
-                    )
-                });
+            let result = clarity_tx.connection().as_transaction(|tx| {
+                tx.run_contract_call(
+                    &sender.into(),
+                    None,
+                    &boot_code_id("pox", mainnet),
+                    "stack-stx",
+                    &[
+                        Value::UInt(stacked_ustx),
+                        reward_addr.as_clarity_tuple().into(),
+                        Value::UInt(u128::from(block_height)),
+                        Value::UInt(u128::from(num_cycles)),
+                    ],
+                    |_, _| false,
+                )
+            });
             match result {
                 Ok((value, _, events)) => {
                     if let Value::Response(ref resp) = value {
@@ -4705,7 +4703,7 @@ impl StacksChainState {
                             memo,
                             ..
                         } = transfer_stx_op;
-                        let result = clarity_tx.connection().as_transaction(ClarityVersion::Clarity1, |tx| {
+                        let result = clarity_tx.connection().as_transaction(|tx| {
                             tx.run_stx_transfer(
                                 &sender.into(),
                                 &recipient.into(),
@@ -4777,7 +4775,7 @@ impl StacksChainState {
         let miner_reward_total = miner_reward.total();
         clarity_tx
             .connection()
-            .as_transaction(ClarityVersion::Clarity1, |x| {
+            .as_transaction(|x| {
                 x.with_clarity_db(|ref mut db| {
                     let recipient_principal =
                         // strictly speaking this check is defensive. It will never be the case
@@ -4845,7 +4843,7 @@ impl StacksChainState {
         let lockup_contract_id = boot_code_id("lockup", mainnet);
         clarity_tx
             .connection()
-            .as_transaction(ClarityVersion::Clarity1, |tx_connection| {
+            .as_transaction(|tx_connection| {
                 let result = tx_connection.with_clarity_db(|db| {
                     let block_height = Value::UInt(db.get_current_block_height().into());
                     let res = db.fetch_entry_unknown_descriptor(

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -415,7 +415,7 @@ impl<'a, 'b> ClarityTx<'a, 'b> {
 
     pub fn increment_ustx_liquid_supply(&mut self, incr_by: u128) {
         self.connection()
-            .as_transaction(ClarityVersion::Clarity1, |tx| {
+            .as_transaction(|tx| {
                 tx.with_clarity_db(|db| {
                     db.increment_ustx_liquid_supply(incr_by)
                         .map_err(|e| e.into())
@@ -1183,16 +1183,13 @@ impl StacksChainState {
                     smart_contract,
                 );
 
-                let tx_receipt = clarity_tx.connection().as_transaction(
-                    ClarityVersion::Clarity1,
-                    |clarity| {
-                        StacksChainState::process_transaction_payload(
-                            clarity,
-                            &boot_code_smart_contract,
-                            &boot_code_account,
-                        )
-                    },
-                )?;
+                let tx_receipt = clarity_tx.connection().as_transaction(|clarity| {
+                    StacksChainState::process_transaction_payload(
+                        clarity,
+                        &boot_code_smart_contract,
+                        &boot_code_account,
+                    )
+                })?;
                 receipts.push(tx_receipt);
 
                 boot_code_account.nonce += 1;
@@ -1206,11 +1203,9 @@ impl StacksChainState {
                 );
             }
             for (address, amount) in boot_data.initial_balances.iter() {
-                clarity_tx
-                    .connection()
-                    .as_transaction(ClarityVersion::Clarity1, |clarity| {
-                        StacksChainState::account_genesis_credit(clarity, address, (*amount).into())
-                    });
+                clarity_tx.connection().as_transaction(|clarity| {
+                    StacksChainState::account_genesis_credit(clarity, address, (*amount).into())
+                });
                 initial_liquid_ustx = initial_liquid_ustx
                     .checked_add(*amount as u128)
                     .expect("FATAL: liquid STX overflow");
@@ -1223,257 +1218,248 @@ impl StacksChainState {
                 allocation_events.push(mint_event);
             }
 
-            clarity_tx
-                .connection()
-                .as_transaction(ClarityVersion::Clarity1, |clarity| {
-                    // Balances
-                    if let Some(get_balances) = boot_data.get_bulk_initial_balances.take() {
-                        info!("Importing accounts from Stacks 1.0");
-                        let mut balances_count = 0;
-                        let initial_balances = get_balances();
-                        for balance in initial_balances {
-                            balances_count = balances_count + 1;
-                            let stx_address =
-                                StacksChainState::parse_genesis_address(&balance.address, mainnet);
-                            StacksChainState::account_genesis_credit(
-                                clarity,
-                                &stx_address,
-                                balance.amount.into(),
-                            );
-                            initial_liquid_ustx = initial_liquid_ustx
-                                .checked_add(balance.amount as u128)
-                                .expect("FATAL: liquid STX overflow");
-                            let mint_event = StacksTransactionEvent::STXEvent(
-                                STXEventType::STXMintEvent(STXMintEventData {
-                                    recipient: stx_address,
-                                    amount: balance.amount.into(),
-                                }),
-                            );
-                            allocation_events.push(mint_event);
-                        }
-                        info!("Seeding {} balances coming from chain dump", balances_count);
+            clarity_tx.connection().as_transaction(|clarity| {
+                // Balances
+                if let Some(get_balances) = boot_data.get_bulk_initial_balances.take() {
+                    info!("Importing accounts from Stacks 1.0");
+                    let mut balances_count = 0;
+                    let initial_balances = get_balances();
+                    for balance in initial_balances {
+                        balances_count = balances_count + 1;
+                        let stx_address =
+                            StacksChainState::parse_genesis_address(&balance.address, mainnet);
+                        StacksChainState::account_genesis_credit(
+                            clarity,
+                            &stx_address,
+                            balance.amount.into(),
+                        );
+                        initial_liquid_ustx = initial_liquid_ustx
+                            .checked_add(balance.amount as u128)
+                            .expect("FATAL: liquid STX overflow");
+                        let mint_event = StacksTransactionEvent::STXEvent(
+                            STXEventType::STXMintEvent(STXMintEventData {
+                                recipient: stx_address,
+                                amount: balance.amount.into(),
+                            }),
+                        );
+                        allocation_events.push(mint_event);
+                    }
+                    info!("Seeding {} balances coming from chain dump", balances_count);
+                }
+
+                // Lockups
+                if let Some(get_schedules) = boot_data.get_bulk_initial_lockups.take() {
+                    info!("Initializing chain with lockups");
+                    let mut lockups_per_block: BTreeMap<u64, Vec<Value>> = BTreeMap::new();
+                    let initial_lockups = get_schedules();
+                    for schedule in initial_lockups {
+                        let stx_address =
+                            StacksChainState::parse_genesis_address(&schedule.address, mainnet);
+                        let value = Value::Tuple(
+                            TupleData::from_data(vec![
+                                ("recipient".into(), Value::Principal(stx_address)),
+                                ("amount".into(), Value::UInt(schedule.amount.into())),
+                            ])
+                            .unwrap(),
+                        );
+                        match lockups_per_block.entry(schedule.block_height) {
+                            Entry::Occupied(schedules) => {
+                                schedules.into_mut().push(value);
+                            }
+                            Entry::Vacant(entry) => {
+                                let schedules = vec![value];
+                                entry.insert(schedules);
+                            }
+                        };
                     }
 
-                    // Lockups
-                    if let Some(get_schedules) = boot_data.get_bulk_initial_lockups.take() {
-                        info!("Initializing chain with lockups");
-                        let mut lockups_per_block: BTreeMap<u64, Vec<Value>> = BTreeMap::new();
-                        let initial_lockups = get_schedules();
-                        for schedule in initial_lockups {
-                            let stx_address =
-                                StacksChainState::parse_genesis_address(&schedule.address, mainnet);
-                            let value = Value::Tuple(
-                                TupleData::from_data(vec![
-                                    ("recipient".into(), Value::Principal(stx_address)),
-                                    ("amount".into(), Value::UInt(schedule.amount.into())),
-                                ])
-                                .unwrap(),
-                            );
-                            match lockups_per_block.entry(schedule.block_height) {
-                                Entry::Occupied(schedules) => {
-                                    schedules.into_mut().push(value);
-                                }
-                                Entry::Vacant(entry) => {
-                                    let schedules = vec![value];
-                                    entry.insert(schedules);
-                                }
-                            };
-                        }
+                    let lockup_contract_id = boot_code_id("lockup", mainnet);
+                    clarity
+                        .with_clarity_db(|db| {
+                            for (block_height, schedule) in lockups_per_block.into_iter() {
+                                let key = Value::UInt(block_height.into());
+                                let value = Value::list_from(schedule).unwrap();
+                                db.insert_entry_unknown_descriptor(
+                                    &lockup_contract_id,
+                                    "lockups",
+                                    key,
+                                    value,
+                                )?;
+                            }
+                            Ok(())
+                        })
+                        .unwrap();
+                }
 
-                        let lockup_contract_id = boot_code_id("lockup", mainnet);
-                        clarity
-                            .with_clarity_db(|db| {
-                                for (block_height, schedule) in lockups_per_block.into_iter() {
-                                    let key = Value::UInt(block_height.into());
-                                    let value = Value::list_from(schedule).unwrap();
-                                    db.insert_entry_unknown_descriptor(
-                                        &lockup_contract_id,
-                                        "lockups",
-                                        key,
-                                        value,
-                                    )?;
-                                }
-                                Ok(())
-                            })
-                            .unwrap();
-                    }
+                // BNS Namespace
+                let bns_contract_id = boot_code_id("bns", mainnet);
+                if let Some(get_namespaces) = boot_data.get_bulk_initial_namespaces.take() {
+                    info!("Initializing chain with namespaces");
+                    clarity
+                        .with_clarity_db(|db| {
+                            let initial_namespaces = get_namespaces();
+                            for entry in initial_namespaces {
+                                let namespace = {
+                                    if !BNS_CHARS_REGEX.is_match(&entry.namespace_id) {
+                                        panic!("Invalid namespace characters");
+                                    }
+                                    let buffer = entry.namespace_id.as_bytes();
+                                    Value::buff_from(buffer.to_vec()).expect("Invalid namespace")
+                                };
 
-                    // BNS Namespace
-                    let bns_contract_id = boot_code_id("bns", mainnet);
-                    if let Some(get_namespaces) = boot_data.get_bulk_initial_namespaces.take() {
-                        info!("Initializing chain with namespaces");
-                        clarity
-                            .with_clarity_db(|db| {
-                                let initial_namespaces = get_namespaces();
-                                for entry in initial_namespaces {
-                                    let namespace = {
-                                        if !BNS_CHARS_REGEX.is_match(&entry.namespace_id) {
-                                            panic!("Invalid namespace characters");
-                                        }
-                                        let buffer = entry.namespace_id.as_bytes();
-                                        Value::buff_from(buffer.to_vec())
-                                            .expect("Invalid namespace")
-                                    };
-
-                                    let importer = {
-                                        let address = StacksChainState::parse_genesis_address(
-                                            &entry.importer,
-                                            mainnet,
-                                        );
-                                        Value::Principal(address)
-                                    };
-
-                                    let revealed_at = Value::UInt(0);
-                                    let launched_at = Value::UInt(0);
-                                    let lifetime = Value::UInt(entry.lifetime.into());
-                                    let price_function = {
-                                        let base = Value::UInt(entry.base.into());
-                                        let coeff = Value::UInt(entry.coeff.into());
-                                        let nonalpha_discount =
-                                            Value::UInt(entry.nonalpha_discount.into());
-                                        let no_vowel_discount =
-                                            Value::UInt(entry.no_vowel_discount.into());
-                                        let buckets: Vec<_> = entry
-                                            .buckets
-                                            .split(";")
-                                            .map(|e| Value::UInt(e.parse::<u64>().unwrap().into()))
-                                            .collect();
-                                        assert_eq!(buckets.len(), 16);
-
-                                        TupleData::from_data(vec![
-                                            ("buckets".into(), Value::list_from(buckets).unwrap()),
-                                            ("base".into(), base),
-                                            ("coeff".into(), coeff),
-                                            ("nonalpha-discount".into(), nonalpha_discount),
-                                            ("no-vowel-discount".into(), no_vowel_discount),
-                                        ])
-                                        .unwrap()
-                                    };
-
-                                    let namespace_props = Value::Tuple(
-                                        TupleData::from_data(vec![
-                                            ("revealed-at".into(), revealed_at),
-                                            (
-                                                "launched-at".into(),
-                                                Value::some(launched_at).unwrap(),
-                                            ),
-                                            ("lifetime".into(), lifetime),
-                                            ("namespace-import".into(), importer),
-                                            ("can-update-price-function".into(), Value::Bool(true)),
-                                            ("price-function".into(), Value::Tuple(price_function)),
-                                        ])
-                                        .unwrap(),
-                                    );
-
-                                    db.insert_entry_unknown_descriptor(
-                                        &bns_contract_id,
-                                        "namespaces",
-                                        namespace,
-                                        namespace_props,
-                                    )?;
-                                }
-                                Ok(())
-                            })
-                            .unwrap();
-                    }
-
-                    // BNS Names
-                    if let Some(get_names) = boot_data.get_bulk_initial_names.take() {
-                        info!("Initializing chain with names");
-                        clarity
-                            .with_clarity_db(|db| {
-                                let initial_names = get_names();
-                                for entry in initial_names {
-                                    let components: Vec<_> =
-                                        entry.fully_qualified_name.split(".").collect();
-                                    assert_eq!(components.len(), 2);
-
-                                    let namespace = {
-                                        let namespace_str = components[1];
-                                        if !BNS_CHARS_REGEX.is_match(&namespace_str) {
-                                            panic!("Invalid namespace characters");
-                                        }
-                                        let buffer = namespace_str.as_bytes();
-                                        Value::buff_from(buffer.to_vec())
-                                            .expect("Invalid namespace")
-                                    };
-
-                                    let name = {
-                                        let name_str = components[0].to_string();
-                                        if !BNS_CHARS_REGEX.is_match(&name_str) {
-                                            panic!("Invalid name characters");
-                                        }
-                                        let buffer = name_str.as_bytes();
-                                        Value::buff_from(buffer.to_vec()).expect("Invalid name")
-                                    };
-
-                                    let fqn = Value::Tuple(
-                                        TupleData::from_data(vec![
-                                            ("namespace".into(), namespace),
-                                            ("name".into(), name),
-                                        ])
-                                        .unwrap(),
-                                    );
-
-                                    let owner_address = StacksChainState::parse_genesis_address(
-                                        &entry.owner,
+                                let importer = {
+                                    let address = StacksChainState::parse_genesis_address(
+                                        &entry.importer,
                                         mainnet,
                                     );
+                                    Value::Principal(address)
+                                };
 
-                                    let zonefile_hash = {
-                                        if entry.zonefile_hash.len() == 0 {
-                                            Value::buff_from(vec![]).unwrap()
-                                        } else {
-                                            let buffer = Hash160::from_hex(&entry.zonefile_hash)
-                                                .expect("Invalid zonefile_hash");
-                                            Value::buff_from(buffer.to_bytes().to_vec()).unwrap()
-                                        }
-                                    };
+                                let revealed_at = Value::UInt(0);
+                                let launched_at = Value::UInt(0);
+                                let lifetime = Value::UInt(entry.lifetime.into());
+                                let price_function = {
+                                    let base = Value::UInt(entry.base.into());
+                                    let coeff = Value::UInt(entry.coeff.into());
+                                    let nonalpha_discount =
+                                        Value::UInt(entry.nonalpha_discount.into());
+                                    let no_vowel_discount =
+                                        Value::UInt(entry.no_vowel_discount.into());
+                                    let buckets: Vec<_> = entry
+                                        .buckets
+                                        .split(";")
+                                        .map(|e| Value::UInt(e.parse::<u64>().unwrap().into()))
+                                        .collect();
+                                    assert_eq!(buckets.len(), 16);
 
-                                    let expected_asset_type =
-                                        db.get_nft_key_type(&bns_contract_id, "names")?;
-                                    db.set_nft_owner(
-                                        &bns_contract_id,
-                                        "names",
-                                        &fqn,
-                                        &owner_address,
-                                        &expected_asset_type,
-                                    )?;
+                                    TupleData::from_data(vec![
+                                        ("buckets".into(), Value::list_from(buckets).unwrap()),
+                                        ("base".into(), base),
+                                        ("coeff".into(), coeff),
+                                        ("nonalpha-discount".into(), nonalpha_discount),
+                                        ("no-vowel-discount".into(), no_vowel_discount),
+                                    ])
+                                    .unwrap()
+                                };
 
-                                    let registered_at = Value::UInt(0);
-                                    let name_props = Value::Tuple(
-                                        TupleData::from_data(vec![
-                                            (
-                                                "registered-at".into(),
-                                                Value::some(registered_at).unwrap(),
-                                            ),
-                                            ("imported-at".into(), Value::none()),
-                                            ("revoked-at".into(), Value::none()),
-                                            ("zonefile-hash".into(), zonefile_hash),
-                                        ])
-                                        .unwrap(),
-                                    );
+                                let namespace_props = Value::Tuple(
+                                    TupleData::from_data(vec![
+                                        ("revealed-at".into(), revealed_at),
+                                        ("launched-at".into(), Value::some(launched_at).unwrap()),
+                                        ("lifetime".into(), lifetime),
+                                        ("namespace-import".into(), importer),
+                                        ("can-update-price-function".into(), Value::Bool(true)),
+                                        ("price-function".into(), Value::Tuple(price_function)),
+                                    ])
+                                    .unwrap(),
+                                );
 
-                                    db.insert_entry_unknown_descriptor(
-                                        &bns_contract_id,
-                                        "name-properties",
-                                        fqn.clone(),
-                                        name_props,
-                                    )?;
+                                db.insert_entry_unknown_descriptor(
+                                    &bns_contract_id,
+                                    "namespaces",
+                                    namespace,
+                                    namespace_props,
+                                )?;
+                            }
+                            Ok(())
+                        })
+                        .unwrap();
+                }
 
-                                    db.insert_entry_unknown_descriptor(
-                                        &bns_contract_id,
-                                        "owner-name",
-                                        Value::Principal(owner_address),
-                                        fqn,
-                                    )?;
-                                }
-                                Ok(())
-                            })
-                            .unwrap();
-                    }
-                    info!("Saving Genesis block. This could take a while");
-                });
+                // BNS Names
+                if let Some(get_names) = boot_data.get_bulk_initial_names.take() {
+                    info!("Initializing chain with names");
+                    clarity
+                        .with_clarity_db(|db| {
+                            let initial_names = get_names();
+                            for entry in initial_names {
+                                let components: Vec<_> =
+                                    entry.fully_qualified_name.split(".").collect();
+                                assert_eq!(components.len(), 2);
+
+                                let namespace = {
+                                    let namespace_str = components[1];
+                                    if !BNS_CHARS_REGEX.is_match(&namespace_str) {
+                                        panic!("Invalid namespace characters");
+                                    }
+                                    let buffer = namespace_str.as_bytes();
+                                    Value::buff_from(buffer.to_vec()).expect("Invalid namespace")
+                                };
+
+                                let name = {
+                                    let name_str = components[0].to_string();
+                                    if !BNS_CHARS_REGEX.is_match(&name_str) {
+                                        panic!("Invalid name characters");
+                                    }
+                                    let buffer = name_str.as_bytes();
+                                    Value::buff_from(buffer.to_vec()).expect("Invalid name")
+                                };
+
+                                let fqn = Value::Tuple(
+                                    TupleData::from_data(vec![
+                                        ("namespace".into(), namespace),
+                                        ("name".into(), name),
+                                    ])
+                                    .unwrap(),
+                                );
+
+                                let owner_address =
+                                    StacksChainState::parse_genesis_address(&entry.owner, mainnet);
+
+                                let zonefile_hash = {
+                                    if entry.zonefile_hash.len() == 0 {
+                                        Value::buff_from(vec![]).unwrap()
+                                    } else {
+                                        let buffer = Hash160::from_hex(&entry.zonefile_hash)
+                                            .expect("Invalid zonefile_hash");
+                                        Value::buff_from(buffer.to_bytes().to_vec()).unwrap()
+                                    }
+                                };
+
+                                let expected_asset_type =
+                                    db.get_nft_key_type(&bns_contract_id, "names")?;
+                                db.set_nft_owner(
+                                    &bns_contract_id,
+                                    "names",
+                                    &fqn,
+                                    &owner_address,
+                                    &expected_asset_type,
+                                )?;
+
+                                let registered_at = Value::UInt(0);
+                                let name_props = Value::Tuple(
+                                    TupleData::from_data(vec![
+                                        (
+                                            "registered-at".into(),
+                                            Value::some(registered_at).unwrap(),
+                                        ),
+                                        ("imported-at".into(), Value::none()),
+                                        ("revoked-at".into(), Value::none()),
+                                        ("zonefile-hash".into(), zonefile_hash),
+                                    ])
+                                    .unwrap(),
+                                );
+
+                                db.insert_entry_unknown_descriptor(
+                                    &bns_contract_id,
+                                    "name-properties",
+                                    fqn.clone(),
+                                    name_props,
+                                )?;
+
+                                db.insert_entry_unknown_descriptor(
+                                    &bns_contract_id,
+                                    "owner-name",
+                                    Value::Principal(owner_address),
+                                    fqn,
+                                )?;
+                            }
+                            Ok(())
+                        })
+                        .unwrap();
+                }
+                info!("Saving Genesis block. This could take a while");
+            });
 
             let allocations_tx = StacksTransaction::new(
                 tx_version.clone(),
@@ -1506,23 +1492,21 @@ impl StacksChainState {
                 Value::UInt(pox_constants.reward_cycle_length as u128),
                 Value::UInt(pox_constants.pox_rejection_fraction as u128),
             ];
-            clarity_tx
-                .connection()
-                .as_transaction(ClarityVersion::Clarity1, |conn| {
-                    conn.run_contract_call(
-                        &sender,
-                        None,
-                        &contract,
-                        "set-burnchain-parameters",
-                        &params,
-                        |_, _| false,
-                    )
-                    .expect("Failed to set burnchain parameters in PoX contract");
-                });
+            clarity_tx.connection().as_transaction(|conn| {
+                conn.run_contract_call(
+                    &sender,
+                    None,
+                    &contract,
+                    "set-burnchain-parameters",
+                    &params,
+                    |_, _| false,
+                )
+                .expect("Failed to set burnchain parameters in PoX contract");
+            });
 
             clarity_tx
                 .connection()
-                .as_transaction(ClarityVersion::Clarity1, |tx| {
+                .as_transaction(|tx| {
                     tx.with_clarity_db(|db| {
                         db.increment_ustx_liquid_supply(initial_liquid_ustx)
                             .map_err(|e| e.into())
@@ -2162,7 +2146,7 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         clarity_tx
             .connection()
-            .as_transaction(ClarityVersion::Clarity1, |tx| {
+            .as_transaction(|tx| {
                 tx.with_clarity_db(|ref mut db| {
                     db.insert_microblock_pubkey_hash_height(mblock_pubkey_hash, height)
                         .expect("FATAL: failed to store microblock public key hash to Clarity DB");

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -415,7 +415,7 @@ impl<'a, 'b> ClarityTx<'a, 'b> {
 
     pub fn increment_ustx_liquid_supply(&mut self, incr_by: u128) {
         self.connection()
-            .as_transaction(|tx| {
+            .as_transaction(ClarityVersion::Clarity1, |tx| {
                 tx.with_clarity_db(|db| {
                     db.increment_ustx_liquid_supply(incr_by)
                         .map_err(|e| e.into())
@@ -1167,12 +1167,15 @@ impl StacksChainState {
                     boot_code_contract.len()
                 );
 
-                let smart_contract = TransactionPayload::SmartContract(TransactionSmartContract {
-                    name: ContractName::try_from(boot_code_name.to_string())
-                        .expect("FATAL: invalid boot-code contract name"),
-                    code_body: StacksString::from_str(boot_code_contract)
-                        .expect("FATAL: invalid boot code body"),
-                });
+                let smart_contract = TransactionPayload::SmartContract(
+                    TransactionSmartContract {
+                        name: ContractName::try_from(boot_code_name.to_string())
+                            .expect("FATAL: invalid boot-code contract name"),
+                        code_body: StacksString::from_str(boot_code_contract)
+                            .expect("FATAL: invalid boot code body"),
+                    },
+                    None,
+                );
 
                 let boot_code_smart_contract = StacksTransaction::new(
                     tx_version.clone(),
@@ -1180,13 +1183,16 @@ impl StacksChainState {
                     smart_contract,
                 );
 
-                let tx_receipt = clarity_tx.connection().as_transaction(|clarity| {
-                    StacksChainState::process_transaction_payload(
-                        clarity,
-                        &boot_code_smart_contract,
-                        &boot_code_account,
-                    )
-                })?;
+                let tx_receipt = clarity_tx.connection().as_transaction(
+                    ClarityVersion::Clarity1,
+                    |clarity| {
+                        StacksChainState::process_transaction_payload(
+                            clarity,
+                            &boot_code_smart_contract,
+                            &boot_code_account,
+                        )
+                    },
+                )?;
                 receipts.push(tx_receipt);
 
                 boot_code_account.nonce += 1;
@@ -1200,9 +1206,11 @@ impl StacksChainState {
                 );
             }
             for (address, amount) in boot_data.initial_balances.iter() {
-                clarity_tx.connection().as_transaction(|clarity| {
-                    StacksChainState::account_genesis_credit(clarity, address, (*amount).into())
-                });
+                clarity_tx
+                    .connection()
+                    .as_transaction(ClarityVersion::Clarity1, |clarity| {
+                        StacksChainState::account_genesis_credit(clarity, address, (*amount).into())
+                    });
                 initial_liquid_ustx = initial_liquid_ustx
                     .checked_add(*amount as u128)
                     .expect("FATAL: liquid STX overflow");
@@ -1215,248 +1223,257 @@ impl StacksChainState {
                 allocation_events.push(mint_event);
             }
 
-            clarity_tx.connection().as_transaction(|clarity| {
-                // Balances
-                if let Some(get_balances) = boot_data.get_bulk_initial_balances.take() {
-                    info!("Importing accounts from Stacks 1.0");
-                    let mut balances_count = 0;
-                    let initial_balances = get_balances();
-                    for balance in initial_balances {
-                        balances_count = balances_count + 1;
-                        let stx_address =
-                            StacksChainState::parse_genesis_address(&balance.address, mainnet);
-                        StacksChainState::account_genesis_credit(
-                            clarity,
-                            &stx_address,
-                            balance.amount.into(),
-                        );
-                        initial_liquid_ustx = initial_liquid_ustx
-                            .checked_add(balance.amount as u128)
-                            .expect("FATAL: liquid STX overflow");
-                        let mint_event = StacksTransactionEvent::STXEvent(
-                            STXEventType::STXMintEvent(STXMintEventData {
-                                recipient: stx_address,
-                                amount: balance.amount.into(),
-                            }),
-                        );
-                        allocation_events.push(mint_event);
-                    }
-                    info!("Seeding {} balances coming from chain dump", balances_count);
-                }
-
-                // Lockups
-                if let Some(get_schedules) = boot_data.get_bulk_initial_lockups.take() {
-                    info!("Initializing chain with lockups");
-                    let mut lockups_per_block: BTreeMap<u64, Vec<Value>> = BTreeMap::new();
-                    let initial_lockups = get_schedules();
-                    for schedule in initial_lockups {
-                        let stx_address =
-                            StacksChainState::parse_genesis_address(&schedule.address, mainnet);
-                        let value = Value::Tuple(
-                            TupleData::from_data(vec![
-                                ("recipient".into(), Value::Principal(stx_address)),
-                                ("amount".into(), Value::UInt(schedule.amount.into())),
-                            ])
-                            .unwrap(),
-                        );
-                        match lockups_per_block.entry(schedule.block_height) {
-                            Entry::Occupied(schedules) => {
-                                schedules.into_mut().push(value);
-                            }
-                            Entry::Vacant(entry) => {
-                                let schedules = vec![value];
-                                entry.insert(schedules);
-                            }
-                        };
+            clarity_tx
+                .connection()
+                .as_transaction(ClarityVersion::Clarity1, |clarity| {
+                    // Balances
+                    if let Some(get_balances) = boot_data.get_bulk_initial_balances.take() {
+                        info!("Importing accounts from Stacks 1.0");
+                        let mut balances_count = 0;
+                        let initial_balances = get_balances();
+                        for balance in initial_balances {
+                            balances_count = balances_count + 1;
+                            let stx_address =
+                                StacksChainState::parse_genesis_address(&balance.address, mainnet);
+                            StacksChainState::account_genesis_credit(
+                                clarity,
+                                &stx_address,
+                                balance.amount.into(),
+                            );
+                            initial_liquid_ustx = initial_liquid_ustx
+                                .checked_add(balance.amount as u128)
+                                .expect("FATAL: liquid STX overflow");
+                            let mint_event = StacksTransactionEvent::STXEvent(
+                                STXEventType::STXMintEvent(STXMintEventData {
+                                    recipient: stx_address,
+                                    amount: balance.amount.into(),
+                                }),
+                            );
+                            allocation_events.push(mint_event);
+                        }
+                        info!("Seeding {} balances coming from chain dump", balances_count);
                     }
 
-                    let lockup_contract_id = boot_code_id("lockup", mainnet);
-                    clarity
-                        .with_clarity_db(|db| {
-                            for (block_height, schedule) in lockups_per_block.into_iter() {
-                                let key = Value::UInt(block_height.into());
-                                let value = Value::list_from(schedule).unwrap();
-                                db.insert_entry_unknown_descriptor(
-                                    &lockup_contract_id,
-                                    "lockups",
-                                    key,
-                                    value,
-                                )?;
-                            }
-                            Ok(())
-                        })
-                        .unwrap();
-                }
+                    // Lockups
+                    if let Some(get_schedules) = boot_data.get_bulk_initial_lockups.take() {
+                        info!("Initializing chain with lockups");
+                        let mut lockups_per_block: BTreeMap<u64, Vec<Value>> = BTreeMap::new();
+                        let initial_lockups = get_schedules();
+                        for schedule in initial_lockups {
+                            let stx_address =
+                                StacksChainState::parse_genesis_address(&schedule.address, mainnet);
+                            let value = Value::Tuple(
+                                TupleData::from_data(vec![
+                                    ("recipient".into(), Value::Principal(stx_address)),
+                                    ("amount".into(), Value::UInt(schedule.amount.into())),
+                                ])
+                                .unwrap(),
+                            );
+                            match lockups_per_block.entry(schedule.block_height) {
+                                Entry::Occupied(schedules) => {
+                                    schedules.into_mut().push(value);
+                                }
+                                Entry::Vacant(entry) => {
+                                    let schedules = vec![value];
+                                    entry.insert(schedules);
+                                }
+                            };
+                        }
 
-                // BNS Namespace
-                let bns_contract_id = boot_code_id("bns", mainnet);
-                if let Some(get_namespaces) = boot_data.get_bulk_initial_namespaces.take() {
-                    info!("Initializing chain with namespaces");
-                    clarity
-                        .with_clarity_db(|db| {
-                            let initial_namespaces = get_namespaces();
-                            for entry in initial_namespaces {
-                                let namespace = {
-                                    if !BNS_CHARS_REGEX.is_match(&entry.namespace_id) {
-                                        panic!("Invalid namespace characters");
-                                    }
-                                    let buffer = entry.namespace_id.as_bytes();
-                                    Value::buff_from(buffer.to_vec()).expect("Invalid namespace")
-                                };
+                        let lockup_contract_id = boot_code_id("lockup", mainnet);
+                        clarity
+                            .with_clarity_db(|db| {
+                                for (block_height, schedule) in lockups_per_block.into_iter() {
+                                    let key = Value::UInt(block_height.into());
+                                    let value = Value::list_from(schedule).unwrap();
+                                    db.insert_entry_unknown_descriptor(
+                                        &lockup_contract_id,
+                                        "lockups",
+                                        key,
+                                        value,
+                                    )?;
+                                }
+                                Ok(())
+                            })
+                            .unwrap();
+                    }
 
-                                let importer = {
-                                    let address = StacksChainState::parse_genesis_address(
-                                        &entry.importer,
+                    // BNS Namespace
+                    let bns_contract_id = boot_code_id("bns", mainnet);
+                    if let Some(get_namespaces) = boot_data.get_bulk_initial_namespaces.take() {
+                        info!("Initializing chain with namespaces");
+                        clarity
+                            .with_clarity_db(|db| {
+                                let initial_namespaces = get_namespaces();
+                                for entry in initial_namespaces {
+                                    let namespace = {
+                                        if !BNS_CHARS_REGEX.is_match(&entry.namespace_id) {
+                                            panic!("Invalid namespace characters");
+                                        }
+                                        let buffer = entry.namespace_id.as_bytes();
+                                        Value::buff_from(buffer.to_vec())
+                                            .expect("Invalid namespace")
+                                    };
+
+                                    let importer = {
+                                        let address = StacksChainState::parse_genesis_address(
+                                            &entry.importer,
+                                            mainnet,
+                                        );
+                                        Value::Principal(address)
+                                    };
+
+                                    let revealed_at = Value::UInt(0);
+                                    let launched_at = Value::UInt(0);
+                                    let lifetime = Value::UInt(entry.lifetime.into());
+                                    let price_function = {
+                                        let base = Value::UInt(entry.base.into());
+                                        let coeff = Value::UInt(entry.coeff.into());
+                                        let nonalpha_discount =
+                                            Value::UInt(entry.nonalpha_discount.into());
+                                        let no_vowel_discount =
+                                            Value::UInt(entry.no_vowel_discount.into());
+                                        let buckets: Vec<_> = entry
+                                            .buckets
+                                            .split(";")
+                                            .map(|e| Value::UInt(e.parse::<u64>().unwrap().into()))
+                                            .collect();
+                                        assert_eq!(buckets.len(), 16);
+
+                                        TupleData::from_data(vec![
+                                            ("buckets".into(), Value::list_from(buckets).unwrap()),
+                                            ("base".into(), base),
+                                            ("coeff".into(), coeff),
+                                            ("nonalpha-discount".into(), nonalpha_discount),
+                                            ("no-vowel-discount".into(), no_vowel_discount),
+                                        ])
+                                        .unwrap()
+                                    };
+
+                                    let namespace_props = Value::Tuple(
+                                        TupleData::from_data(vec![
+                                            ("revealed-at".into(), revealed_at),
+                                            (
+                                                "launched-at".into(),
+                                                Value::some(launched_at).unwrap(),
+                                            ),
+                                            ("lifetime".into(), lifetime),
+                                            ("namespace-import".into(), importer),
+                                            ("can-update-price-function".into(), Value::Bool(true)),
+                                            ("price-function".into(), Value::Tuple(price_function)),
+                                        ])
+                                        .unwrap(),
+                                    );
+
+                                    db.insert_entry_unknown_descriptor(
+                                        &bns_contract_id,
+                                        "namespaces",
+                                        namespace,
+                                        namespace_props,
+                                    )?;
+                                }
+                                Ok(())
+                            })
+                            .unwrap();
+                    }
+
+                    // BNS Names
+                    if let Some(get_names) = boot_data.get_bulk_initial_names.take() {
+                        info!("Initializing chain with names");
+                        clarity
+                            .with_clarity_db(|db| {
+                                let initial_names = get_names();
+                                for entry in initial_names {
+                                    let components: Vec<_> =
+                                        entry.fully_qualified_name.split(".").collect();
+                                    assert_eq!(components.len(), 2);
+
+                                    let namespace = {
+                                        let namespace_str = components[1];
+                                        if !BNS_CHARS_REGEX.is_match(&namespace_str) {
+                                            panic!("Invalid namespace characters");
+                                        }
+                                        let buffer = namespace_str.as_bytes();
+                                        Value::buff_from(buffer.to_vec())
+                                            .expect("Invalid namespace")
+                                    };
+
+                                    let name = {
+                                        let name_str = components[0].to_string();
+                                        if !BNS_CHARS_REGEX.is_match(&name_str) {
+                                            panic!("Invalid name characters");
+                                        }
+                                        let buffer = name_str.as_bytes();
+                                        Value::buff_from(buffer.to_vec()).expect("Invalid name")
+                                    };
+
+                                    let fqn = Value::Tuple(
+                                        TupleData::from_data(vec![
+                                            ("namespace".into(), namespace),
+                                            ("name".into(), name),
+                                        ])
+                                        .unwrap(),
+                                    );
+
+                                    let owner_address = StacksChainState::parse_genesis_address(
+                                        &entry.owner,
                                         mainnet,
                                     );
-                                    Value::Principal(address)
-                                };
 
-                                let revealed_at = Value::UInt(0);
-                                let launched_at = Value::UInt(0);
-                                let lifetime = Value::UInt(entry.lifetime.into());
-                                let price_function = {
-                                    let base = Value::UInt(entry.base.into());
-                                    let coeff = Value::UInt(entry.coeff.into());
-                                    let nonalpha_discount =
-                                        Value::UInt(entry.nonalpha_discount.into());
-                                    let no_vowel_discount =
-                                        Value::UInt(entry.no_vowel_discount.into());
-                                    let buckets: Vec<_> = entry
-                                        .buckets
-                                        .split(";")
-                                        .map(|e| Value::UInt(e.parse::<u64>().unwrap().into()))
-                                        .collect();
-                                    assert_eq!(buckets.len(), 16);
+                                    let zonefile_hash = {
+                                        if entry.zonefile_hash.len() == 0 {
+                                            Value::buff_from(vec![]).unwrap()
+                                        } else {
+                                            let buffer = Hash160::from_hex(&entry.zonefile_hash)
+                                                .expect("Invalid zonefile_hash");
+                                            Value::buff_from(buffer.to_bytes().to_vec()).unwrap()
+                                        }
+                                    };
 
-                                    TupleData::from_data(vec![
-                                        ("buckets".into(), Value::list_from(buckets).unwrap()),
-                                        ("base".into(), base),
-                                        ("coeff".into(), coeff),
-                                        ("nonalpha-discount".into(), nonalpha_discount),
-                                        ("no-vowel-discount".into(), no_vowel_discount),
-                                    ])
-                                    .unwrap()
-                                };
+                                    let expected_asset_type =
+                                        db.get_nft_key_type(&bns_contract_id, "names")?;
+                                    db.set_nft_owner(
+                                        &bns_contract_id,
+                                        "names",
+                                        &fqn,
+                                        &owner_address,
+                                        &expected_asset_type,
+                                    )?;
 
-                                let namespace_props = Value::Tuple(
-                                    TupleData::from_data(vec![
-                                        ("revealed-at".into(), revealed_at),
-                                        ("launched-at".into(), Value::some(launched_at).unwrap()),
-                                        ("lifetime".into(), lifetime),
-                                        ("namespace-import".into(), importer),
-                                        ("can-update-price-function".into(), Value::Bool(true)),
-                                        ("price-function".into(), Value::Tuple(price_function)),
-                                    ])
-                                    .unwrap(),
-                                );
+                                    let registered_at = Value::UInt(0);
+                                    let name_props = Value::Tuple(
+                                        TupleData::from_data(vec![
+                                            (
+                                                "registered-at".into(),
+                                                Value::some(registered_at).unwrap(),
+                                            ),
+                                            ("imported-at".into(), Value::none()),
+                                            ("revoked-at".into(), Value::none()),
+                                            ("zonefile-hash".into(), zonefile_hash),
+                                        ])
+                                        .unwrap(),
+                                    );
 
-                                db.insert_entry_unknown_descriptor(
-                                    &bns_contract_id,
-                                    "namespaces",
-                                    namespace,
-                                    namespace_props,
-                                )?;
-                            }
-                            Ok(())
-                        })
-                        .unwrap();
-                }
+                                    db.insert_entry_unknown_descriptor(
+                                        &bns_contract_id,
+                                        "name-properties",
+                                        fqn.clone(),
+                                        name_props,
+                                    )?;
 
-                // BNS Names
-                if let Some(get_names) = boot_data.get_bulk_initial_names.take() {
-                    info!("Initializing chain with names");
-                    clarity
-                        .with_clarity_db(|db| {
-                            let initial_names = get_names();
-                            for entry in initial_names {
-                                let components: Vec<_> =
-                                    entry.fully_qualified_name.split(".").collect();
-                                assert_eq!(components.len(), 2);
-
-                                let namespace = {
-                                    let namespace_str = components[1];
-                                    if !BNS_CHARS_REGEX.is_match(&namespace_str) {
-                                        panic!("Invalid namespace characters");
-                                    }
-                                    let buffer = namespace_str.as_bytes();
-                                    Value::buff_from(buffer.to_vec()).expect("Invalid namespace")
-                                };
-
-                                let name = {
-                                    let name_str = components[0].to_string();
-                                    if !BNS_CHARS_REGEX.is_match(&name_str) {
-                                        panic!("Invalid name characters");
-                                    }
-                                    let buffer = name_str.as_bytes();
-                                    Value::buff_from(buffer.to_vec()).expect("Invalid name")
-                                };
-
-                                let fqn = Value::Tuple(
-                                    TupleData::from_data(vec![
-                                        ("namespace".into(), namespace),
-                                        ("name".into(), name),
-                                    ])
-                                    .unwrap(),
-                                );
-
-                                let owner_address =
-                                    StacksChainState::parse_genesis_address(&entry.owner, mainnet);
-
-                                let zonefile_hash = {
-                                    if entry.zonefile_hash.len() == 0 {
-                                        Value::buff_from(vec![]).unwrap()
-                                    } else {
-                                        let buffer = Hash160::from_hex(&entry.zonefile_hash)
-                                            .expect("Invalid zonefile_hash");
-                                        Value::buff_from(buffer.to_bytes().to_vec()).unwrap()
-                                    }
-                                };
-
-                                let expected_asset_type =
-                                    db.get_nft_key_type(&bns_contract_id, "names")?;
-                                db.set_nft_owner(
-                                    &bns_contract_id,
-                                    "names",
-                                    &fqn,
-                                    &owner_address,
-                                    &expected_asset_type,
-                                )?;
-
-                                let registered_at = Value::UInt(0);
-                                let name_props = Value::Tuple(
-                                    TupleData::from_data(vec![
-                                        (
-                                            "registered-at".into(),
-                                            Value::some(registered_at).unwrap(),
-                                        ),
-                                        ("imported-at".into(), Value::none()),
-                                        ("revoked-at".into(), Value::none()),
-                                        ("zonefile-hash".into(), zonefile_hash),
-                                    ])
-                                    .unwrap(),
-                                );
-
-                                db.insert_entry_unknown_descriptor(
-                                    &bns_contract_id,
-                                    "name-properties",
-                                    fqn.clone(),
-                                    name_props,
-                                )?;
-
-                                db.insert_entry_unknown_descriptor(
-                                    &bns_contract_id,
-                                    "owner-name",
-                                    Value::Principal(owner_address),
-                                    fqn,
-                                )?;
-                            }
-                            Ok(())
-                        })
-                        .unwrap();
-                }
-                info!("Saving Genesis block. This could take a while");
-            });
+                                    db.insert_entry_unknown_descriptor(
+                                        &bns_contract_id,
+                                        "owner-name",
+                                        Value::Principal(owner_address),
+                                        fqn,
+                                    )?;
+                                }
+                                Ok(())
+                            })
+                            .unwrap();
+                    }
+                    info!("Saving Genesis block. This could take a while");
+                });
 
             let allocations_tx = StacksTransaction::new(
                 tx_version.clone(),
@@ -1489,21 +1506,23 @@ impl StacksChainState {
                 Value::UInt(pox_constants.reward_cycle_length as u128),
                 Value::UInt(pox_constants.pox_rejection_fraction as u128),
             ];
-            clarity_tx.connection().as_transaction(|conn| {
-                conn.run_contract_call(
-                    &sender,
-                    None,
-                    &contract,
-                    "set-burnchain-parameters",
-                    &params,
-                    |_, _| false,
-                )
-                .expect("Failed to set burnchain parameters in PoX contract");
-            });
+            clarity_tx
+                .connection()
+                .as_transaction(ClarityVersion::Clarity1, |conn| {
+                    conn.run_contract_call(
+                        &sender,
+                        None,
+                        &contract,
+                        "set-burnchain-parameters",
+                        &params,
+                        |_, _| false,
+                    )
+                    .expect("Failed to set burnchain parameters in PoX contract");
+                });
 
             clarity_tx
                 .connection()
-                .as_transaction(|tx| {
+                .as_transaction(ClarityVersion::Clarity1, |tx| {
                     tx.with_clarity_db(|db| {
                         db.increment_ustx_liquid_supply(initial_liquid_ustx)
                             .map_err(|e| e.into())
@@ -2143,7 +2162,7 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         clarity_tx
             .connection()
-            .as_transaction(|tx| {
+            .as_transaction(ClarityVersion::Clarity1, |tx| {
                 tx.with_clarity_db(|ref mut db| {
                     db.insert_microblock_pubkey_hash_height(mblock_pubkey_hash, height)
                         .expect("FATAL: failed to store microblock public key hash to Clarity DB");

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -667,7 +667,7 @@ impl<'a> StacksMicroblockBuilder<'a> {
                             ));
                         }
                     }
-                    TransactionPayload::SmartContract(_) => {
+                    TransactionPayload::SmartContract(..) => {
                         return Ok(TransactionResult::skipped(
                             &tx,
                             "BlockLimitFunction::CONTRACT_LIMIT_HIT".to_string(),
@@ -1257,7 +1257,7 @@ impl StacksBlockBuilder {
                             );
                         }
                     }
-                    TransactionPayload::SmartContract(_) => {
+                    TransactionPayload::SmartContract(..) => {
                         return TransactionResult::skipped(
                             &tx,
                             "BlockLimitFunction::CONTRACT_LIMIT_HIT".to_string(),

--- a/src/chainstate/stacks/tests/accounting.rs
+++ b/src/chainstate/stacks/tests/accounting.rs
@@ -1039,6 +1039,7 @@ fn test_get_block_info_v210() {
                     let list_val = clarity_tx.with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity2,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1341,6 +1342,7 @@ fn test_get_block_info_v210_no_microblocks() {
                     let list_val = clarity_tx.with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity2,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1807,6 +1809,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
                     let list_val = clarity_tx.with_readonly_clarity_env(
                         false,
                         CHAIN_ID_TESTNET,
+                        ClarityVersion::Clarity2,
                         PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                         None,
                         LimitedCostTracker::new_free(),
@@ -1837,6 +1840,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
                         let miner_val = clarity_tx.with_readonly_clarity_env(
                             false,
                             CHAIN_ID_TESTNET,
+                            ClarityVersion::Clarity2,
                             PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                             None,
                             LimitedCostTracker::new_free(),
@@ -1912,6 +1916,7 @@ fn test_coinbase_pay_to_alt_recipient_v210(pay_to_contract: bool) {
                 .with_readonly_clarity_env(
                     false,
                     CHAIN_ID_TESTNET,
+                    ClarityVersion::Clarity2,
                     PrincipalData::parse("SP3Q4A5WWZ80REGBN0ZXNE540ECJ9JZ4A765Q5K2Q").unwrap(),
                     None,
                     LimitedCostTracker::new_free(),

--- a/src/chainstate/stacks/tests/block_construction.rs
+++ b/src/chainstate/stacks/tests/block_construction.rs
@@ -3244,7 +3244,7 @@ fn test_contract_call_across_clarity_versions() {
             start_height: 1,
             end_height: 2, // NOTE: the first 25 burnchain blocks have no sortition
             block_limit: ExecutionCost::max_value(),
-            network_epoch: PEER_VERSION_EPOCH_2_0,
+            network_epoch: PEER_VERSION_EPOCH_2_05,
         },
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -826,7 +826,12 @@ fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) 
                     DEFAULT_CLI_EPOCH,
                 );
                 vm_env
-                    .initialize_contract(contract_identifier, &contract_content, None)
+                    .initialize_versioned_contract(
+                        contract_identifier,
+                        ClarityVersion::Clarity2,
+                        &contract_content,
+                        None,
+                    )
                     .unwrap();
             }
             Err(_) => {
@@ -1520,8 +1525,9 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                         Ok(analysis) => {
                             let result_and_cost =
                                 with_env_costs(mainnet, &header_db, &mut marf, |vm_env| {
-                                    vm_env.initialize_contract(
+                                    vm_env.initialize_versioned_contract(
                                         contract_identifier,
+                                        ClarityVersion::Clarity2,
                                         &contract_content,
                                         None,
                                     )

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -144,7 +144,7 @@ fn friendly_expect_opt<A>(input: Option<A>, msg: &str) -> A {
     })
 }
 
-pub const DEFAULT_CLI_EPOCH: StacksEpochId = StacksEpochId::Epoch2_05;
+pub const DEFAULT_CLI_EPOCH: StacksEpochId = StacksEpochId::Epoch21;
 
 struct EvalInput {
     marf_kv: MarfedKV,
@@ -428,6 +428,7 @@ where
         db,
         cost_track,
         DEFAULT_CLI_EPOCH,
+        ClarityVersion::Clarity2,
     );
     let result = f(&mut vm_env);
     let cost = vm_env.get_cost_total();
@@ -811,6 +812,7 @@ fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) 
                     default_chain_id(mainnet),
                     db,
                     DEFAULT_CLI_EPOCH,
+                    ClarityVersion::Clarity2,
                 );
                 vm_env
                     .initialize_contract(contract_identifier, &contract_content, None)
@@ -839,8 +841,13 @@ fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) 
     ];
 
     let db = marf.get_clarity_db(header_db, &NULL_BURN_STATE_DB);
-    let mut vm_env =
-        OwnedEnvironment::new_free(mainnet, default_chain_id(mainnet), db, DEFAULT_CLI_EPOCH);
+    let mut vm_env = OwnedEnvironment::new_free(
+        mainnet,
+        default_chain_id(mainnet),
+        db,
+        DEFAULT_CLI_EPOCH,
+        ClarityVersion::Clarity2,
+    );
     vm_env
         .execute_transaction(
             sender,
@@ -1140,6 +1147,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                 default_chain_id(mainnet),
                 marf.as_clarity_db(),
                 DEFAULT_CLI_EPOCH,
+                ClarityVersion::Clarity2,
             );
             let mut exec_env = vm_env.get_exec_environment(None, None);
             let mut analysis_marf = MemoryBackingStore::new();
@@ -1210,6 +1218,7 @@ pub fn invoke_command(invoked_by: &str, args: &[String]) -> (i32, Option<serde_j
                 default_chain_id(true),
                 marf.as_clarity_db(),
                 DEFAULT_CLI_EPOCH,
+                ClarityVersion::Clarity2,
             );
 
             let contract_id = QualifiedContractIdentifier::transient();

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1409,7 +1409,7 @@ mod tests {
 
                 let contract = "(define-public (foo (x int) (y int)) (ok (+ x y)))";
 
-                let (ct_ast, ct_analysis) = tx
+                let (ct_ast, _ct_analysis) = tx
                     .analyze_smart_contract(
                         &contract_identifier,
                         ClarityVersion::Clarity1,

--- a/src/clarity_vm/tests/analysis_costs.rs
+++ b/src/clarity_vm/tests/analysis_costs.rs
@@ -132,12 +132,13 @@ pub fn test_tracked_costs(
             epoch
         );
 
-        conn.as_transaction(version, |conn| {
+        conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
-                .analyze_smart_contract(&trait_contract_id, contract_trait)
+                .analyze_smart_contract(&trait_contract_id, version, contract_trait)
                 .unwrap();
             conn.initialize_smart_contract(
                 &trait_contract_id,
+                version,
                 &ct_ast,
                 contract_trait,
                 None,
@@ -159,12 +160,13 @@ pub fn test_tracked_costs(
             &burn_state_db,
         );
 
-        conn.as_transaction(version, |conn| {
+        conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
-                .analyze_smart_contract(&other_contract_id, contract_other)
+                .analyze_smart_contract(&other_contract_id, version, contract_other)
                 .unwrap();
             conn.initialize_smart_contract(
                 &other_contract_id,
+                version,
                 &ct_ast,
                 contract_other,
                 None,
@@ -186,12 +188,13 @@ pub fn test_tracked_costs(
             &burn_state_db,
         );
 
-        conn.as_transaction(version, |conn| {
+        conn.as_transaction(|conn| {
             let (ct_ast, ct_analysis) = conn
-                .analyze_smart_contract(&self_contract_id, &contract_self)
+                .analyze_smart_contract(&self_contract_id, version, &contract_self)
                 .unwrap();
             conn.initialize_smart_contract(
                 &self_contract_id,
+                version,
                 &ct_ast,
                 &contract_self,
                 None,

--- a/src/clarity_vm/tests/analysis_costs.rs
+++ b/src/clarity_vm/tests/analysis_costs.rs
@@ -209,6 +209,10 @@ fn epoch_21_test_all(use_mainnet: bool, version: ClarityVersion) {
     let baseline = test_tracked_costs("1", use_mainnet, StacksEpochId::Epoch21, version);
 
     for f in NativeFunctions::ALL.iter() {
+        if version < f.get_version() {
+            continue;
+        }
+
         let test = get_simple_test(f);
         let cost = test_tracked_costs(test, use_mainnet, StacksEpochId::Epoch21, version);
         assert!(cost.exceeds(&baseline));
@@ -227,13 +231,23 @@ fn epoch_21_test_all_testnet() {
     epoch_21_test_all(false, ClarityVersion::Clarity2);
 }
 
-fn epoch_205_test_all(use_mainnet: bool, version: ClarityVersion) {
-    let baseline = test_tracked_costs("1", use_mainnet, StacksEpochId::Epoch2_05, version);
+fn epoch_205_test_all(use_mainnet: bool) {
+    let baseline = test_tracked_costs(
+        "1",
+        use_mainnet,
+        StacksEpochId::Epoch2_05,
+        ClarityVersion::Clarity1,
+    );
 
     for f in NativeFunctions::ALL.iter() {
         if f.get_version() == ClarityVersion::Clarity1 {
             let test = get_simple_test(f);
-            let cost = test_tracked_costs(test, use_mainnet, StacksEpochId::Epoch2_05, version);
+            let cost = test_tracked_costs(
+                test,
+                use_mainnet,
+                StacksEpochId::Epoch2_05,
+                ClarityVersion::Clarity1,
+            );
             assert!(cost.exceeds(&baseline));
         }
     }
@@ -241,12 +255,10 @@ fn epoch_205_test_all(use_mainnet: bool, version: ClarityVersion) {
 
 #[test]
 fn epoch_205_test_all_mainnet() {
-    epoch_205_test_all(true, ClarityVersion::Clarity1);
-    epoch_205_test_all(true, ClarityVersion::Clarity2);
+    epoch_205_test_all(true);
 }
 
 #[test]
 fn epoch_205_test_all_testnet() {
-    epoch_205_test_all(false, ClarityVersion::Clarity1);
-    epoch_205_test_all(false, ClarityVersion::Clarity2);
+    epoch_205_test_all(false);
 }

--- a/src/clarity_vm/tests/contracts.rs
+++ b/src/clarity_vm/tests/contracts.rs
@@ -54,6 +54,7 @@ use clarity::vm::Value::Sequence;
 use clarity::vm::database::MemoryBackingStore;
 
 use crate::chainstate::stacks::boot::contract_tests::{test_sim_height_to_hash, ClarityTestSim};
+use crate::clarity::vm::clarity::ClarityConnection;
 use crate::clarity::vm::clarity::TransactionConnection;
 
 #[test]
@@ -69,8 +70,11 @@ fn test_get_burn_block_info_eval() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-1").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-burn-block-info? header-hash height))";
-        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
-            let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
+        let epoch = conn.get_epoch();
+        conn.as_transaction(|clarity_db| {
+            let clarity_version = ClarityVersion::default_for_epoch(epoch);
+            let res =
+                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::UnknownFunction(func_name) = check_error.err {
                     assert_eq!(func_name, "get-burn-block-info?");
@@ -87,8 +91,11 @@ fn test_get_burn_block_info_eval() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-2").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-burn-block-info? header-hash height))";
-        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
-            let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
+        let epoch = conn.get_epoch();
+        conn.as_transaction(|clarity_db| {
+            let clarity_version = ClarityVersion::default_for_epoch(epoch);
+            let res =
+                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::UnknownFunction(func_name) = check_error.err {
                     assert_eq!(func_name, "get-burn-block-info?");
@@ -105,18 +112,27 @@ fn test_get_burn_block_info_eval() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-3").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-burn-block-info? header-hash height))";
-        conn.as_transaction(ClarityVersion::Clarity2, |clarity_db| {
+        let epoch = conn.get_epoch();
+        conn.as_transaction(|clarity_db| {
+            let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_identifier, contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, contract)
                 .unwrap();
             clarity_db
-                .initialize_smart_contract(&contract_identifier, &ast, contract, None, |_, _| false)
+                .initialize_smart_contract(
+                    &contract_identifier,
+                    clarity_version,
+                    &ast,
+                    contract,
+                    None,
+                    |_, _| false,
+                )
                 .unwrap();
         });
         // This relies on `TestSimBurnStateDB::get_burn_header_hash'
         // * burnchain is 100 blocks ahead of stacks
         // * sortition IDs, consensus hashes, and block hashes encode height and fork ID
-        let mut tx = conn.start_transaction_processing(ClarityVersion::Clarity2);
+        let mut tx = conn.start_transaction_processing();
         assert_eq!(
             Value::Optional(OptionalData {
                 data: Some(Box::new(Sequence(Buffer(BuffData {
@@ -166,8 +182,11 @@ fn test_get_block_info_eval_v210() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-1").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-block-info? block-reward height))";
-        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
-            let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
+        let epoch = conn.get_epoch();
+        conn.as_transaction(|clarity_db| {
+            let clarity_version = ClarityVersion::default_for_epoch(epoch);
+            let res =
+                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::NoSuchBlockInfoProperty(name) = check_error.err {
                     assert_eq!(name, "block-reward");
@@ -184,8 +203,11 @@ fn test_get_block_info_eval_v210() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-2").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-block-info? block-reward height))";
-        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
-            let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
+        let epoch = conn.get_epoch();
+        conn.as_transaction(|clarity_db| {
+            let clarity_version = ClarityVersion::default_for_epoch(epoch);
+            let res =
+                clarity_db.analyze_smart_contract(&contract_identifier, clarity_version, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::NoSuchBlockInfoProperty(name) = check_error.err {
                     assert_eq!(name, "block-reward");
@@ -204,15 +226,17 @@ fn test_get_block_info_eval_v210() {
             "(define-private (test-func-1 (height uint)) (get-block-info? block-reward height)) 
              (define-private (test-func-2 (height uint)) (get-block-info? miner-spend-winner height))
              (define-private (test-func-3 (height uint)) (get-block-info? miner-spend-total height))";
-        conn.as_transaction(ClarityVersion::Clarity2, |clarity_db| {
+        let epoch = conn.get_epoch();
+        conn.as_transaction(|clarity_db| {
+            let clarity_version = ClarityVersion::default_for_epoch(epoch);
             let (ast, analysis) = clarity_db
-                .analyze_smart_contract(&contract_identifier, contract)
+                .analyze_smart_contract(&contract_identifier, clarity_version, contract)
                 .unwrap();
             clarity_db
-                .initialize_smart_contract(&contract_identifier, &ast, contract, None, |_, _| false)
+                .initialize_smart_contract(&contract_identifier, clarity_version, &ast, contract, None, |_, _| false)
                 .unwrap();
         });
-        let mut tx = conn.start_transaction_processing(ClarityVersion::Clarity2);
+        let mut tx = conn.start_transaction_processing();
         // no values for the genesis block
         assert_eq!(
             Value::none(),

--- a/src/clarity_vm/tests/contracts.rs
+++ b/src/clarity_vm/tests/contracts.rs
@@ -69,7 +69,7 @@ fn test_get_burn_block_info_eval() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-1").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-burn-block-info? header-hash height))";
-        conn.as_transaction(|clarity_db| {
+        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
             let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::UnknownFunction(func_name) = check_error.err {
@@ -87,7 +87,7 @@ fn test_get_burn_block_info_eval() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-2").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-burn-block-info? header-hash height))";
-        conn.as_transaction(|clarity_db| {
+        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
             let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::UnknownFunction(func_name) = check_error.err {
@@ -105,8 +105,8 @@ fn test_get_burn_block_info_eval() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-3").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-burn-block-info? header-hash height))";
-        conn.as_transaction(|clarity_db| {
-            let (ast, _) = clarity_db
+        conn.as_transaction(ClarityVersion::Clarity2, |clarity_db| {
+            let (ast, analysis) = clarity_db
                 .analyze_smart_contract(&contract_identifier, contract)
                 .unwrap();
             clarity_db
@@ -116,7 +116,7 @@ fn test_get_burn_block_info_eval() {
         // This relies on `TestSimBurnStateDB::get_burn_header_hash'
         // * burnchain is 100 blocks ahead of stacks
         // * sortition IDs, consensus hashes, and block hashes encode height and fork ID
-        let mut tx = conn.start_transaction_processing();
+        let mut tx = conn.start_transaction_processing(ClarityVersion::Clarity2);
         assert_eq!(
             Value::Optional(OptionalData {
                 data: Some(Box::new(Sequence(Buffer(BuffData {
@@ -166,7 +166,7 @@ fn test_get_block_info_eval_v210() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-1").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-block-info? block-reward height))";
-        conn.as_transaction(|clarity_db| {
+        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
             let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::NoSuchBlockInfoProperty(name) = check_error.err {
@@ -184,7 +184,7 @@ fn test_get_block_info_eval_v210() {
         let contract_identifier = QualifiedContractIdentifier::local("test-contract-2").unwrap();
         let contract =
             "(define-private (test-func (height uint)) (get-block-info? block-reward height))";
-        conn.as_transaction(|clarity_db| {
+        conn.as_transaction(ClarityVersion::Clarity1, |clarity_db| {
             let res = clarity_db.analyze_smart_contract(&contract_identifier, contract);
             if let Err(ClarityError::Analysis(check_error)) = res {
                 if let CheckErrors::NoSuchBlockInfoProperty(name) = check_error.err {
@@ -204,15 +204,15 @@ fn test_get_block_info_eval_v210() {
             "(define-private (test-func-1 (height uint)) (get-block-info? block-reward height)) 
              (define-private (test-func-2 (height uint)) (get-block-info? miner-spend-winner height))
              (define-private (test-func-3 (height uint)) (get-block-info? miner-spend-total height))";
-        conn.as_transaction(|clarity_db| {
-            let (ast, _) = clarity_db
+        conn.as_transaction(ClarityVersion::Clarity2, |clarity_db| {
+            let (ast, analysis) = clarity_db
                 .analyze_smart_contract(&contract_identifier, contract)
                 .unwrap();
             clarity_db
                 .initialize_smart_contract(&contract_identifier, &ast, contract, None, |_, _| false)
                 .unwrap();
         });
-        let mut tx = conn.start_transaction_processing();
+        let mut tx = conn.start_transaction_processing(ClarityVersion::Clarity2);
         // no values for the genesis block
         assert_eq!(
             Value::none(),

--- a/src/clarity_vm/tests/costs.rs
+++ b/src/clarity_vm/tests/costs.rs
@@ -956,7 +956,7 @@ fn epoch_21_test_all_testnet() {
     epoch_21_test_all(false)
 }
 
-fn test_cost_contract_short_circuits(use_mainnet: bool) {
+fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: ClarityVersion) {
     let marf_kv = MarfedKV::temporary();
     let chain_id = test_only_mainnet_to_chain_id(use_mainnet);
     let mut clarity_instance = ClarityInstance::new(use_mainnet, chain_id, marf_kv);
@@ -1024,7 +1024,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool) {
         ]
         .iter()
         {
-            block_conn.as_transaction(|tx| {
+            block_conn.as_transaction(clarity_version, |tx| {
                 let (ast, analysis) = tx
                     .analyze_smart_contract(contract_name, contract_src)
                     .unwrap();
@@ -1174,15 +1174,17 @@ fn test_cost_contract_short_circuits(use_mainnet: bool) {
 
 #[test]
 fn test_cost_contract_short_circuits_mainnet() {
-    test_cost_contract_short_circuits(true)
+    test_cost_contract_short_circuits(true, ClarityVersion::Clarity1);
+    test_cost_contract_short_circuits(true, ClarityVersion::Clarity2);
 }
 
 #[test]
 fn test_cost_contract_short_circuits_testnet() {
-    test_cost_contract_short_circuits(false)
+    test_cost_contract_short_circuits(false, ClarityVersion::Clarity1);
+    test_cost_contract_short_circuits(false, ClarityVersion::Clarity2);
 }
 
-fn test_cost_voting_integration(use_mainnet: bool) {
+fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersion) {
     let marf_kv = MarfedKV::temporary();
     let chain_id = test_only_mainnet_to_chain_id(use_mainnet);
     let mut clarity_instance = ClarityInstance::new(use_mainnet, chain_id, marf_kv);
@@ -1287,7 +1289,7 @@ fn test_cost_voting_integration(use_mainnet: bool) {
         ]
         .iter()
         {
-            block_conn.as_transaction(|tx| {
+            block_conn.as_transaction(clarity_version, |tx| {
                 let (ast, analysis) = tx
                     .analyze_smart_contract(contract_name, contract_src)
                     .unwrap();
@@ -1579,5 +1581,6 @@ fn test_cost_voting_integration(use_mainnet: bool) {
 
 #[test]
 fn test_cost_voting_integration_testnet() {
-    test_cost_voting_integration(false)
+    test_cost_voting_integration(false, ClarityVersion::Clarity1);
+    test_cost_voting_integration(false, ClarityVersion::Clarity2);
 }

--- a/src/clarity_vm/tests/costs.rs
+++ b/src/clarity_vm/tests/costs.rs
@@ -35,7 +35,8 @@ use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::functions::NativeFunctions;
 use clarity::vm::representations::SymbolicExpression;
 use clarity::vm::test_util::{
-    execute, execute_on_network, symbols_from_values, TEST_BURN_STATE_DB, TEST_HEADER_DB,
+    execute, execute_on_network, symbols_from_values, TEST_BURN_STATE_DB, TEST_BURN_STATE_DB_21,
+    TEST_HEADER_DB,
 };
 use clarity::vm::types::{
     AssetIdentifier, OptionalData, PrincipalData, QualifiedContractIdentifier, ResponseData, Value,
@@ -960,12 +961,18 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
     let marf_kv = MarfedKV::temporary();
     let chain_id = test_only_mainnet_to_chain_id(use_mainnet);
     let mut clarity_instance = ClarityInstance::new(use_mainnet, chain_id, marf_kv);
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
+
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
             &StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -994,7 +1001,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
             &StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let cost_definer_src = "
@@ -1041,7 +1048,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
     let without_interposing_5 = {
         let mut store = marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+            store.as_clarity_db(&TEST_HEADER_DB, burn_db),
             StacksEpochId::Epoch20,
             use_mainnet,
         );
@@ -1064,7 +1071,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
     let without_interposing_10 = {
         let mut store = marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([3 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+            store.as_clarity_db(&TEST_HEADER_DB, burn_db),
             StacksEpochId::Epoch20,
             use_mainnet,
         );
@@ -1092,7 +1099,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
 
     {
         let mut store = marf_kv.begin(&StacksBlockId([3 as u8; 32]), &StacksBlockId([4 as u8; 32]));
-        let mut db = store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+        let mut db = store.as_clarity_db(&TEST_HEADER_DB, burn_db);
         db.begin();
         db.set_variable_unknown_descriptor(
             voting_contract_to_use,
@@ -1123,7 +1130,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
         let mut store = marf_kv.begin(&StacksBlockId([4 as u8; 32]), &StacksBlockId([5 as u8; 32]));
 
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+            store.as_clarity_db(&TEST_HEADER_DB, burn_db),
             StacksEpochId::Epoch20,
             use_mainnet,
         );
@@ -1146,7 +1153,7 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
     let with_interposing_10 = {
         let mut store = marf_kv.begin(&StacksBlockId([5 as u8; 32]), &StacksBlockId([6 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+            store.as_clarity_db(&TEST_HEADER_DB, burn_db),
             StacksEpochId::Epoch20,
             use_mainnet,
         );
@@ -1188,12 +1195,18 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
     let marf_kv = MarfedKV::temporary();
     let chain_id = test_only_mainnet_to_chain_id(use_mainnet);
     let mut clarity_instance = ClarityInstance::new(use_mainnet, chain_id, marf_kv);
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
+
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
             &StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -1226,7 +1239,7 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
             &StacksBlockId::new(&FIRST_BURNCHAIN_CONSENSUS_HASH, &FIRST_STACKS_BLOCK_HASH),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let cost_definer_src = "
@@ -1383,7 +1396,7 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
     {
         let mut store = marf_kv.begin(&StacksBlockId([1 as u8; 32]), &StacksBlockId([2 as u8; 32]));
 
-        let mut db = store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+        let mut db = store.as_clarity_db(&TEST_HEADER_DB, burn_db);
         db.begin();
 
         db.set_variable_unknown_descriptor(
@@ -1419,7 +1432,7 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
     let le_cost_without_interception = {
         let mut store = marf_kv.begin(&StacksBlockId([2 as u8; 32]), &StacksBlockId([3 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+            store.as_clarity_db(&TEST_HEADER_DB, burn_db),
             StacksEpochId::Epoch20,
             use_mainnet,
         );
@@ -1480,7 +1493,7 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
     {
         let mut store = marf_kv.begin(&StacksBlockId([3 as u8; 32]), &StacksBlockId([4 as u8; 32]));
 
-        let mut db = store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB);
+        let mut db = store.as_clarity_db(&TEST_HEADER_DB, burn_db);
         db.begin();
 
         let good_proposals = good_cases.len() as u128;
@@ -1518,7 +1531,7 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
     {
         let mut store = marf_kv.begin(&StacksBlockId([4 as u8; 32]), &StacksBlockId([5 as u8; 32]));
         let mut owned_env = OwnedEnvironment::new_max_limit(
-            store.as_clarity_db(&TEST_HEADER_DB, &TEST_BURN_STATE_DB),
+            store.as_clarity_db(&TEST_HEADER_DB, burn_db),
             StacksEpochId::Epoch20,
             use_mainnet,
         );

--- a/src/clarity_vm/tests/costs.rs
+++ b/src/clarity_vm/tests/costs.rs
@@ -1031,12 +1031,19 @@ fn test_cost_contract_short_circuits(use_mainnet: bool, clarity_version: Clarity
         ]
         .iter()
         {
-            block_conn.as_transaction(clarity_version, |tx| {
+            block_conn.as_transaction(|tx| {
                 let (ast, analysis) = tx
-                    .analyze_smart_contract(contract_name, contract_src)
+                    .analyze_smart_contract(contract_name, clarity_version, contract_src)
                     .unwrap();
-                tx.initialize_smart_contract(contract_name, &ast, contract_src, None, |_, _| false)
-                    .unwrap();
+                tx.initialize_smart_contract(
+                    contract_name,
+                    clarity_version,
+                    &ast,
+                    contract_src,
+                    None,
+                    |_, _| false,
+                )
+                .unwrap();
                 tx.save_analysis(contract_name, &analysis).unwrap();
             });
         }
@@ -1302,12 +1309,19 @@ fn test_cost_voting_integration(use_mainnet: bool, clarity_version: ClarityVersi
         ]
         .iter()
         {
-            block_conn.as_transaction(clarity_version, |tx| {
+            block_conn.as_transaction(|tx| {
                 let (ast, analysis) = tx
-                    .analyze_smart_contract(contract_name, contract_src)
+                    .analyze_smart_contract(contract_name, clarity_version, contract_src)
                     .unwrap();
-                tx.initialize_smart_contract(contract_name, &ast, contract_src, None, |_, _| false)
-                    .unwrap();
+                tx.initialize_smart_contract(
+                    contract_name,
+                    clarity_version,
+                    &ast,
+                    contract_src,
+                    None,
+                    |_, _| false,
+                )
+                .unwrap();
                 tx.save_analysis(contract_name, &analysis).unwrap();
             });
         }

--- a/src/clarity_vm/tests/costs.rs
+++ b/src/clarity_vm/tests/costs.rs
@@ -816,7 +816,12 @@ fn epoch205_nfts_testnet() {
     epoch205_nfts(false)
 }
 
-fn test_tracked_costs(prog: &str, use_mainnet: bool, epoch: StacksEpochId) -> ExecutionCost {
+fn test_tracked_costs(
+    prog: &str,
+    use_mainnet: bool,
+    epoch: StacksEpochId,
+    version: ClarityVersion,
+) -> ExecutionCost {
     let contract_trait = "(define-trait trait-1 (
                             (foo-exec (int) (response int int))
                           ))";
@@ -858,13 +863,13 @@ fn test_tracked_costs(prog: &str, use_mainnet: bool, epoch: StacksEpochId) -> Ex
 
     with_owned_env(epoch, use_mainnet, |mut owned_env| {
         owned_env
-            .initialize_contract(trait_contract_id.clone(), contract_trait, None)
+            .initialize_versioned_contract(trait_contract_id.clone(), version, contract_trait, None)
             .unwrap();
         owned_env
-            .initialize_contract(other_contract_id.clone(), contract_other, None)
+            .initialize_versioned_contract(other_contract_id.clone(), version, contract_other, None)
             .unwrap();
         owned_env
-            .initialize_contract(self_contract_id.clone(), &contract_self, None)
+            .initialize_versioned_contract(self_contract_id.clone(), version, &contract_self, None)
             .unwrap();
 
         let target_contract = Value::from(PrincipalData::Contract(other_contract_id.clone()));
@@ -887,13 +892,23 @@ fn test_tracked_costs(prog: &str, use_mainnet: bool, epoch: StacksEpochId) -> Ex
 // test each individual cost function can be correctly invoked as
 //  Clarity code executes in Epoch 2.00
 fn epoch_20_test_all(use_mainnet: bool) {
-    let baseline = test_tracked_costs("1", use_mainnet, StacksEpochId::Epoch20);
+    let baseline = test_tracked_costs(
+        "1",
+        use_mainnet,
+        StacksEpochId::Epoch20,
+        ClarityVersion::Clarity1,
+    );
 
     for f in NativeFunctions::ALL.iter() {
         // Note: The 2.05 test assumes Clarity1.
         if f.get_version() == ClarityVersion::Clarity1 {
             let test = get_simple_test(f);
-            let cost = test_tracked_costs(test, use_mainnet, StacksEpochId::Epoch20);
+            let cost = test_tracked_costs(
+                test,
+                use_mainnet,
+                StacksEpochId::Epoch20,
+                ClarityVersion::Clarity1,
+            );
             assert!(cost.exceeds(&baseline));
         }
     }
@@ -912,13 +927,23 @@ fn epoch_20_test_all_testnet() {
 // test each individual cost function can be correctly invoked as
 //  Clarity code executes in Epoch 2.05
 fn epoch_205_test_all(use_mainnet: bool) {
-    let baseline = test_tracked_costs("1", use_mainnet, StacksEpochId::Epoch2_05);
+    let baseline = test_tracked_costs(
+        "1",
+        use_mainnet,
+        StacksEpochId::Epoch2_05,
+        ClarityVersion::Clarity1,
+    );
 
     for f in NativeFunctions::ALL.iter() {
         // Note: The 2.05 test assumes Clarity1.
         if f.get_version() == ClarityVersion::Clarity1 {
             let test = get_simple_test(f);
-            let cost = test_tracked_costs(test, use_mainnet, StacksEpochId::Epoch2_05);
+            let cost = test_tracked_costs(
+                test,
+                use_mainnet,
+                StacksEpochId::Epoch2_05,
+                ClarityVersion::Clarity1,
+            );
             assert!(cost.exceeds(&baseline));
         }
     }
@@ -935,14 +960,24 @@ fn epoch_205_test_all_testnet() {
 }
 
 // test each individual cost function can be correctly invoked as
-//  Clarity code executes in Epoch 2.05
+//  Clarity code executes in Epoch 2.1
 fn epoch_21_test_all(use_mainnet: bool) {
-    let baseline = test_tracked_costs("1", use_mainnet, StacksEpochId::Epoch21);
+    let baseline = test_tracked_costs(
+        "1",
+        use_mainnet,
+        StacksEpochId::Epoch21,
+        ClarityVersion::Clarity2,
+    );
 
     for f in NativeFunctions::ALL.iter() {
         // Note: Include Clarity2 functions for Epoch21.
         let test = get_simple_test(f);
-        let cost = test_tracked_costs(test, use_mainnet, StacksEpochId::Epoch21);
+        let cost = test_tracked_costs(
+            test,
+            use_mainnet,
+            StacksEpochId::Epoch21,
+            ClarityVersion::Clarity2,
+        );
         assert!(cost.exceeds(&baseline));
     }
 }

--- a/src/clarity_vm/tests/events.rs
+++ b/src/clarity_vm/tests/events.rs
@@ -33,6 +33,7 @@ use stacks_common::types::StacksEpochId;
 use crate::vm::database::MemoryBackingStore;
 
 use clarity::vm::tests::test_only_mainnet_to_chain_id;
+use clarity::vm::ClarityVersion;
 
 fn helper_execute(contract: &str, method: &str) -> (Value, Vec<StacksTransactionEvent>) {
     helper_execute_epoch(contract, method, None, StacksEpochId::Epoch21, false)
@@ -69,7 +70,7 @@ fn helper_execute_epoch(
     }
 
     if let Some(epoch) = set_epoch {
-        genesis.as_transaction(|tx_conn| {
+        genesis.as_transaction(ClarityVersion::Clarity1, |tx_conn| {
             // bump the epoch in the Clarity DB
             tx_conn
                 .with_clarity_db(|db| {

--- a/src/clarity_vm/tests/events.rs
+++ b/src/clarity_vm/tests/events.rs
@@ -101,7 +101,7 @@ fn helper_execute_epoch(
     );
     let mut placeholder_context = ContractContext::new(
         QualifiedContractIdentifier::transient(),
-        ClarityVersion::Clarity1,
+        ClarityVersion::default_for_epoch(epoch),
     );
 
     {

--- a/src/clarity_vm/tests/events.rs
+++ b/src/clarity_vm/tests/events.rs
@@ -34,6 +34,7 @@ use crate::vm::database::MemoryBackingStore;
 
 use clarity::vm::tests::test_only_mainnet_to_chain_id;
 use clarity::vm::ClarityVersion;
+use clarity::vm::ContractContext;
 
 fn helper_execute(contract: &str, method: &str) -> (Value, Vec<StacksTransactionEvent>) {
     helper_execute_epoch(contract, method, None, StacksEpochId::Epoch21, false)
@@ -70,7 +71,7 @@ fn helper_execute_epoch(
     }
 
     if let Some(epoch) = set_epoch {
-        genesis.as_transaction(ClarityVersion::Clarity1, |tx_conn| {
+        genesis.as_transaction(|tx_conn| {
             // bump the epoch in the Clarity DB
             tx_conn
                 .with_clarity_db(|db| {
@@ -98,9 +99,13 @@ fn helper_execute_epoch(
         epoch,
         use_mainnet,
     );
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         env.initialize_contract(contract_id.clone(), contract)
             .unwrap();
     }

--- a/src/clarity_vm/tests/forking.rs
+++ b/src/clarity_vm/tests/forking.rs
@@ -26,6 +26,8 @@ use clarity::vm::test_util::{
 };
 use clarity::vm::types::Value;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
+use clarity::vm::version::ClarityVersion;
+use clarity::vm::ContractContext;
 use stacks_common::types::chainstate::BlockHeaderHash;
 use stacks_common::types::chainstate::StacksBlockId;
 
@@ -77,10 +79,14 @@ fn test_at_block_mutations() {
     ) -> Result<Value> {
         let c = QualifiedContractIdentifier::local("contract").unwrap();
         let p1 = execute(p1_str).expect_principal();
+        let mut placeholder_context = ContractContext::new(
+            QualifiedContractIdentifier::transient(),
+            ClarityVersion::Clarity1,
+        );
         eprintln!("Branched execution...");
 
         {
-            let mut env = owned_env.get_exec_environment(None, None);
+            let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
             let command = format!("(var-get datum)");
             let value = env.eval_read_only(&c, &command).unwrap();
             assert_eq!(value, Value::Int(expected_value));
@@ -151,10 +157,14 @@ fn test_at_block_good() {
     ) -> Result<Value> {
         let c = QualifiedContractIdentifier::local("contract").unwrap();
         let p1 = execute(p1_str).expect_principal();
+        let mut placeholder_context = ContractContext::new(
+            QualifiedContractIdentifier::transient(),
+            ClarityVersion::Clarity1,
+        );
         eprintln!("Branched execution...");
 
         {
-            let mut env = owned_env.get_exec_environment(None, None);
+            let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
             let command = format!("(var-get datum)");
             let value = env.eval_read_only(&c, &command).unwrap();
             assert_eq!(value, Value::Int(expected_value));
@@ -344,11 +354,15 @@ fn branched_execution(owned_env: &mut OwnedEnvironment, expect_success: bool) {
         }
     };
     let contract_identifier = QualifiedContractIdentifier::new(p1_address.clone(), "tokens".into());
+    let mut placeholder_context = ContractContext::new(
+        QualifiedContractIdentifier::transient(),
+        ClarityVersion::Clarity1,
+    );
 
     eprintln!("Branched execution...");
 
     {
-        let mut env = owned_env.get_exec_environment(None, None);
+        let mut env = owned_env.get_exec_environment(None, None, &mut placeholder_context);
         let command = format!("(get-balance {})", p1_str);
         let balance = env.eval_read_only(&contract_identifier, &command).unwrap();
         let expected = if expect_success { 10 } else { 0 };

--- a/src/clarity_vm/tests/large_contract.rs
+++ b/src/clarity_vm/tests/large_contract.rs
@@ -658,7 +658,7 @@ pub fn rollback_log_memory_test(
         }
 
         conn.as_transaction(|conn| {
-            let (ct_ast, ct_analysis) = conn
+            let (ct_ast, _ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
                 .unwrap();
             assert!(format!(
@@ -733,7 +733,7 @@ pub fn let_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_id
         contract.push_str(") 1)");
 
         conn.as_transaction(|conn| {
-            let (ct_ast, ct_analysis) = conn
+            let (ct_ast, _ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
                 .unwrap();
             assert!(format!(
@@ -811,7 +811,7 @@ pub fn argument_memory_test(
         contract.push_str(")");
 
         conn.as_transaction(|conn| {
-            let (ct_ast, ct_analysis) = conn
+            let (ct_ast, _ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
                 .unwrap();
             assert!(format!(
@@ -905,7 +905,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
         eprintln!("{}", contract_err);
 
         conn.as_transaction(|conn| {
-            let (ct_ast, ct_analysis) = conn
+            let (ct_ast, _ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, clarity_version, &contract_ok)
                 .unwrap();
             assert!(match conn
@@ -926,7 +926,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
         });
 
         conn.as_transaction(|conn| {
-            let (ct_ast, ct_analysis) = conn
+            let (ct_ast, _ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, clarity_version, &contract_err)
                 .unwrap();
             assert!(format!(
@@ -1030,7 +1030,7 @@ pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion, #[case] epoch_
                 });
             } else {
                 conn.as_transaction(|conn| {
-                    let (ct_ast, ct_analysis) = conn
+                    let (ct_ast, _ct_analysis) = conn
                         .analyze_smart_contract(&contract_identifier, clarity_version, &contract)
                         .unwrap();
                     assert!(format!(

--- a/src/clarity_vm/tests/large_contract.rs
+++ b/src/clarity_vm/tests/large_contract.rs
@@ -115,7 +115,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
         let contract_ast =
             ast::build_ast(&contract_identifier, tokens_contract, &mut (), version).unwrap();
 
-        block.as_transaction(|tx| {
+        block.as_transaction(version, |tx| {
             tx.initialize_smart_contract(
                 &contract_identifier,
                 &contract_ast,
@@ -128,7 +128,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(!is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p2,
                     None,
                     &contract_identifier,
@@ -141,7 +141,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
         ));
         assert!(is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -155,7 +155,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(!is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -168,13 +168,13 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
         ));
         assert!(is_committed(
             & // send to self!
-            block.as_transaction(|tx| tx.run_contract_call(&p1, None, &contract_identifier, "token-transfer",
+            block.as_transaction(version, |tx| tx.run_contract_call(&p1, None, &contract_identifier, "token-transfer",
                                     &[p1.clone().into(), Value::UInt(1000)], |_, _| false)).unwrap().0
         ));
 
         assert_eq!(
             block
-                .as_transaction(|tx| tx.eval_read_only(
+                .as_transaction(version, |tx| tx.eval_read_only(
                     &contract_identifier,
                     "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"
                 ))
@@ -183,7 +183,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
         );
         assert_eq!(
             block
-                .as_transaction(|tx| tx.eval_read_only(
+                .as_transaction(version, |tx| tx.eval_read_only(
                     &contract_identifier,
                     "(my-get-token-balance 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G)"
                 ))
@@ -193,7 +193,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -207,7 +207,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -221,7 +221,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -235,7 +235,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert_eq!(
             block
-                .as_transaction(|tx| tx.eval_read_only(
+                .as_transaction(version, |tx| tx.eval_read_only(
                     &contract_identifier,
                     "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"
                 ))
@@ -245,7 +245,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(!is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -280,7 +280,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
         );
         assert!(is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -294,7 +294,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert!(!is_committed(
             &block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -308,7 +308,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
 
         assert_eq!(
             block
-                .as_transaction(|tx| tx.eval_read_only(
+                .as_transaction(version, |tx| tx.eval_read_only(
                     &contract_identifier,
                     "(my-get-token-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR)"
                 ))
@@ -317,7 +317,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
         );
         assert_eq!(
             block
-                .as_transaction(|tx| tx.run_contract_call(
+                .as_transaction(version, |tx| tx.run_contract_call(
                     &p1,
                     None,
                     &contract_identifier,
@@ -557,9 +557,8 @@ fn inner_test_simple_naming_system(owned_env: &mut OwnedEnvironment, version: Cl
  *   `(define-data-var var-x ...)` uses more than 1048576 bytes of memory.
  *      this is mainly due to using hex encoding in the sqlite storage.
  */
-#[test]
-#[ignore]
-pub fn rollback_log_memory_test() {
+#[apply(clarity_version_template)]
+pub fn rollback_log_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
@@ -600,8 +599,8 @@ pub fn rollback_log_memory_test() {
             contract.push_str(&exploder);
         }
 
-        conn.as_transaction(|conn| {
-            let (ct_ast, _ct_analysis) = conn
+        conn.as_transaction(clarity_version, |conn| {
+            let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, &contract)
                 .unwrap();
             assert!(format!(
@@ -620,8 +619,8 @@ pub fn rollback_log_memory_test() {
     }
 }
 
-#[test]
-pub fn let_memory_test() {
+#[apply(clarity_version_template)]
+pub fn let_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
@@ -668,8 +667,8 @@ pub fn let_memory_test() {
 
         contract.push_str(") 1)");
 
-        conn.as_transaction(|conn| {
-            let (ct_ast, _ct_analysis) = conn
+        conn.as_transaction(clarity_version, |conn| {
+            let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, &contract)
                 .unwrap();
             assert!(format!(
@@ -688,8 +687,8 @@ pub fn let_memory_test() {
     }
 }
 
-#[test]
-pub fn argument_memory_test() {
+#[apply(clarity_version_template)]
+pub fn argument_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
@@ -736,8 +735,8 @@ pub fn argument_memory_test() {
 
         contract.push_str(")");
 
-        conn.as_transaction(|conn| {
-            let (ct_ast, _ct_analysis) = conn
+        conn.as_transaction(clarity_version, |conn| {
+            let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, &contract)
                 .unwrap();
             assert!(format!(
@@ -756,8 +755,8 @@ pub fn argument_memory_test() {
     }
 }
 
-#[test]
-pub fn fcall_memory_test() {
+#[apply(clarity_version_template)]
+pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let COUNT_PER_FUNC = 10;
@@ -823,8 +822,8 @@ pub fn fcall_memory_test() {
         eprintln!("{}", contract_ok);
         eprintln!("{}", contract_err);
 
-        conn.as_transaction(|conn| {
-            let (ct_ast, _ct_analysis) = conn
+        conn.as_transaction(clarity_version, |conn| {
+            let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, &contract_ok)
                 .unwrap();
             assert!(match conn
@@ -843,8 +842,8 @@ pub fn fcall_memory_test() {
             });
         });
 
-        conn.as_transaction(|conn| {
-            let (ct_ast, _ct_analysis) = conn
+        conn.as_transaction(clarity_version, |conn| {
+            let (ct_ast, ct_analysis) = conn
                 .analyze_smart_contract(&contract_identifier, &contract_err)
                 .unwrap();
             assert!(format!(
@@ -863,9 +862,8 @@ pub fn fcall_memory_test() {
     }
 }
 
-#[test]
-#[ignore]
-pub fn ccall_memory_test() {
+#[apply(clarity_version_template)]
+pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let COUNT_PER_CONTRACT = 20;
@@ -924,7 +922,7 @@ pub fn ccall_memory_test() {
             let contract_identifier = QualifiedContractIdentifier::local(&contract_name).unwrap();
 
             if i < (CONTRACTS - 1) {
-                conn.as_transaction(|conn| {
+                conn.as_transaction(clarity_version, |conn| {
                     let (ct_ast, ct_analysis) = conn
                         .analyze_smart_contract(&contract_identifier, &contract)
                         .unwrap();
@@ -940,8 +938,8 @@ pub fn ccall_memory_test() {
                         .unwrap();
                 });
             } else {
-                conn.as_transaction(|conn| {
-                    let (ct_ast, _ct_analysis) = conn
+                conn.as_transaction(clarity_version, |conn| {
+                    let (ct_ast, ct_analysis) = conn
                         .analyze_smart_contract(&contract_identifier, &contract)
                         .unwrap();
                     assert!(format!(

--- a/src/clarity_vm/tests/large_contract.rs
+++ b/src/clarity_vm/tests/large_contract.rs
@@ -101,13 +101,27 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
             .unwrap(),
     );
     let contract_identifier = QualifiedContractIdentifier::local("tokens").unwrap();
+    let burn_db = if version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
+
+    clarity
+        .begin_test_genesis_block(
+            &StacksBlockId::sentinel(),
+            &StacksBlockId([0xfe as u8; 32]),
+            &TEST_HEADER_DB,
+            burn_db,
+        )
+        .commit_block();
 
     {
-        let mut block = clarity.begin_test_genesis_block(
-            &StacksBlockId::sentinel(),
-            &test_block_headers(0),
+        let mut block = clarity.begin_block(
+            &StacksBlockId([0xfe as u8; 32]),
+            &StacksBlockId([0 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let tokens_contract = SIMPLE_TOKENS;
@@ -265,7 +279,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
                 &test_block_headers(i),
                 &test_block_headers(i + 1),
                 &TEST_HEADER_DB,
-                &TEST_BURN_STATE_DB,
+                burn_db,
             );
             block.commit_block();
         }
@@ -276,7 +290,7 @@ fn test_simple_token_system(#[case] version: ClarityVersion) {
             &test_block_headers(25),
             &test_block_headers(26),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
         assert!(is_committed(
             &block
@@ -562,6 +576,11 @@ pub fn rollback_log_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
     clarity_instance
@@ -569,7 +588,7 @@ pub fn rollback_log_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId::sentinel(),
             &StacksBlockId([0 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -578,7 +597,7 @@ pub fn rollback_log_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId([0 as u8; 32]),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let define_data_var = "(define-data-var XZ (buff 1048576) 0x00)";
@@ -624,6 +643,11 @@ pub fn let_memory_test(#[case] clarity_version: ClarityVersion) {
     let marf = MarfedKV::temporary();
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let EXPLODE_N = 100;
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -632,7 +656,7 @@ pub fn let_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId::sentinel(),
             &StacksBlockId([0 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -641,7 +665,7 @@ pub fn let_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId([0 as u8; 32]),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let define_data_var = "(define-constant buff-0 0x00)";
@@ -694,13 +718,18 @@ pub fn argument_memory_test(#[case] clarity_version: ClarityVersion) {
     let EXPLODE_N = 100;
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
 
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
             &StacksBlockId([0 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -709,7 +738,7 @@ pub fn argument_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId([0 as u8; 32]),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let define_data_var = "(define-constant buff-0 0x00)";
@@ -761,6 +790,11 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion) {
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let COUNT_PER_FUNC = 10;
     let FUNCS = 10;
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
 
     let contract_identifier = QualifiedContractIdentifier::local("foo").unwrap();
 
@@ -769,7 +803,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId::sentinel(),
             &StacksBlockId([0 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -778,7 +812,7 @@ pub fn fcall_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId([0 as u8; 32]),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let define_data_var = "(define-constant buff-0 0x00)";
@@ -868,13 +902,18 @@ pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion) {
     let mut clarity_instance = ClarityInstance::new(false, CHAIN_ID_TESTNET, marf);
     let COUNT_PER_CONTRACT = 20;
     let CONTRACTS = 5;
+    let burn_db = if clarity_version == ClarityVersion::Clarity2 {
+        &TEST_BURN_STATE_DB_21
+    } else {
+        &TEST_BURN_STATE_DB
+    };
 
     clarity_instance
         .begin_test_genesis_block(
             &StacksBlockId::sentinel(),
             &StacksBlockId([0 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         )
         .commit_block();
 
@@ -883,7 +922,7 @@ pub fn ccall_memory_test(#[case] clarity_version: ClarityVersion) {
             &StacksBlockId([0 as u8; 32]),
             &StacksBlockId([1 as u8; 32]),
             &TEST_HEADER_DB,
-            &TEST_BURN_STATE_DB,
+            burn_db,
         );
 
         let define_data_var = "(define-constant buff-0 0x00)\n";

--- a/src/cost_estimates/fee_medians.rs
+++ b/src/cost_estimates/fee_medians.rs
@@ -330,7 +330,7 @@ fn fee_rate_and_weight_from_receipt(
         }
         TransactionPayload::PoisonMicroblock(_, _)
         | TransactionPayload::ContractCall(_)
-        | TransactionPayload::SmartContract(_) => {
+        | TransactionPayload::SmartContract(..) => {
             // These transaction payload types all "work" the same: they have associated ExecutionCosts
             // and contibute to the block length limit with their tx_len
             metric.from_cost_and_len(&tx_receipt.execution_cost, &block_limit, tx_size)

--- a/src/cost_estimates/fee_scalar.rs
+++ b/src/cost_estimates/fee_scalar.rs
@@ -178,7 +178,7 @@ impl<M: CostMetric> FeeEstimator for ScalarFeeRateEstimator<M> {
                     }
                     TransactionPayload::PoisonMicroblock(_, _)
                     | TransactionPayload::ContractCall(_)
-                    | TransactionPayload::SmartContract(_) => {
+                    | TransactionPayload::SmartContract(..) => {
                         // These transaction payload types all "work" the same: they have associated ExecutionCosts
                         // and contibute to the block length limit with their tx_len
                         self.metric.from_cost_and_len(

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -236,7 +236,7 @@ impl PessimisticEstimator {
                     epoch_marker, cc.address, cc.contract_name, cc.function_name
                 )
             }
-            TransactionPayload::SmartContract(_sc) => "contract-publish".to_string(),
+            TransactionPayload::SmartContract(..) => "contract-publish".to_string(),
             TransactionPayload::PoisonMicroblock(_, _) => "poison-ublock".to_string(),
             TransactionPayload::Coinbase(..) => "coinbase".to_string(),
         };

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -3602,8 +3602,8 @@ pub mod test {
 
                             // extend to 10 microblocks
                             while microblocks.len() != num_blocks {
-                                let next_microblock_payload =
-                                    TransactionPayload::SmartContract(TransactionSmartContract {
+                                let next_microblock_payload = TransactionPayload::SmartContract(
+                                    TransactionSmartContract {
                                         name: ContractName::try_from(format!(
                                             "hello-world-{}",
                                             thread_rng().gen::<u64>()
@@ -3613,7 +3613,9 @@ pub mod test {
                                             "(begin (print \"hello world\"))",
                                         )
                                         .expect("FATAL: valid code"),
-                                    });
+                                    },
+                                    None,
+                                );
                                 let mut mblock = microblocks.last().unwrap().clone();
                                 let last_nonce = mblock
                                     .txs

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2639,48 +2639,45 @@ pub mod test {
             let post_flight_callback = move |clarity_tx: &mut ClarityTx| {
                 let mut receipts = vec![];
                 if conf.setup_code.len() > 0 {
-                    let receipt = clarity_tx.connection().as_transaction(
-                        ClarityVersion::Clarity1,
-                        |clarity| {
-                            let boot_code_addr = boot_code_test_addr();
-                            let boot_code_account = StacksAccount {
-                                principal: boot_code_addr.to_account_principal(),
-                                nonce: 0,
-                                stx_balance: STXBalance::zero(),
-                            };
+                    let receipt = clarity_tx.connection().as_transaction(|clarity| {
+                        let boot_code_addr = boot_code_test_addr();
+                        let boot_code_account = StacksAccount {
+                            principal: boot_code_addr.to_account_principal(),
+                            nonce: 0,
+                            stx_balance: STXBalance::zero(),
+                        };
 
-                            let boot_code_auth = boot_code_tx_auth(boot_code_addr);
+                        let boot_code_auth = boot_code_tx_auth(boot_code_addr);
 
-                            debug!(
+                        debug!(
                             "Instantiate test-specific boot code contract '{}.{}' ({} bytes)...",
                             &boot_code_addr.to_string(),
                             &conf.test_name,
                             conf.setup_code.len()
                         );
 
-                            let smart_contract = TransactionPayload::SmartContract(
-                                TransactionSmartContract {
-                                    name: ContractName::try_from(conf.test_name.as_str())
-                                        .expect("FATAL: invalid boot-code contract name"),
-                                    code_body: StacksString::from_str(&conf.setup_code)
-                                        .expect("FATAL: invalid boot code body"),
-                                },
-                                None,
-                            );
+                        let smart_contract = TransactionPayload::SmartContract(
+                            TransactionSmartContract {
+                                name: ContractName::try_from(conf.test_name.as_str())
+                                    .expect("FATAL: invalid boot-code contract name"),
+                                code_body: StacksString::from_str(&conf.setup_code)
+                                    .expect("FATAL: invalid boot code body"),
+                            },
+                            None,
+                        );
 
-                            let boot_code_smart_contract = StacksTransaction::new(
-                                TransactionVersion::Testnet,
-                                boot_code_auth.clone(),
-                                smart_contract,
-                            );
-                            StacksChainState::process_transaction_payload(
-                                clarity,
-                                &boot_code_smart_contract,
-                                &boot_code_account,
-                            )
-                            .unwrap()
-                        },
-                    );
+                        let boot_code_smart_contract = StacksTransaction::new(
+                            TransactionVersion::Testnet,
+                            boot_code_auth.clone(),
+                            smart_contract,
+                        );
+                        StacksChainState::process_transaction_payload(
+                            clarity,
+                            &boot_code_smart_contract,
+                            &boot_code_account,
+                        )
+                        .unwrap()
+                    });
                     receipts.push(receipt);
                 }
                 debug!("Bootup receipts: {:?}", &receipts);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2096,6 +2096,7 @@ pub mod test {
     use clarity::vm::costs::ExecutionCost;
     use clarity::vm::database::STXBalance;
     use clarity::vm::types::*;
+    use clarity::vm::ClarityVersion;
     use stacks_common::address::*;
     use stacks_common::util::get_epoch_time_secs;
     use stacks_common::util::hash::*;
@@ -2638,43 +2639,48 @@ pub mod test {
             let post_flight_callback = move |clarity_tx: &mut ClarityTx| {
                 let mut receipts = vec![];
                 if conf.setup_code.len() > 0 {
-                    let receipt = clarity_tx.connection().as_transaction(|clarity| {
-                        let boot_code_addr = boot_code_test_addr();
-                        let boot_code_account = StacksAccount {
-                            principal: boot_code_addr.to_account_principal(),
-                            nonce: 0,
-                            stx_balance: STXBalance::zero(),
-                        };
+                    let receipt = clarity_tx.connection().as_transaction(
+                        ClarityVersion::Clarity1,
+                        |clarity| {
+                            let boot_code_addr = boot_code_test_addr();
+                            let boot_code_account = StacksAccount {
+                                principal: boot_code_addr.to_account_principal(),
+                                nonce: 0,
+                                stx_balance: STXBalance::zero(),
+                            };
 
-                        let boot_code_auth = boot_code_tx_auth(boot_code_addr);
+                            let boot_code_auth = boot_code_tx_auth(boot_code_addr);
 
-                        debug!(
+                            debug!(
                             "Instantiate test-specific boot code contract '{}.{}' ({} bytes)...",
                             &boot_code_addr.to_string(),
                             &conf.test_name,
                             conf.setup_code.len()
                         );
 
-                        let smart_contract =
-                            TransactionPayload::SmartContract(TransactionSmartContract {
-                                name: ContractName::try_from(conf.test_name.as_str())
-                                    .expect("FATAL: invalid boot-code contract name"),
-                                code_body: StacksString::from_str(&conf.setup_code)
-                                    .expect("FATAL: invalid boot code body"),
-                            });
+                            let smart_contract = TransactionPayload::SmartContract(
+                                TransactionSmartContract {
+                                    name: ContractName::try_from(conf.test_name.as_str())
+                                        .expect("FATAL: invalid boot-code contract name"),
+                                    code_body: StacksString::from_str(&conf.setup_code)
+                                        .expect("FATAL: invalid boot code body"),
+                                },
+                                None,
+                            );
 
-                        let boot_code_smart_contract = StacksTransaction::new(
-                            TransactionVersion::Testnet,
-                            boot_code_auth.clone(),
-                            smart_contract,
-                        );
-                        StacksChainState::process_transaction_payload(
-                            clarity,
-                            &boot_code_smart_contract,
-                            &boot_code_account,
-                        )
-                        .unwrap()
-                    });
+                            let boot_code_smart_contract = StacksTransaction::new(
+                                TransactionVersion::Testnet,
+                                boot_code_auth.clone(),
+                                smart_contract,
+                            );
+                            StacksChainState::process_transaction_payload(
+                                clarity,
+                                &boot_code_smart_contract,
+                                &boot_code_account,
+                            )
+                            .unwrap()
+                        },
+                    );
                     receipts.push(receipt);
                 }
                 debug!("Bootup receipts: {:?}", &receipts);

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -1770,7 +1770,7 @@ mod test {
     use crate::chainstate::stacks::db::blocks::MINIMUM_TX_FEE_RATE_PER_BYTE;
     use crate::chainstate::stacks::test::*;
     use crate::chainstate::stacks::tests::make_coinbase_with_nonce;
-    use crate::chainstate::stacks::*;
+    use crate::chainstate::stacks::tests::*;
     use crate::chainstate::stacks::*;
     use crate::net::asn::*;
     use crate::net::chat::*;
@@ -1791,6 +1791,7 @@ mod test {
     use crate::clarity_vm::clarity::ClarityConnection;
     use crate::core::*;
     use clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::ClarityVersion;
     use stacks_common::types::chainstate::BlockHeaderHash;
 
     #[test]
@@ -3147,6 +3148,7 @@ mod test {
                         TransactionPayload::new_smart_contract(
                             &name.to_string(),
                             &contract.to_string(),
+                            None,
                         )
                         .unwrap(),
                     );
@@ -4365,7 +4367,7 @@ mod test {
             };
 
         // tenures 26 and 27 should fail, since the block is a pay-to-contract block
-        // Pay-to-contract should only be supported if the parent block is in epoch 2.1, which
+        // Pay-to-contract should only be supported if the block is in epoch 2.1, which
         // activates at tenure 27.
         for i in 0..2 {
             let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
@@ -4413,6 +4415,415 @@ mod test {
                 panic!("Got unexpected error {:?}", &e);
             }
         };
+        peer.sortdb = Some(sortdb);
+        peer.stacks_node = Some(node);
+    }
+
+    #[test]
+    fn test_block_versioned_smart_contract_gated_at_v210() {
+        let mut peer_config = TestPeerConfig::new(
+            "test_block_versioned_smart_contract_gated_at_v210",
+            4248,
+            4249,
+        );
+
+        let initial_balances = vec![(
+            PrincipalData::from(peer_config.spending_account.origin_address().unwrap()),
+            1000000,
+        )];
+
+        let epochs = vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 0,
+                end_height: 28, // NOTE: the first 25 burnchain blocks have no sortition
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: 28,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+        ];
+
+        peer_config.epochs = Some(epochs);
+        peer_config.initial_balances = initial_balances;
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let mut make_tenure =
+            |miner: &mut TestMiner,
+             sortdb: &mut SortitionDB,
+             chainstate: &mut StacksChainState,
+             vrfproof: VRFProof,
+             parent_opt: Option<&StacksBlock>,
+             microblock_parent_opt: Option<&StacksMicroblockHeader>| {
+                let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+
+                let stacks_tip_opt = chainstate.get_stacks_chain_tip(sortdb).unwrap();
+                let parent_tip = match stacks_tip_opt {
+                    None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                    Some(staging_block) => {
+                        let ic = sortdb.index_conn();
+                        let snapshot = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                            &ic,
+                            &tip.sortition_id,
+                            &staging_block.anchored_block_hash,
+                        )
+                        .unwrap()
+                        .unwrap(); // succeeds because we don't fork
+                        StacksChainState::get_anchored_block_header_info(
+                            chainstate.db(),
+                            &snapshot.consensus_hash,
+                            &snapshot.winning_stacks_block_hash,
+                        )
+                        .unwrap()
+                        .unwrap()
+                    }
+                };
+
+                let parent_header_hash = parent_tip.anchored_header.block_hash();
+                let parent_consensus_hash = parent_tip.consensus_hash.clone();
+                let parent_index_hash = StacksBlockHeader::make_index_block_hash(
+                    &parent_consensus_hash,
+                    &parent_header_hash,
+                );
+
+                let coinbase_tx = make_coinbase_with_nonce(
+                    miner,
+                    parent_tip.stacks_block_height as usize,
+                    0,
+                    None,
+                );
+
+                let versioned_contract = make_smart_contract_with_version(
+                    miner,
+                    1,
+                    tip.block_height.try_into().unwrap(),
+                    0,
+                    Some(ClarityVersion::Clarity1),
+                    Some(1000),
+                );
+
+                let mut mblock_pubkey_hash_bytes = [0u8; 20];
+                mblock_pubkey_hash_bytes.copy_from_slice(&coinbase_tx.txid()[0..20]);
+
+                let builder = StacksBlockBuilder::make_block_builder(
+                    chainstate.mainnet,
+                    &parent_tip,
+                    vrfproof,
+                    tip.total_burn,
+                    Hash160(mblock_pubkey_hash_bytes),
+                )
+                .unwrap();
+
+                let anchored_block = StacksBlockBuilder::make_anchored_block_from_txs(
+                    builder,
+                    chainstate,
+                    &sortdb.index_conn(),
+                    vec![coinbase_tx, versioned_contract],
+                )
+                .unwrap();
+
+                eprintln!("{:?}", &anchored_block.0);
+                (anchored_block.0, vec![])
+            };
+
+        // tenures 26 and 27 should fail, since the block contains a versioned smart contract.
+        // Versioned smart contracts should only be supported if the block is in epoch 2.1, which
+        // activates at tenure 27.
+        for i in 0..2 {
+            let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
+            let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+
+            let sortdb = peer.sortdb.take().unwrap();
+            let mut node = peer.stacks_node.take().unwrap();
+            match Relayer::process_new_anchored_block(
+                &sortdb.index_conn(),
+                &mut node.chainstate,
+                &consensus_hash,
+                &stacks_block,
+                123,
+            ) {
+                Ok(x) => {
+                    eprintln!("{:?}", &stacks_block);
+                    panic!("Stored pay-to-contract stacks block before epoch 2.1");
+                }
+                Err(chainstate_error::InvalidStacksBlock(_)) => {}
+                Err(e) => {
+                    panic!("Got unexpected error {:?}", &e);
+                }
+            };
+            peer.sortdb = Some(sortdb);
+            peer.stacks_node = Some(node);
+        }
+
+        // *now* it should succeed, since tenure 28 was in epoch 2.1
+        let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
+
+        let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+
+        let sortdb = peer.sortdb.take().unwrap();
+        let mut node = peer.stacks_node.take().unwrap();
+        match Relayer::process_new_anchored_block(
+            &sortdb.index_conn(),
+            &mut node.chainstate,
+            &consensus_hash,
+            &stacks_block,
+            123,
+        ) {
+            Ok(x) => {
+                assert!(x, "Failed to process valid versioned smart contract block");
+            }
+            Err(e) => {
+                panic!("Got unexpected error {:?}", &e);
+            }
+        };
+        peer.sortdb = Some(sortdb);
+        peer.stacks_node = Some(node);
+    }
+
+    #[test]
+    fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
+        let mut peer_config = TestPeerConfig::new(
+            "test_block_versioned_smart_contract_mempool_rejection_until_v210",
+            4250,
+            4251,
+        );
+
+        let initial_balances = vec![(
+            PrincipalData::from(peer_config.spending_account.origin_address().unwrap()),
+            1000000,
+        )];
+
+        let epochs = vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 0,
+                end_height: 28, // NOTE: the first 25 burnchain blocks have no sortition
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: 28,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+        ];
+
+        peer_config.epochs = Some(epochs);
+        peer_config.initial_balances = initial_balances;
+
+        let mut peer = TestPeer::new(peer_config);
+        let versioned_contract_opt: RefCell<Option<StacksTransaction>> = RefCell::new(None);
+        let nonce: RefCell<u64> = RefCell::new(0);
+
+        let mut make_tenure =
+            |miner: &mut TestMiner,
+             sortdb: &mut SortitionDB,
+             chainstate: &mut StacksChainState,
+             vrfproof: VRFProof,
+             parent_opt: Option<&StacksBlock>,
+             microblock_parent_opt: Option<&StacksMicroblockHeader>| {
+                let tip = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn()).unwrap();
+
+                let stacks_tip_opt = chainstate.get_stacks_chain_tip(sortdb).unwrap();
+                let parent_tip = match stacks_tip_opt {
+                    None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                    Some(staging_block) => {
+                        let ic = sortdb.index_conn();
+                        let snapshot = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                            &ic,
+                            &tip.sortition_id,
+                            &staging_block.anchored_block_hash,
+                        )
+                        .unwrap()
+                        .unwrap(); // succeeds because we don't fork
+                        StacksChainState::get_anchored_block_header_info(
+                            chainstate.db(),
+                            &snapshot.consensus_hash,
+                            &snapshot.winning_stacks_block_hash,
+                        )
+                        .unwrap()
+                        .unwrap()
+                    }
+                };
+
+                let parent_header_hash = parent_tip.anchored_header.block_hash();
+                let parent_consensus_hash = parent_tip.consensus_hash.clone();
+                let parent_index_hash = StacksBlockHeader::make_index_block_hash(
+                    &parent_consensus_hash,
+                    &parent_header_hash,
+                );
+
+                let next_nonce = *nonce.borrow();
+                let coinbase_tx = make_coinbase_with_nonce(
+                    miner,
+                    parent_tip.stacks_block_height as usize,
+                    next_nonce,
+                    None,
+                );
+
+                let versioned_contract = make_smart_contract_with_version(
+                    miner,
+                    next_nonce + 1,
+                    tip.block_height.try_into().unwrap(),
+                    0,
+                    Some(ClarityVersion::Clarity1),
+                    Some(1000),
+                );
+
+                *versioned_contract_opt.borrow_mut() = Some(versioned_contract);
+                *nonce.borrow_mut() = next_nonce + 1;
+
+                let mut mblock_pubkey_hash_bytes = [0u8; 20];
+                mblock_pubkey_hash_bytes.copy_from_slice(&coinbase_tx.txid()[0..20]);
+
+                let builder = StacksBlockBuilder::make_block_builder(
+                    chainstate.mainnet,
+                    &parent_tip,
+                    vrfproof,
+                    tip.total_burn,
+                    Hash160(mblock_pubkey_hash_bytes),
+                )
+                .unwrap();
+
+                let anchored_block = StacksBlockBuilder::make_anchored_block_from_txs(
+                    builder,
+                    chainstate,
+                    &sortdb.index_conn(),
+                    vec![coinbase_tx],
+                )
+                .unwrap();
+
+                eprintln!("{:?}", &anchored_block.0);
+                (anchored_block.0, vec![])
+            };
+
+        for i in 0..2 {
+            let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
+            let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+
+            let sortdb = peer.sortdb.take().unwrap();
+            let mut node = peer.stacks_node.take().unwrap();
+
+            // the empty block should be accepted
+            match Relayer::process_new_anchored_block(
+                &sortdb.index_conn(),
+                &mut node.chainstate,
+                &consensus_hash,
+                &stacks_block,
+                123,
+            ) {
+                Ok(x) => {
+                    assert!(x, "Did not accept valid block");
+                }
+                Err(e) => {
+                    panic!("Got unexpected error {:?}", &e);
+                }
+            };
+
+            // process it
+            peer.coord.handle_new_stacks_block().unwrap();
+
+            // the mempool would reject a versioned contract transaction, since we're not yet at
+            // tenure 28
+            let versioned_contract = (*versioned_contract_opt.borrow()).clone().unwrap();
+            let versioned_contract_len = versioned_contract.serialize_to_vec().len();
+            match node.chainstate.will_admit_mempool_tx(
+                &consensus_hash,
+                &stacks_block.block_hash(),
+                &versioned_contract,
+                versioned_contract_len as u64,
+            ) {
+                Err(MemPoolRejection::Other(msg)) => {
+                    assert!(msg.find("not supported in this epoch").is_some());
+                }
+                Err(e) => {
+                    panic!("will_admit_mempool_tx {:?}", &e);
+                }
+                Ok(_) => {
+                    panic!("will_admit_mempool_tx succeeded");
+                }
+            };
+
+            peer.sortdb = Some(sortdb);
+            peer.stacks_node = Some(node);
+        }
+
+        // *now* it should succeed, since tenure 28 was in epoch 2.1
+        let (burn_ops, stacks_block, microblocks) = peer.make_tenure(&mut make_tenure);
+        let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+
+        let sortdb = peer.sortdb.take().unwrap();
+        let mut node = peer.stacks_node.take().unwrap();
+        match Relayer::process_new_anchored_block(
+            &sortdb.index_conn(),
+            &mut node.chainstate,
+            &consensus_hash,
+            &stacks_block,
+            123,
+        ) {
+            Ok(x) => {
+                assert!(x, "Failed to process valid versioned smart contract block");
+            }
+            Err(e) => {
+                panic!("Got unexpected error {:?}", &e);
+            }
+        };
+
+        // process it
+        peer.coord.handle_new_stacks_block().unwrap();
+
+        // the mempool would accept a versioned contract transaction, since we're not yet at
+        // tenure 28
+        let versioned_contract = (*versioned_contract_opt.borrow()).clone().unwrap();
+        let versioned_contract_len = versioned_contract.serialize_to_vec().len();
+        match node.chainstate.will_admit_mempool_tx(
+            &consensus_hash,
+            &stacks_block.block_hash(),
+            &versioned_contract,
+            versioned_contract_len as u64,
+        ) {
+            Err(e) => {
+                panic!("will_admit_mempool_tx {:?}", &e);
+            }
+            Ok(_) => {}
+        };
+
         peer.sortdb = Some(sortdb);
         peer.stacks_node = Some(node);
     }

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1201,6 +1201,7 @@ mod test {
                     TransactionPayload::new_smart_contract(
                         &"hello-world".to_string(),
                         &big_contract.to_string(),
+                        None,
                     )
                     .unwrap(),
                 );

--- a/testnet/stacks-node/src/run_loop/mod.rs
+++ b/testnet/stacks-node/src/run_loop/mod.rs
@@ -117,7 +117,7 @@ impl RunLoopCallbacks {
             }
             match &tx.payload {
                 TransactionPayload::Coinbase(..) => println!("   Coinbase"),
-                TransactionPayload::SmartContract(contract) => println!("   Publish smart contract\n**************************\n{:?}\n**************************", contract.code_body),
+                TransactionPayload::SmartContract(contract, ..) => println!("   Publish smart contract\n**************************\n{:?}\n**************************", contract.code_body),
                 TransactionPayload::TokenTransfer(recipent, amount, _) => println!("   Transfering {} µSTX to {}", amount, recipent.to_string()),
                 _ => println!("   {:?}", tx.payload)
             }

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -783,7 +783,7 @@ fn test_cost_limit_switch_version205() {
     let increment_contract_defines = select_transactions_where(
         &test_observer::get_blocks(),
         |transaction| match &transaction.payload {
-            TransactionPayload::SmartContract(contract) => {
+            TransactionPayload::SmartContract(contract, ..) => {
                 contract.name == ContractName::try_from("increment-contract").unwrap()
             }
             _ => false,
@@ -1115,7 +1115,7 @@ fn bigger_microblock_streams_in_2_05() {
                 }
                 let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
                 let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
-                if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+                if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                     if tsc.name.to_string().find("costs-2").is_some() {
                         in_205 = true;
                     } else if tsc.name.to_string().find("large").is_some() {

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -616,7 +616,7 @@ fn should_succeed_mining_valid_txs() {
                     let contract_tx = &chain_tip.block.txs[1];
                     assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
-                        TransactionPayload::SmartContract(_) => true,
+                        TransactionPayload::SmartContract(..) => true,
                         _ => false,
                     });
 
@@ -902,7 +902,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                     let contract_tx = &chain_tip.block.txs[1];
                     assert!(contract_tx.chain_id == CHAIN_ID_TESTNET);
                     assert!(match contract_tx.payload {
-                        TransactionPayload::SmartContract(_) => true,
+                        TransactionPayload::SmartContract(..) => true,
                         _ => false,
                     });
                 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -2739,7 +2739,7 @@ fn size_overflow_unconfirmed_microblocks_integration_test() {
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
             let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
-            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+            if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                 if tsc.name.to_string().find("large-").is_some() {
                     num_big_anchored_txs += 1;
                     total_big_txs_per_block += 1;
@@ -2942,7 +2942,7 @@ fn size_overflow_unconfirmed_stream_microblocks_integration_test() {
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
             let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
-            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+            if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                 if tsc.name.to_string().find("small").is_some() {
                     num_big_microblock_txs += 1;
                     total_big_txs_per_microblock += 1;
@@ -3118,7 +3118,7 @@ fn size_overflow_unconfirmed_invalid_stream_microblocks_integration_test() {
             }
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
             let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
-            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+            if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                 if tsc.name.to_string().find("small").is_some() {
                     num_big_microblock_txs += 1;
                     total_big_txs_per_microblock += 1;
@@ -3399,7 +3399,7 @@ fn runtime_overflow_unconfirmed_microblocks_integration_test() {
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
             let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             eprintln!("tx: {:?}", &parsed);
-            if let TransactionPayload::SmartContract(tsc) = parsed.payload {
+            if let TransactionPayload::SmartContract(tsc, ..) = parsed.payload {
                 if tsc.name.to_string().find("large-").is_some() {
                     num_big_anchored_txs += 1;
                     total_big_txs_in_blocks += 1;


### PR DESCRIPTION
This addresses #3131 and #2719, as well as #2609.  It introduces a `SmartContract` payload variant that takes an explicit Clarity version, so that post-2.1 developers can require that the contract adhere to Clarity 1 or Clarity 2 rules.  If they do not do so, then the epoch default Clarity version is used (which will be Clarity 2 in 2.1).

The PR removes most uses of `ClarityVersion::default_for_epoch()` and replaces them with a transaction-supplied Clarity version.  When a transaction is processed, a new method `StacksChainState::get_tx_clarity_version()` is called to deduce which version of Clarity to supply the Clarity VM.  The rules are as follows:

* If the transaction is a smart contract transaction, and a version is explicitly given, then use that.
* If the transaction is a smart contract transaction, and a version is not given, then use the epoch default.
* If the transaction is a contract-call transaction, then load up the target contract and use its version.
* In all other cases, use the epoch default.

This PR tests #2719 by addressing #3131.  It introduces a "torture test" for cross-contract and cross-Clarity-version contract calls in `chainstate::stacks::tests::block_construction::test_contract_call_across_clarity_versions`.  It verifies the following:

* The method invoked by a contract call transaction runs with the Clarity version that the contract that defined it used.  So for example, a Clarity1 contract can call a Clarity2 contract function, and that Clarity2 function can do Clarity2-specific things.

* The method invoked by an explicit `contract-call?` follows the above rule as well.

* A trait defined in Clarity1 can be implemented by a Clarity2 contract.

* A trait defined in Clarity2 can be implemented by a Clarity1 contract.

* Dynamic dispatches to traits will run with the Clarity version of the trait implementation.  So for example, if a Clarity1 contract calls into a trait that, regardless of the trait definition's Clarity version, has a Clarity2 implementation, then the dispatch will run in Clarity2.

* The closure of an `(at-block)` will run with the Clarity version in which it is defined, like any other code statement.  Similarly, contract-calls within the at-block will run in the target method's contract's Clarity version.

The PR addresses #2609 by ensuring that a block will not be processed if it contains 2.1-only transactions, such as pay-to-alt-principal coinbases and explicit-version smart contracts.  This gating logic not only applies in block validation (which covers both the blockchain-processing and miner), but also in mempool acceptance.