### PR TITLE
Adds human-readable time to logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ### Added
 - Added prometheus output for "transactions in last block" (#3138).
+- Added envrionement variable STACKS_LOG_FORMAT_TIME to set the time format
+  stacks-node uses for logging.
+  Example: STACKS_LOG_FORMAT_TIME="%Y-%m-%d %H:%M:%S" cargo stacks-node
 
 ### Changed
 - Updates to the logging of transaction events (#3139).

--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -41,15 +41,21 @@ fn print_msg_header(mut rd: &mut dyn RecordDecorator, record: &Record) -> io::Re
     write!(rd, " ")?;
 
     rd.start_timestamp()?;
-    let elapsed = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or(Duration::from_secs(0));
-    write!(
-        rd,
-        "[{:5}.{:06}]",
-        elapsed.as_secs(),
-        elapsed.subsec_nanos() / 1000
-    )?;
+    let system_time = SystemTime::now();
+    if env::var("BLOCKSTACK_FORMAT_TIME") != Ok("1".into()) {
+        let elapsed = system_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or(Duration::from_secs(0));
+        write!(
+            rd,
+            "[{:5}.{:06}]",
+            elapsed.as_secs(),
+            elapsed.subsec_nanos() / 1000
+        )?;
+    } else {
+        let datetime: DateTime<Local> = system_time.into();
+        write!(rd, "[{}]", datetime.format("%Y-%m-%d %H:%M:%S"))?;
+    }
     write!(rd, " ")?;
     write!(rd, "[{}:{}]", record.file(), record.line())?;
     write!(rd, " ")?;

--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -26,8 +26,7 @@ use std::time::{Duration, SystemTime};
 
 lazy_static! {
     pub static ref LOGGER: Logger = make_logger();
-    pub static ref STACKS_LOG_FORMAT_TIME: Result<String, env::VarError> =
-        env::var("STACKS_LOG_FORMAT_TIME");
+    pub static ref STACKS_LOG_FORMAT_TIME: Option<String> = env::var("STACKS_LOG_FORMAT_TIME").ok();
 }
 struct TermFormat<D: Decorator> {
     decorator: D,
@@ -45,7 +44,7 @@ fn print_msg_header(mut rd: &mut dyn RecordDecorator, record: &Record) -> io::Re
     rd.start_timestamp()?;
     let system_time = SystemTime::now();
     match &*STACKS_LOG_FORMAT_TIME {
-        Err(e) => {
+        None => {
             let elapsed = system_time
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or(Duration::from_secs(0));
@@ -56,7 +55,7 @@ fn print_msg_header(mut rd: &mut dyn RecordDecorator, record: &Record) -> io::Re
                 elapsed.subsec_nanos() / 1000
             )?;
         }
-        Ok(ref format) => {
+        Some(ref format) => {
             let datetime: DateTime<Local> = system_time.into();
             write!(rd, "[{}]", datetime.format(format))?;
         }


### PR DESCRIPTION
Adds the environment variable `BLOCKSTACK_FORMAT_TIME` to use human-readable time:

```
$ cargo stacks-node check-config
INFO [1658776091.841531] [testnet/stacks-node/src/main.rs:82] [main] stacks-node 0.1.0 (human-time:8a83e72f31+, debug build, macos [aarch64])
ERRO [1658776091.841989] [testnet/stacks-node/src/main.rs:58] [main] Process abort due to thread panic: panicked at 'called `Result::unwrap()` on an `Err` value: MissingOption(Keys(["--config", ""]))', testnet/stacks-node/src/main.rs:113:71
ERRO [1658776092.441379] [testnet/stacks-node/src/main.rs:60] [main] Panic backtrace:    0: backtrace::backtrace::libunwind::trace
```

```
$ STACKS_LOG_FORMAT_TIME="%Y-%m-%d %H:%M:%S" cargo stacks-node check-config
INFO [2022-07-25 14:09:58] [testnet/stacks-node/src/main.rs:82] [main] stacks-node 0.1.0 (human-time:8a83e72f31+, debug build, macos [aarch64])
ERRO [2022-07-25 14:09:58] [testnet/stacks-node/src/main.rs:58] [main] Process abort due to thread panic: panicked at 'called `Result::unwrap()` on an `Err` value: MissingOption(Keys(["--config", ""]))', testnet/stacks-node/src/main.rs:113:71
ERRO [2022-07-25 14:09:59] [testnet/stacks-node/src/main.rs:60] [main] Panic backtrace:    0: backtrace::backtrace::libunwind::trace
```