### PR TITLE
docs: fix output type of `as-max-len?`

### DIFF
--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -560,7 +560,7 @@ and outputs a list of the same type with max_len += 1.",
 
 const ASSERTS_MAX_LEN_API: SpecialAPI = SpecialAPI {
     input_type: "sequence_A, uint",
-    output_type: "sequence_A",
+    output_type: "(optional sequence_A)",
     signature: "(as-max-len? sequence max_length)",
     description:
         "The `as-max-len?` function takes a sequence argument and a uint-valued, literal length argument.


### PR DESCRIPTION
### Description
This is a very simple PR that fixes the output type of the `as-max-len?` in the documentation.

### Applicable issues
- N/A

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
