### PR TITLE
Feat/runtime analysis errors

### DIFF
--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4661,6 +4661,7 @@ impl StacksChainState {
                             execution_cost,
                             microblock_header: None,
                             tx_index: 0,
+                            vm_error: None,
                         };
 
                         all_receipts.push(receipt);
@@ -4724,6 +4725,7 @@ impl StacksChainState {
                                     execution_cost: ExecutionCost::zero(),
                                     microblock_header: None,
                                     tx_index: 0,
+                                    vm_error: None,
                                 })
                             }
                             Err(e) => {

--- a/src/chainstate/stacks/events.rs
+++ b/src/chainstate/stacks/events.rs
@@ -49,4 +49,6 @@ pub struct StacksTransactionReceipt {
     pub execution_cost: ExecutionCost,
     pub microblock_header: Option<StacksMicroblockHeader>,
     pub tx_index: u32,
+    /// This is really a string-formatted CheckError (which can't be clone()'ed)
+    pub vm_error: Option<String>,
 }


### PR DESCRIPTION
This PR makes all `Error::Unchecked(..)` Clarity errors encountered at runtime into runtime errors that do not invalidate the block.  This feature is gated and only takes effect in Stacks 2.1.