### PR TITLE
docs: clarify amounts in microstacks

### DIFF
--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -1912,7 +1912,7 @@ const STX_GET_BALANCE: SimpleFunctionAPI = SimpleFunctionAPI {
     signature: "(stx-get-balance owner)",
     description: "`stx-get-balance` is used to query the STX balance of the `owner` principal.
 
-This function returns the STX balance, in microstacks (1 STX = 1000000 microstacks), of the
+This function returns the STX balance, in microstacks (1 STX = 1,000,000 microstacks), of the
 `owner` principal. In the event that the `owner` principal isn't materialized, it returns 0.
 ",
     example: "
@@ -1980,7 +1980,7 @@ const STX_BURN: SimpleFunctionAPI = SimpleFunctionAPI {
     name: None,
     signature: "(stx-burn? amount sender)",
     description: "`stx-burn?` decreases the `sender` principal's STX holdings by `amount`,
-specified in microstacks, destroying the STX. The `sender` principal _must_ be equal to the current
+specified in microstacks, by destroying the STX. The `sender` principal _must_ be equal to the current
 context's `tx-sender`.
 
 This function returns (ok true) if the transfer is successful. In the event of an unsuccessful transfer it returns

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -1912,8 +1912,8 @@ const STX_GET_BALANCE: SimpleFunctionAPI = SimpleFunctionAPI {
     signature: "(stx-get-balance owner)",
     description: "`stx-get-balance` is used to query the STX balance of the `owner` principal.
 
-This function returns the STX balance of the `owner` principal. In the event that the `owner`
-principal isn't materialized, it returns 0.
+This function returns the STX balance, in microstacks (1 STX = 1000000 microstacks), of the
+`owner` principal. In the event that the `owner` principal isn't materialized, it returns 0.
 ",
     example: "
 (stx-get-balance 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR) ;; Returns u0
@@ -1928,7 +1928,7 @@ const STX_GET_ACCOUNT: SimpleFunctionAPI = SimpleFunctionAPI {
 
 This function returns a tuple with the canonical account representation for an STX account.
 This includes the current amount of unlocked STX, the current amount of locked STX, and the
-unlock height for any locked STX.
+unlock height for any locked STX, all denominated in microstacks.
 ",
     example: r#"
 (stx-account 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR) ;; Returns (tuple (locked u0) (unlock-height u0) (unlocked u0))
@@ -1941,7 +1941,8 @@ const STX_TRANSFER: SpecialAPI = SpecialAPI {
     output_type: "(response bool uint)",
     signature: "(stx-transfer? amount sender recipient)",
     description: "`stx-transfer?` is used to increase the STX balance for the `recipient` principal
-by debiting the `sender` principal. The `sender` principal _must_ be equal to the current context's `tx-sender`.
+by debiting the `sender` principal by `amount`, specified in microstacks. The `sender` principal
+ _must_ be equal to the current context's `tx-sender`.
 
 This function returns (ok true) if the transfer is successful. In the event of an unsuccessful transfer it returns
 one of the following error codes:
@@ -1978,8 +1979,9 @@ This function returns (ok true) if the transfer is successful, or, on an error, 
 const STX_BURN: SimpleFunctionAPI = SimpleFunctionAPI {
     name: None,
     signature: "(stx-burn? amount sender)",
-    description: "`stx-burn?` decreases the `sender` principal's STX holdings by `amount`, destroying
-the STX. The `sender` principal _must_ be equal to the current context's `tx-sender`.
+    description: "`stx-burn?` decreases the `sender` principal's STX holdings by `amount`,
+specified in microstacks, destroying the STX. The `sender` principal _must_ be equal to the current
+context's `tx-sender`.
 
 This function returns (ok true) if the transfer is successful. In the event of an unsuccessful transfer it returns
 one of the following error codes:


### PR DESCRIPTION
### Description
There is no mention of microstacks in this documentation, which could be
confusing for new developers. This commit specifies the units for the
amounts used in  `stx-get-balance`, `stx-account`, `stx-transfer?` and
`stx-burn?`.

I did not see any consistency with line-wrapping, so I just eye-balled it to something that looked reasonable compared to the existing strings, but would be happy to make changes to that if you want.

One thing I am unclear on is whether https://docs.stacks.co/docs/write-smart-contracts/clarity-language/language-functions gets generated from this file or if I should also open a PR one that repo.

### Applicable issues
N/A

### Additional info (benefits, drawbacks, caveats)

### Checklist
N/A - documentation improvement only
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
