### PR TITLE
Fix in `next`: Type mismatches on new functions

### DIFF
--- a/clarity/src/vm/analysis/type_checker/natives/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/natives/mod.rs
@@ -509,7 +509,7 @@ fn check_principal_construct(
             TupleTypeSignature::try_from(vec![
                 ("error_code".into(), TypeSignature::UIntType),
                 (
-                    "principal".into(),
+                    "value".into(),
                     TypeSignature::new_option(TypeSignature::PrincipalType).expect("FATAL: failed to create (optional principal) type signature"),
                 ),
             ])

--- a/clarity/src/vm/analysis/type_checker/natives/sequences.rs
+++ b/clarity/src/vm/analysis/type_checker/natives/sequences.rs
@@ -410,7 +410,9 @@ pub fn check_special_slice(
     // Check sequence
     let seq_type = checker.type_check(&args[0], context)?;
     let seq = match seq_type {
-        TypeSignature::SequenceType(seq) => TypeSignature::SequenceType(seq),
+        TypeSignature::SequenceType(seq) => {
+            TypeSignature::new_option(TypeSignature::SequenceType(seq))?
+        }
         _ => return Err(CheckErrors::ExpectedSequence(seq_type).into()),
     };
 

--- a/clarity/src/vm/analysis/type_checker/tests/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/tests/mod.rs
@@ -1329,11 +1329,11 @@ fn test_slice_list() {
         "(slice (list) u0 u3)",
     ];
     let expected = [
-        "(list 7 int)",
-        "(list 5 uint)",
-        "(list 7 int)",
-        "(list 7 int)",
-        "(list 0 UnknownType)",
+        "(optional (list 7 int))",
+        "(optional (list 5 uint))",
+        "(optional (list 7 int))",
+        "(optional (list 7 int))",
+        "(optional (list 0 UnknownType))",
     ];
 
     for (good_test, expected) in good.iter().zip(expected.iter()) {
@@ -1365,7 +1365,7 @@ fn test_slice_buff() {
         "(slice 0x000102030405 u0 u3)",
         "(slice 0x000102030405 u3 u2)",
     ];
-    let expected = ["(buff 6)", "(buff 6)"];
+    let expected = ["(optional (buff 6))", "(optional (buff 6))"];
 
     for (good_test, expected) in good.iter().zip(expected.iter()) {
         assert_eq!(
@@ -1396,7 +1396,10 @@ fn test_slice_ascii() {
         "(slice \"blockstack\" u4 u5)",
         "(slice \"blockstack\" u0 u5)",
     ];
-    let expected = ["(string-ascii 10)", "(string-ascii 10)"];
+    let expected = [
+        "(optional (string-ascii 10))",
+        "(optional (string-ascii 10))",
+    ];
 
     for (good_test, expected) in good.iter().zip(expected.iter()) {
         assert_eq!(
@@ -1427,7 +1430,7 @@ fn test_slice_utf8() {
         "(slice u\"blockstack\" u4 u5)",
         "(slice u\"blockstack\" u4 u5)",
     ];
-    let expected = ["(string-utf8 10)", "(string-utf8 10)"];
+    let expected = ["(optional (string-utf8 10))", "(optional (string-utf8 10))"];
 
     for (good_test, expected) in good.iter().zip(expected.iter()) {
         assert_eq!(
@@ -2958,7 +2961,7 @@ fn test_principal_destruct() {
 fn test_principal_construct() {
     // This is the type we expect on success.
     let expected_type =
-        "(response principal (tuple (error_code uint) (principal (optional principal))))";
+        "(response principal (tuple (error_code uint) (value (optional principal))))";
     let good_pairs = [
         // Standard good example of a standard principal
         (

--- a/clarity/src/vm/functions/principals.rs
+++ b/clarity/src/vm/functions/principals.rs
@@ -112,12 +112,12 @@ fn create_principal_destruct_tuple(
 
 /// Creates Response return type, to wrap an *actual error* result of a `principal-construct`.
 ///
-/// The response is an error Response, where the `err` value is a tuple `{error_int,parse_tuple}`.
+/// The response is an error Response, where the `err` value is a tuple `{error_code, parse_tuple}`.
 /// `error_int` is of type `UInt`, `parse_tuple` is None.
 fn create_principal_true_error_response(error_int: PrincipalConstructErrorCode) -> Value {
     Value::error(Value::Tuple(
         TupleData::from_data(vec![
-            ("error_int".into(), Value::UInt(error_int as u128)),
+            ("error_code".into(), Value::UInt(error_int as u128)),
             ("value".into(), Value::none()),
         ])
         .expect("FAIL: Failed to initialize tuple."),
@@ -128,7 +128,7 @@ fn create_principal_true_error_response(error_int: PrincipalConstructErrorCode) 
 /// Creates Response return type, to wrap a *return value returned as an error* result of a
 /// `principal-construct`.
 ///
-/// The response is an error Response, where the `err` value is a tuple `{error_int,value}`.
+/// The response is an error Response, where the `err` value is a tuple `{error_code, value}`.
 /// `error_int` is of type `UInt`, `value` is of type `Some(Value)`.
 fn create_principal_value_error_response(
     error_int: PrincipalConstructErrorCode,
@@ -136,7 +136,7 @@ fn create_principal_value_error_response(
 ) -> Value {
     Value::error(Value::Tuple(
         TupleData::from_data(vec![
-            ("error_int".into(), Value::UInt(error_int as u128)),
+            ("error_code".into(), Value::UInt(error_int as u128)),
             (
                 "value".into(),
                 Value::some(value).expect("Unexpected problem creating Value."),

--- a/clarity/src/vm/tests/principals.rs
+++ b/clarity/src/vm/tests/principals.rs
@@ -850,7 +850,7 @@ fn test_principal_construct_version_byte_future() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::VERSION_BYTE as u128)
                     ),
                     (
@@ -885,7 +885,7 @@ fn test_principal_construct_version_byte_future() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::VERSION_BYTE as u128)
                     ),
                     (
@@ -1009,7 +1009,7 @@ fn test_principal_construct_response_errors() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::BUFFER_LENGTH as u128)
                     ),
                     ("value".into(), Value::none()),
@@ -1036,7 +1036,7 @@ fn test_principal_construct_response_errors() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::BUFFER_LENGTH as u128)
                     ),
                     ("value".into(), Value::none()),
@@ -1054,7 +1054,7 @@ fn test_principal_construct_response_errors() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::BUFFER_LENGTH as u128)
                     ),
                     ("value".into(), Value::none()),
@@ -1080,7 +1080,7 @@ fn test_principal_construct_response_errors() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::CONTRACT_NAME as u128)
                     ),
                     ("value".into(), Value::none()),
@@ -1106,7 +1106,7 @@ fn test_principal_construct_response_errors() {
             data: Box::new(Value::Tuple(
                 TupleData::from_data(vec![
                     (
-                        "error_int".into(),
+                        "error_code".into(),
                         Value::UInt(PrincipalConstructErrorCode::CONTRACT_NAME as u128)
                     ),
                     ("value".into(), Value::none()),


### PR DESCRIPTION
I discovered two mismatches between the typechecker and the runtime in new Clarity functions.

This PR fixes those mismatches, and adds a typing test to the documentation self-tests. This ensures that the typechecker's inferred types for all the examples admit the resulting value.
