### PR TITLE
Fix type error in monitoring_prom build

### DIFF
--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -128,8 +128,10 @@ pub fn set_last_execution_cost_observed(
 /// Log the number of transactions in the latest block.
 #[allow(unused_variables)]
 pub fn set_last_block_transaction_count(transactions_in_block: u64) {
+    // Saturating cast from u64 to i64
     #[cfg(feature = "monitoring_prom")]
-    prometheus::LAST_BLOCK_TRANSACTION_COUNT.set(transactions_in_block as f64);
+    prometheus::LAST_BLOCK_TRANSACTION_COUNT
+        .set(i64::try_from(transactions_in_block).unwrap_or_else(|_| i64::MAX));
 }
 
 pub fn increment_btc_ops_sent_counter() {


### PR DESCRIPTION
This fixes a build error in `develop` currently.