### PR TITLE
PoX 2 Unlock

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -4,13 +4,12 @@ WORKDIR /build
 
 ENV CARGO_MANIFEST_DIR="$(pwd)"
 
-RUN rustup override set nightly-2022-01-14 && \
-    rustup component add llvm-tools-preview && \
+RUN rustup component add llvm-tools-preview && \
     cargo install grcov
 
-ENV RUSTFLAGS="-Zinstrument-coverage" \
+ENV RUSTFLAGS="-Cinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
-    
+
 COPY . .
 
 RUN cargo build --workspace && \

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -6,11 +6,10 @@ COPY . .
 
 WORKDIR /src/testnet/stacks-node
 
-RUN rustup override set nightly-2022-01-14 && \
-    rustup component add llvm-tools-preview && \
+RUN rustup component add llvm-tools-preview && \
     cargo install grcov
 
-ENV RUSTFLAGS="-Zinstrument-coverage" \
+ENV RUSTFLAGS="-Cinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
 RUN cargo test --no-run && \

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -9,11 +9,10 @@ RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
-RUN rustup override set nightly-2022-01-14 && \
-    rustup component add llvm-tools-preview && \
+RUN rustup component add llvm-tools-preview && \
     cargo install grcov
 
-ENV RUSTFLAGS="-Zinstrument-coverage" \
+ENV RUSTFLAGS="-Cinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
 RUN cargo test --no-run --workspace && \

--- a/clarity/src/vm/clarity.rs
+++ b/clarity/src/vm/clarity.rs
@@ -149,6 +149,14 @@ pub trait ClarityConnection {
 }
 
 pub trait TransactionConnection: ClarityConnection {
+    /// Do something with this connection's Clarity environment that can be aborted
+    ///  with `abort_call_back`.
+    /// This returns the return value of `to_do`:
+    ///  * the generic term `R`
+    ///  * the asset changes during `to_do` in an `AssetMap`
+    ///  * the Stacks events during the transaction
+    /// and a `bool` value which is `true` if the `abort_call_back` caused the changes to abort
+    /// If `to_do` returns an `Err` variant, then the changes are aborted.
     fn with_abort_callback<F, A, R, E>(
         &mut self,
         to_do: F,

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1083,6 +1083,12 @@ impl<'a, 'b> Environment<'a, 'b> {
         self.inner_execute_contract(contract, tx_name, args, read_only, true)
     }
 
+    /// This method handles actual execution of contract-calls on a contract.
+    ///
+    /// `allow_private` should always be set to `false` for user transactions:
+    ///  this ensures that only `define-public` and `define-read-only` methods can
+    ///  be invoked. The `allow_private` mode should only be used by
+    ///  `Environment::execute_contract_allow_private`.
     fn inner_execute_contract(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,

--- a/clarity/src/vm/contexts.rs
+++ b/clarity/src/vm/contexts.rs
@@ -1062,10 +1062,34 @@ impl<'a, 'b> Environment<'a, 'b> {
 
     pub fn execute_contract(
         &mut self,
+        contract: &QualifiedContractIdentifier,
+        tx_name: &str,
+        args: &[SymbolicExpression],
+        read_only: bool,
+    ) -> Result<Value> {
+        self.inner_execute_contract(contract, tx_name, args, read_only, false)
+    }
+
+    /// This method is exposed for callers that need to invoke a private method directly.
+    /// For example, this is used by the Stacks chainstate for invoking private methods
+    /// on the pox-2 contract. This should not be called by user transaction processing.
+    pub fn execute_contract_allow_private(
+        &mut self,
+        contract: &QualifiedContractIdentifier,
+        tx_name: &str,
+        args: &[SymbolicExpression],
+        read_only: bool,
+    ) -> Result<Value> {
+        self.inner_execute_contract(contract, tx_name, args, read_only, true)
+    }
+
+    fn inner_execute_contract(
+        &mut self,
         contract_identifier: &QualifiedContractIdentifier,
         tx_name: &str,
         args: &[SymbolicExpression],
         read_only: bool,
+        allow_private: bool,
     ) -> Result<Value> {
         let contract_size = self
             .global_context
@@ -1080,7 +1104,7 @@ impl<'a, 'b> Environment<'a, 'b> {
 
             let func = contract.contract_context.lookup_function(tx_name)
                 .ok_or_else(|| { CheckErrors::UndefinedFunction(tx_name.to_string()) })?;
-            if !func.is_public() {
+            if !allow_private && !func.is_public() {
                 return Err(CheckErrors::NoSuchPublicFunction(contract_identifier.to_string(), tx_name.to_string()).into());
             } else if read_only && !func.is_read_only() {
                 return Err(CheckErrors::PublicFunctionNotReadOnly(contract_identifier.to_string(), tx_name.to_string()).into());

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -1166,6 +1166,23 @@ impl<'a> ClarityDatabase<'a> {
         )
     }
 
+    /// Like fetch_entry_unknown_descriptor, except that it expects
+    ///  to receive a value (i.e., it expects the state to exist)
+    /// This should only ever be invoked outside of Clarity, e.g. by the VM
+    ///  when loading state from a known-contract
+    pub fn expect_fetch_entry(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        map_name: &str,
+        key_value: &Value,
+    ) -> Result<Value> {
+        self.fetch_entry_unknown_descriptor(contract_identifier, map_name, key_value)
+            .map(|v| {
+                v.expect_optional()
+                    .expect("Expected fetch_entry to return a value")
+            })
+    }
+
     pub fn fetch_entry_unknown_descriptor(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
@@ -1176,6 +1193,7 @@ impl<'a> ClarityDatabase<'a> {
         self.fetch_entry(contract_identifier, map_name, key_value, &descriptor)
     }
 
+    /// Returns a Clarity optional type wrapping a found or not found result
     pub fn fetch_entry(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
@@ -1358,6 +1376,16 @@ impl<'a> ClarityDatabase<'a> {
                 .checked_add(placed_size)
                 .expect("Overflowed Clarity key/value size"),
         })
+    }
+
+    pub fn delete_entry_unknown_descriptor(
+        &mut self,
+        contract_identifier: &QualifiedContractIdentifier,
+        map_name: &str,
+        key_value: &Value,
+    ) -> Result<ValueResult> {
+        let descriptor = self.load_map(contract_identifier, map_name)?;
+        self.delete_entry(contract_identifier, map_name, key_value, &descriptor)
     }
 
     pub fn delete_entry(

--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -1205,23 +1205,6 @@ impl<'a> ClarityDatabase<'a> {
         )
     }
 
-    /// Like fetch_entry_unknown_descriptor, except that it expects
-    ///  to receive a value (i.e., it expects the state to exist)
-    /// This should only ever be invoked outside of Clarity, e.g. by the VM
-    ///  when loading state from a known-contract
-    pub fn expect_fetch_entry(
-        &mut self,
-        contract_identifier: &QualifiedContractIdentifier,
-        map_name: &str,
-        key_value: &Value,
-    ) -> Result<Value> {
-        self.fetch_entry_unknown_descriptor(contract_identifier, map_name, key_value)
-            .map(|v| {
-                v.expect_optional()
-                    .expect("Expected fetch_entry to return a value")
-            })
-    }
-
     pub fn fetch_entry_unknown_descriptor(
         &mut self,
         contract_identifier: &QualifiedContractIdentifier,
@@ -1415,16 +1398,6 @@ impl<'a> ClarityDatabase<'a> {
                 .checked_add(placed_size)
                 .expect("Overflowed Clarity key/value size"),
         })
-    }
-
-    pub fn delete_entry_unknown_descriptor(
-        &mut self,
-        contract_identifier: &QualifiedContractIdentifier,
-        map_name: &str,
-        key_value: &Value,
-    ) -> Result<ValueResult> {
-        let descriptor = self.load_map(contract_identifier, map_name)?;
-        self.delete_entry(contract_identifier, map_name, key_value, &descriptor)
     }
 
     pub fn delete_entry(

--- a/clarity/src/vm/database/structures.rs
+++ b/clarity/src/vm/database/structures.rs
@@ -485,15 +485,9 @@ impl<'db, 'conn> STXBalanceSnapshot<'db, 'conn> {
         let new_unlock_height = self.burn_block_height + 1;
         self.balance = match self.balance {
             STXBalance::Unlocked { amount } => STXBalance::Unlocked { amount },
-            STXBalance::LockedPoxOne {
-                amount_unlocked,
-                amount_locked,
-                ..
-            } => STXBalance::LockedPoxOne {
-                amount_unlocked,
-                amount_locked,
-                unlock_height: new_unlock_height,
-            },
+            STXBalance::LockedPoxOne { .. } => {
+                unreachable!("Attempted to accelerate the unlock of a lockup created by PoX-1")
+            }
             STXBalance::LockedPoxTwo {
                 amount_unlocked,
                 amount_locked,

--- a/clarity/src/vm/database/structures.rs
+++ b/clarity/src/vm/database/structures.rs
@@ -474,9 +474,8 @@ impl<'db, 'conn> STXBalanceSnapshot<'db, 'conn> {
         };
     }
 
-    /// Lock `amount_to_lock` tokens on this account until `unlock_burn_height`.
-    /// After calling, this method will set the balance to a "LockedPoxTwo" balance,
-    ///  because this method is only invoked as a result of PoX2 interactions
+    /// If this snapshot is locked, then alter the lock height to be
+    /// the next burn block (i.e., `self.burn_block_height + 1`)
     pub fn accelerate_unlock(&mut self) {
         let unlocked = self.unlock_available_tokens_if_any();
         if unlocked > 0 {

--- a/clarity/src/vm/types/mod.rs
+++ b/clarity/src/vm/types/mod.rs
@@ -1359,13 +1359,6 @@ impl TupleData {
         self.data_map.len() as u64
     }
 
-    /// This is like `from_data` for constructing a tuple, but is to be used in contexts
-    /// where the constructed tuple is *known* to be a valid Clarity value (e.g., static contexts)
-    /// This panics if the tuple is not a valid Clarity value.
-    pub fn from_data_static(data: Vec<(ClarityName, Value)>) -> TupleData {
-        Self::from_data(data).expect("FATAL: static Clarity tuple initialization failed")
-    }
-
     pub fn from_data(mut data: Vec<(ClarityName, Value)>) -> Result<TupleData> {
         let mut type_map = BTreeMap::new();
         let mut data_map = BTreeMap::new();

--- a/clarity/src/vm/types/mod.rs
+++ b/clarity/src/vm/types/mod.rs
@@ -1339,6 +1339,13 @@ impl TupleData {
         self.data_map.len() as u64
     }
 
+    /// This is like `from_data` for constructing a tuple, but is to be used in contexts
+    /// where the constructed tuple is *known* to be a valid Clarity value (e.g., static contexts)
+    /// This panics if the tuple is not a valid Clarity value.
+    pub fn from_data_static(data: Vec<(ClarityName, Value)>) -> TupleData {
+        Self::from_data(data).expect("FATAL: static Clarity tuple initialization failed")
+    }
+
     pub fn from_data(mut data: Vec<(ClarityName, Value)>) -> Result<TupleData> {
         let mut type_map = BTreeMap::new();
         let mut data_map = BTreeMap::new();

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -46,6 +46,7 @@ use crate::burnchains::{
     BurnchainStateTransition, BurnchainStateTransitionOps, BurnchainTransaction,
     Error as burnchain_error, PoxConstants,
 };
+use crate::chainstate::burn::db::sortdb::SortitionHandle;
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleConn, SortitionHandleTx};
 use crate::chainstate::burn::distribution::BurnSamplePoint;
 use crate::chainstate::burn::operations::{

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -73,11 +73,11 @@ use crate::util_lib::db::Error as db_error;
 use stacks_common::address::public_keys_to_address_hash;
 use stacks_common::address::AddressHashMode;
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash as BitcoinSha256dHash;
-use stacks_common::util::{get_epoch_time_ms, sleep_ms};
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::log;
 use stacks_common::util::vrf::VRFPublicKey;
+use stacks_common::util::{get_epoch_time_ms, sleep_ms};
 
 use crate::burnchains::bitcoin::indexer::BitcoinIndexer;
 use crate::chainstate::stacks::boot::POX_2_MAINNET_CODE;

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -502,7 +502,9 @@ impl Burnchain {
         burn_ht: u64,
         reward_cycle_length: u64,
     ) -> bool {
-        let effective_height = burn_ht - first_block_ht;
+        let effective_height = burn_ht
+            .checked_sub(first_block_ht)
+            .expect("FATAL: attempted to check reward cycle start before first block height");
         // first block of the new reward cycle
         (effective_height % reward_cycle_length) <= 1
     }

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -491,6 +491,18 @@ impl Burnchain {
         )
     }
 
+    /// Is this block the block in a reward cycle right before the reward phase
+    ///  starts? This is the mod 0 block.
+    pub fn is_pre_reward_cycle_start(
+        first_block_ht: u64,
+        burn_ht: u64,
+        reward_cycle_length: u64,
+    ) -> bool {
+        let effective_height = burn_ht - first_block_ht;
+        // first block of the new reward cycle
+        (effective_height % reward_cycle_length) <= 1
+    }
+
     pub fn static_is_in_prepare_phase(
         first_block_height: u64,
         reward_cycle_length: u64,

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -492,9 +492,12 @@ impl Burnchain {
         )
     }
 
-    /// Is this block the block in a reward cycle right before the reward phase
-    ///  starts? This is the mod 0 block.
-    pub fn is_pre_reward_cycle_start(
+    /// Is this block either the first block in a reward cycle or
+    ///  right before the reward phase starts? This is the mod 0 or mod 1
+    ///  block. Reward cycle start events (like auto-unlocks) process *after*
+    ///  the first reward block, so this function is used to determine when
+    ///  that has passed.
+    pub fn is_before_reward_cycle(
         first_block_ht: u64,
         burn_ht: u64,
         reward_cycle_length: u64,

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1506,7 +1506,6 @@ impl<'a> SortitionHandleConn<'a> {
         SortitionHandleConn::open_reader(connection, &sn.sortition_id)
     }
 
-    #[cfg(test)]
     pub fn get_last_anchor_block_hash(&self) -> Result<Option<BlockHeaderHash>, db_error> {
         let anchor_block_hash = SortitionDB::parse_last_anchor_block_hash(
             self.get_indexed(&self.context.chain_tip, &db_keys::pox_last_anchor())?,
@@ -1544,6 +1543,66 @@ impl<'a> SortitionHandleConn<'a> {
             },
             index: &connection.index,
         })
+    }
+
+    /// is the given block a descendant of `potential_ancestor`?
+    ///  * block_at_burn_height: the burn height of the sortition that chose the stacks block to check
+    ///  * potential_ancestor: the stacks block hash of the potential ancestor
+    pub fn descended_from(
+        &mut self,
+        block_at_burn_height: u64,
+        potential_ancestor: &BlockHeaderHash,
+    ) -> Result<bool, db_error> {
+        let earliest_block_height = self.conn().query_row(
+            "SELECT block_height FROM snapshots WHERE winning_stacks_block_hash = ? ORDER BY block_height ASC LIMIT 1",
+            &[potential_ancestor],
+            |row| Ok(u64::from_row(row).expect("Expected u64 in database")))?;
+
+        let mut sn = self
+            .get_block_snapshot_by_height(block_at_burn_height)?
+            .ok_or_else(|| {
+                test_debug!("No snapshot at height {}", block_at_burn_height);
+                db_error::NotFoundError
+            })?;
+
+        while sn.block_height >= earliest_block_height {
+            if !sn.sortition {
+                return Ok(false);
+            }
+            if &sn.winning_stacks_block_hash == potential_ancestor {
+                return Ok(true);
+            }
+
+            // step back to the parent
+            match SortitionDB::get_block_commit_parent_sortition_id(
+                self.conn(),
+                &sn.winning_block_txid,
+                &sn.sortition_id,
+            )? {
+                Some(parent_sortition_id) => {
+                    // we have the block_commit parent memoization data
+                    test_debug!(
+                        "Parent sortition of {} memoized as {}",
+                        &sn.winning_block_txid,
+                        &parent_sortition_id
+                    );
+                    sn = SortitionDB::get_block_snapshot(self.conn(), &parent_sortition_id)?
+                        .ok_or_else(|| db_error::NotFoundError)?;
+                }
+                None => {
+                    // we do not have the block_commit parent memoization data
+                    // step back to the parent
+                    test_debug!("No parent sortition memo for {}", &sn.winning_block_txid);
+                    let block_commit =
+                        get_block_commit_by_txid(&self.conn(), &sn.winning_block_txid)?
+                            .expect("CORRUPTION: winning block commit for snapshot not found");
+                    sn = self
+                        .get_block_snapshot_by_height(block_commit.parent_block_ptr as u64)?
+                        .ok_or_else(|| db_error::NotFoundError)?;
+                }
+            }
+        }
+        return Ok(false);
     }
 
     fn get_tip_indexed(&self, key: &str) -> Result<Option<String>, db_error> {

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -1637,66 +1637,6 @@ impl<'a> SortitionHandleConn<'a> {
         })
     }
 
-    /// is the given block a descendant of `potential_ancestor`?
-    ///  * block_at_burn_height: the burn height of the sortition that chose the stacks block to check
-    ///  * potential_ancestor: the stacks block hash of the potential ancestor
-    pub fn descended_from(
-        &mut self,
-        block_at_burn_height: u64,
-        potential_ancestor: &BlockHeaderHash,
-    ) -> Result<bool, db_error> {
-        let earliest_block_height = self.conn().query_row(
-            "SELECT block_height FROM snapshots WHERE winning_stacks_block_hash = ? ORDER BY block_height ASC LIMIT 1",
-            &[potential_ancestor],
-            |row| Ok(u64::from_row(row).expect("Expected u64 in database")))?;
-
-        let mut sn = self
-            .get_block_snapshot_by_height(block_at_burn_height)?
-            .ok_or_else(|| {
-                test_debug!("No snapshot at height {}", block_at_burn_height);
-                db_error::NotFoundError
-            })?;
-
-        while sn.block_height >= earliest_block_height {
-            if !sn.sortition {
-                return Ok(false);
-            }
-            if &sn.winning_stacks_block_hash == potential_ancestor {
-                return Ok(true);
-            }
-
-            // step back to the parent
-            match SortitionDB::get_block_commit_parent_sortition_id(
-                self.conn(),
-                &sn.winning_block_txid,
-                &sn.sortition_id,
-            )? {
-                Some(parent_sortition_id) => {
-                    // we have the block_commit parent memoization data
-                    test_debug!(
-                        "Parent sortition of {} memoized as {}",
-                        &sn.winning_block_txid,
-                        &parent_sortition_id
-                    );
-                    sn = SortitionDB::get_block_snapshot(self.conn(), &parent_sortition_id)?
-                        .ok_or_else(|| db_error::NotFoundError)?;
-                }
-                None => {
-                    // we do not have the block_commit parent memoization data
-                    // step back to the parent
-                    test_debug!("No parent sortition memo for {}", &sn.winning_block_txid);
-                    let block_commit =
-                        get_block_commit_by_txid(&self.conn(), &sn.winning_block_txid)?
-                            .expect("CORRUPTION: winning block commit for snapshot not found");
-                    sn = self
-                        .get_block_snapshot_by_height(block_commit.parent_block_ptr as u64)?
-                        .ok_or_else(|| db_error::NotFoundError)?;
-                }
-            }
-        }
-        return Ok(false);
-    }
-
     fn get_tip_indexed(&self, key: &str) -> Result<Option<String>, db_error> {
         self.get_indexed(&self.context.chain_tip, key)
     }

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -23,6 +23,7 @@ use crate::burnchains::BurnchainBlockHeader;
 use crate::burnchains::Txid;
 use crate::burnchains::{BurnchainRecipient, BurnchainSigner};
 use crate::burnchains::{BurnchainTransaction, PublicKey};
+use crate::chainstate::burn::db::sortdb::SortitionHandle;
 use crate::chainstate::burn::db::sortdb::{SortitionDB, SortitionHandleTx};
 use crate::chainstate::burn::operations::Error as op_error;
 use crate::chainstate::burn::operations::{

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -33,6 +33,7 @@ use crate::chainstate::burn::operations::leader_block_commit::*;
 use crate::chainstate::burn::operations::*;
 use crate::chainstate::burn::*;
 use crate::chainstate::coordinator::{Error as CoordError, *};
+use crate::chainstate::stacks::boot::PoxStartCycleInfo;
 use crate::chainstate::stacks::db::{
     accounts::MinerReward, ClarityTx, StacksChainState, StacksHeaderInfo,
 };
@@ -359,8 +360,13 @@ impl RewardSetProvider for StubbedRewardSetProvider {
         burnchain: &Burnchain,
         sortdb: &SortitionDB,
         block_id: &StacksBlockId,
-    ) -> Result<Vec<StacksAddress>, chainstate::coordinator::Error> {
-        Ok(self.0.clone())
+    ) -> Result<RewardSet, chainstate::coordinator::Error> {
+        Ok(RewardSet {
+            rewarded_addresses: self.0.clone(),
+            start_cycle_state: PoxStartCycleInfo {
+                missed_reward_slots: vec![],
+            },
+        })
     }
 }
 

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -942,6 +942,7 @@ fn pox_2_lock_extend_units() {
                 } else {
                     &POX_ADDRS[1]
                 };
+                let expected_stacker = Value::from(&USER_KEYS[1]);
                 assert_eq!(
                     env.eval_read_only(
                         &POX_2_CONTRACT_TESTNET,
@@ -950,9 +951,10 @@ fn pox_2_lock_extend_units() {
                         .unwrap()
                         .0,
                     execute(&format!(
-                        "{{ pox-addr: {}, total-ustx: u{} }}",
+                        "{{ pox-addr: {}, total-ustx: u{}, stacker: (some '{}) }}",
                         expected_pox_addr,
-                        1_000_000
+                        1_000_000,
+                        &expected_stacker,
                     ))
                 );
             }
@@ -1508,7 +1510,7 @@ fn pox_2_delegate_extend_units() {
                         .unwrap()
                         .0,
                     execute(&format!(
-                        "{{ pox-addr: {}, total-ustx: u{} }}",
+                        "{{ pox-addr: {}, total-ustx: u{}, stacker: none }}",
                         expected_pox_addr,
                         MIN_THRESHOLD.deref(),
                     ))

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -1443,7 +1443,7 @@ fn pox_2_delegate_extend_units() {
             .unwrap()
             .0.to_string(), "(err 21)".to_string(),
             "Delegate cannot stack-extend for User0 for 10 cycles",
-);
+        );
 
         assert_eq!(
             env.execute_transaction(

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -141,6 +141,12 @@ pub struct RawRewardSetEntry {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PoxStartCycleInfo {
+    /// This data contains the set of principals who missed a reward slot
+    ///  in this reward cycle.
+    ///
+    /// The first element of the tuple is the principal whose microSTX
+    ///  were locked, and the second element is the amount of microSTX
+    ///  that were locked
     pub missed_reward_slots: Vec<(PrincipalData, u128)>,
 }
 
@@ -411,7 +417,14 @@ impl StacksChainState {
             if let Some(stacker) = stacker.as_ref() {
                 contributed_stackers.push((stacker.clone(), stacked_amt));
             }
-            // peak at the next address in the set, and see if we need to sum
+            // Here we check if we should combine any entries with the same
+            //  reward address together in the reward set.
+            // The outer while loop pops the last element of the
+            //  addresses vector, and here we peak at the last item in
+            //  the vector (via last()). Because the items in the
+            //  vector are sorted by address, we know that any entry
+            //  with the same `reward_address` as `address` will be at the end of
+            //  the list (and therefore found by this loop)
             while addresses.last().map(|x| &x.reward_address) == Some(&address) {
                 let next_contrib = addresses
                     .pop()

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -233,6 +233,8 @@ impl StacksChainState {
     ) -> Result<(), Error> {
         clarity.with_clarity_db(|db| Ok(Self::mark_pox_cycle_handled(db, cycle_number)))?;
 
+        debug!("Handling PoX reward cycle start"; "reward_cycle" => cycle_number, "cycle_active" => cycle_info.is_some());
+
         let cycle_info = match cycle_info {
             Some(x) => x,
             None => return Ok(()),
@@ -461,22 +463,6 @@ impl StacksChainState {
         }
 
         Ok(())
-    }
-
-    /// After Stacks 2.1, invoke to process any Stacks chainstate operations required
-    ///  at the start of a reward cycle (i.e., qualifying unlocks)
-    pub fn process_pox_cycle_start_2_1(last_anchor_block: Option<BlockHeaderHash>) {
-        // Step 1: determine if a PoX anchor block was chosen for this cycle
-        //  *and* that this Stacks block descends from that block
-        match last_anchor_block {
-            Some(_) => {}
-            None => {
-                debug!(
-                    "No anchor block chosen in this PoX cycle, so no need to process cycle start"
-                );
-                return;
-            }
-        }
     }
 
     fn eval_boot_code_read_only(

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -995,7 +995,9 @@ pub mod test {
             },
         ];
         assert_eq!(
-            StacksChainState::make_reward_set(threshold, addresses).len(),
+            StacksChainState::make_reward_set(threshold, addresses)
+                .rewarded_addresses
+                .len(),
             3
         );
     }

--- a/src/chainstate/stacks/boot/pox-2.clar
+++ b/src/chainstate/stacks/boot/pox-2.clar
@@ -296,7 +296,7 @@
                      { total-ustx: (+ (get amount-ustx params) total-ustx) })
                   (some reward-index))
             none))
-          (next-i (if (< i num-cycles) (+ i u1) (+ i u0))))
+          (next-i (if (< i num-cycles) (+ i u1) i)))
     {
         pox-addr: (get pox-addr params),
         first-reward-cycle: (get first-reward-cycle params),

--- a/src/chainstate/stacks/boot/pox-2.clar
+++ b/src/chainstate/stacks/boot/pox-2.clar
@@ -393,7 +393,7 @@
                                   (num-cycles uint))
   (begin
     ;; minimum uSTX must be met
-    (asserts! (<= (print (get-stacking-minimum)) amount-ustx)
+    (asserts! (<= (get-stacking-minimum) amount-ustx)
               (err ERR_STACKING_THRESHOLD_NOT_MET))
 
     (minimal-can-stack-stx pox-addr amount-ustx first-reward-cycle num-cycles)))

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -12,9 +12,11 @@ use crate::chainstate::stacks::boot::{
 use crate::chainstate::stacks::db::{
     MinerPaymentSchedule, StacksHeaderInfo, MINER_REWARD_MATURITY,
 };
+use crate::chainstate::stacks::index::marf::MarfConnection;
 use crate::chainstate::stacks::index::MarfTrieId;
 use crate::chainstate::stacks::*;
 use crate::clarity_vm::database::marf::MarfedKV;
+use crate::clarity_vm::database::HeadersDBConn;
 use crate::core::*;
 use crate::util_lib::db::{DBConn, FromRow};
 use clarity::vm::contexts::OwnedEnvironment;
@@ -51,7 +53,7 @@ use stacks_common::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksBlockId, VRFSeed,
 };
 
-use super::test::*;
+use super::{test::*, RawRewardSetEntry};
 use crate::clarity_vm::clarity::Error as ClarityError;
 
 use crate::chainstate::burn::operations::*;
@@ -64,6 +66,84 @@ const USTX_PER_HOLDER: u128 = 1_000_000;
 ///  SortitionDB option-reference. Panics on any errors.
 fn get_tip(sortdb: Option<&SortitionDB>) -> BlockSnapshot {
     SortitionDB::get_canonical_burn_chain_tip(&sortdb.unwrap().conn()).unwrap()
+}
+
+/// Get the reward set entries if evaluated at the given StacksBlock
+pub fn get_reward_set_entries_at(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    at_burn_ht: u64,
+) -> Vec<RawRewardSetEntry> {
+    let burnchain = peer.config.burnchain.clone();
+    with_sortdb(peer, |ref mut c, ref sortdb| {
+        get_reward_set_entries_at_block(c, &burnchain, sortdb, tip, at_burn_ht).unwrap()
+    })
+}
+
+/// Get the STXBalance for `account` at the given chaintip
+pub fn get_stx_account_at(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    account: &PrincipalData,
+) -> STXBalance {
+    with_clarity_db_ro(peer, tip, |db| db.get_account_stx_balance(account))
+}
+
+/// Get the STXBalance for `account` at the given chaintip
+pub fn get_stacking_state_pox_2(
+    peer: &mut TestPeer,
+    tip: &StacksBlockId,
+    account: &PrincipalData,
+) -> Option<Value> {
+    with_clarity_db_ro(peer, tip, |db| {
+        let lookup_tuple = Value::Tuple(TupleData::from_data_static(vec![(
+            "stacker".into(),
+            account.clone().into(),
+        )]));
+        db.fetch_entry_unknown_descriptor(
+            &boot_code_id(boot::POX_2_NAME, false),
+            "stacking-state",
+            &lookup_tuple,
+        )
+        .unwrap()
+        .expect_optional()
+    })
+}
+
+/// Get the `cycle_number`'s total stacked amount at the given chaintip
+pub fn get_reward_cycle_total(peer: &mut TestPeer, tip: &StacksBlockId, cycle_number: u64) -> u128 {
+    with_clarity_db_ro(peer, tip, |db| {
+        let total_stacked_key = TupleData::from_data_static(vec![(
+            "reward-cycle".into(),
+            Value::UInt(cycle_number.into()),
+        )])
+        .into();
+        db.expect_fetch_entry(
+            &boot_code_id(boot::POX_2_NAME, false),
+            "reward-cycle-total-stacked",
+            &total_stacked_key,
+        )
+        .unwrap()
+        .expect_tuple()
+        .get_owned("total-ustx")
+        .expect("Malformed tuple returned by PoX contract")
+        .expect_u128()
+    })
+}
+
+/// Allows you to do something read-only with the ClarityDB at the given chaintip
+pub fn with_clarity_db_ro<F, R>(peer: &mut TestPeer, tip: &StacksBlockId, todo: F) -> R
+where
+    F: FnOnce(&mut ClarityDatabase) -> R,
+{
+    with_sortdb(peer, |ref mut c, ref sortdb| {
+        let headers_db = HeadersDBConn(c.state_index.sqlite_conn());
+        let burn_db = sortdb.index_conn();
+        let mut read_only_clar = c
+            .clarity_state
+            .read_only_connection(tip, &headers_db, &burn_db);
+        read_only_clar.with_clarity_db_readonly(todo)
+    })
 }
 
 /// In this test case, two Stackers, Alice and Bob stack and interact with the
@@ -502,6 +582,256 @@ fn test_simple_pox_lockup_transition_pox_2() {
             _ => false,
         },
         "Charlie tx0 should have committed okay"
+    );
+}
+
+#[test]
+fn test_simple_pox_2_auto_unlock_ab() {
+    test_simple_pox_2_auto_unlock(true)
+}
+
+#[test]
+fn test_simple_pox_2_auto_unlock_ba() {
+    test_simple_pox_2_auto_unlock(false)
+}
+
+/// In this test case, two Stackers, Alice and Bob stack and interact with the
+///  PoX v1 contract and PoX v2 contract across the epoch transition.
+///
+/// Alice: stacks via PoX v1 for 4 cycles. The third of these cycles occurs after
+///        the PoX v1 -> v2 transition, and so Alice gets "early unlocked".
+///        After the early unlock, Alice re-stacks in PoX v2
+///        Alice tries to stack again via PoX v1, which is allowed by the contract,
+///        but forbidden by the VM (because PoX has transitioned to v2)
+/// Bob:   stacks via PoX v2 for 6 cycles. He attempted to stack via PoX v1 as well,
+///        but is forbidden because he has already placed an account lock via PoX v2.
+///
+/// Note: this test is symmetric over the order of alice and bob's stacking calls.
+///       when alice goes first, the auto-unlock code doesn't need to perform a "move"
+///       when bob goes first, the auto-unlock code does need to perform a "move"
+fn test_simple_pox_2_auto_unlock(alice_first: bool) {
+    // this is the number of blocks after the first sortition any V1
+    // PoX locks will automatically unlock at.
+    let AUTO_UNLOCK_HEIGHT = 12;
+    let EXPECTED_FIRST_V2_CYCLE = 8;
+    // the sim environment produces 25 empty sortitions before
+    //  tenures start being tracked.
+    let EMPTY_SORTITIONS = 25;
+
+    let mut burnchain = Burnchain::default_unittest(0, &BurnchainHeaderHash::zero());
+    burnchain.pox_constants.reward_cycle_length = 5;
+    burnchain.pox_constants.prepare_length = 2;
+    burnchain.pox_constants.anchor_threshold = 1;
+    burnchain.pox_constants.pox_participation_threshold_pct = 1;
+    burnchain.pox_constants.v1_unlock_height = AUTO_UNLOCK_HEIGHT + EMPTY_SORTITIONS;
+
+    let first_v2_cycle = burnchain
+        .block_height_to_reward_cycle(burnchain.pox_constants.v1_unlock_height as u64)
+        .unwrap()
+        + 1;
+
+    assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
+
+    eprintln!("First v2 cycle = {}", first_v2_cycle);
+
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+
+    let observer = TestEventObserver::new();
+
+    let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
+        &burnchain,
+        &format!("test_simple_pox_2_auto_unlock_{}", alice_first),
+        6002,
+        Some(epochs.clone()),
+        Some(&observer),
+    );
+
+    let num_blocks = 35;
+
+    let alice = keys.pop().unwrap();
+    let bob = keys.pop().unwrap();
+    let charlie = keys.pop().unwrap();
+
+    let mut coinbase_nonce = 0;
+
+    // produce blocks until the epoch switch
+    for _i in 0..10 {
+        peer.tenure_with_txs(&[], &mut coinbase_nonce);
+    }
+
+    // in the next tenure, PoX 2 should now exist.
+    // Lets have Bob lock up for v2
+    // this will lock for cycles 8, 9, 10, and 11
+    //  the first v2 cycle will be 8
+    let tip = get_tip(peer.sortdb.as_ref());
+
+    let alice_lockup = make_pox_2_lockup(
+        &alice,
+        0,
+        1024 * POX_THRESHOLD_STEPS_USTX,
+        AddressHashMode::SerializeP2PKH,
+        key_to_stacks_addr(&alice).bytes,
+        6,
+        tip.block_height,
+    );
+
+    let bob_lockup = make_pox_2_lockup(
+        &bob,
+        0,
+        1 * POX_THRESHOLD_STEPS_USTX,
+        AddressHashMode::SerializeP2PKH,
+        key_to_stacks_addr(&bob).bytes,
+        6,
+        tip.block_height,
+    );
+
+    // our "tenure counter" is now at 10
+    assert_eq!(tip.block_height, 10 + EMPTY_SORTITIONS as u64);
+
+    let txs = if alice_first {
+        [alice_lockup, bob_lockup]
+    } else {
+        [bob_lockup, alice_lockup]
+    };
+    let mut latest_block = peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+
+    // check that the "raw" reward set will contain entries for alice and bob
+    //  at the cycle start
+    for cycle_number in EXPECTED_FIRST_V2_CYCLE..(EXPECTED_FIRST_V2_CYCLE + 6) {
+        let cycle_start = burnchain.reward_cycle_to_block_height(cycle_number);
+        let reward_set_entries = get_reward_set_entries_at(&mut peer, &latest_block, cycle_start);
+        assert_eq!(reward_set_entries.len(), 2);
+        assert_eq!(
+            reward_set_entries[0].reward_address.bytes(),
+            key_to_stacks_addr(&bob).bytes.0.to_vec()
+        );
+        assert_eq!(
+            reward_set_entries[1].reward_address.bytes(),
+            key_to_stacks_addr(&alice).bytes.0.to_vec()
+        );
+    }
+
+    // we'll produce blocks until the next reward cycle gets through the "handled start" code
+    //  this is one block after the reward cycle starts
+    let height_target = burnchain.reward_cycle_to_block_height(EXPECTED_FIRST_V2_CYCLE) + 1;
+
+    // but first, check that bob has locked tokens at (height_target + 1)
+    let (bob_bal, _) = get_stx_account_at(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(&bob).to_account_principal(),
+    )
+    .canonical_repr_at_block(height_target + 1, burnchain.pox_constants.v1_unlock_height);
+    assert_eq!(bob_bal.amount_locked(), POX_THRESHOLD_STEPS_USTX);
+
+    while get_tip(peer.sortdb.as_ref()).block_height < height_target {
+        latest_block = peer.tenure_with_txs(&[], &mut coinbase_nonce);
+    }
+
+    // check that the "raw" reward sets for all cycles just contains entries for alice
+    //  at the cycle start
+    for cycle_number in EXPECTED_FIRST_V2_CYCLE..(EXPECTED_FIRST_V2_CYCLE + 6) {
+        let cycle_start = burnchain.reward_cycle_to_block_height(cycle_number);
+        let reward_set_entries = get_reward_set_entries_at(&mut peer, &latest_block, cycle_start);
+        assert_eq!(reward_set_entries.len(), 1);
+        assert_eq!(
+            reward_set_entries[0].reward_address.bytes(),
+            key_to_stacks_addr(&alice).bytes.0.to_vec()
+        );
+    }
+
+    // now check that bob has no locked tokens at (height_target + 1)
+    let (bob_bal, _) = get_stx_account_at(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(&bob).to_account_principal(),
+    )
+    .canonical_repr_at_block(height_target + 1, burnchain.pox_constants.v1_unlock_height);
+    assert_eq!(bob_bal.amount_locked(), 0);
+
+    // but bob's still locked at (height_target): the unlock is accelerated to the "next" burn block
+    let (bob_bal, _) = get_stx_account_at(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(&bob).to_account_principal(),
+    )
+    .canonical_repr_at_block(height_target + 1, burnchain.pox_constants.v1_unlock_height);
+    assert_eq!(bob_bal.amount_locked(), 0);
+
+    // check that the total reward cycle amounts have decremented correctly
+    for cycle_number in EXPECTED_FIRST_V2_CYCLE..(EXPECTED_FIRST_V2_CYCLE + 6) {
+        assert_eq!(
+            get_reward_cycle_total(&mut peer, &latest_block, cycle_number),
+            1024 * POX_THRESHOLD_STEPS_USTX
+        );
+    }
+
+    // check that bob's stacking-state is gone and alice's stacking-state is correct
+    assert!(
+        get_stacking_state_pox_2(
+            &mut peer,
+            &latest_block,
+            &key_to_stacks_addr(&bob).to_account_principal()
+        )
+        .is_none(),
+        "Bob should not have a stacking-state entry"
+    );
+
+    let alice_state = get_stacking_state_pox_2(
+        &mut peer,
+        &latest_block,
+        &key_to_stacks_addr(&alice).to_account_principal(),
+    )
+    .expect("Alice should have stacking-state entry")
+    .expect_tuple();
+    let reward_indexes_str = format!("{}", alice_state.get("reward-set-indexes").unwrap());
+    assert_eq!(reward_indexes_str, "(u0 u0 u0 u0 u0 u0)");
+
+    // now let's check some tx receipts
+
+    let alice_address = key_to_stacks_addr(&alice);
+    let bob_address = key_to_stacks_addr(&bob);
+    let blocks = observer.get_blocks();
+
+    let mut alice_txs = HashMap::new();
+    let mut bob_txs = HashMap::new();
+    let mut charlie_txs = HashMap::new();
+
+    eprintln!("Alice addr: {}", alice_address);
+    eprintln!("Bob addr: {}", bob_address);
+
+    for b in blocks.into_iter() {
+        for r in b.receipts.into_iter() {
+            if let TransactionOrigin::Stacks(ref t) = r.transaction {
+                let addr = t.auth.origin().address_testnet();
+                eprintln!("TX addr: {}", addr);
+                if addr == alice_address {
+                    alice_txs.insert(t.auth.get_origin_nonce(), r);
+                } else if addr == bob_address {
+                    bob_txs.insert(t.auth.get_origin_nonce(), r);
+                } else if addr == key_to_stacks_addr(&charlie) {
+                    assert!(
+                        r.execution_cost != ExecutionCost::zero(),
+                        "Execution cost is not zero!"
+                    );
+                    charlie_txs.insert(t.auth.get_origin_nonce(), r);
+                }
+            }
+        }
+    }
+
+    assert_eq!(alice_txs.len(), 1);
+    assert_eq!(charlie_txs.len(), 0);
+
+    assert_eq!(bob_txs.len(), 1);
+
+    //  TX0 -> Bob's initial lockup in PoX 2
+    assert!(
+        match bob_txs.get(&0).unwrap().result {
+            Value::Response(ref r) => r.committed,
+            _ => false,
+        },
+        "Bob tx0 should have committed okay"
     );
 }
 

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -795,6 +795,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
 
     let alice_address = key_to_stacks_addr(&alice);
     let bob_address = key_to_stacks_addr(&bob);
+    let charlie_address = key_to_stacks_addr(&charlie);
     let blocks = observer.get_blocks();
 
     let mut alice_txs = HashMap::new();
@@ -813,7 +814,7 @@ fn test_simple_pox_2_auto_unlock(alice_first: bool) {
                     alice_txs.insert(t.auth.get_origin_nonce(), r);
                 } else if addr == bob_address {
                     bob_txs.insert(t.auth.get_origin_nonce(), r);
-                } else if addr == key_to_stacks_addr(&charlie) {
+                } else if addr == charlie_address {
                     assert!(
                         r.execution_cost != ExecutionCost::zero(),
                         "Execution cost is not zero!"

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5205,18 +5205,6 @@ impl StacksChainState {
         let evaluated_epoch = clarity_tx.get_epoch();
         clarity_tx.reset_cost(parent_block_cost.clone());
 
-        debug!("Evaluating block with epoch = {}", evaluated_epoch);
-        if evaluated_epoch >= StacksEpochId::Epoch21 {
-            Self::check_and_handle_reward_start(
-                burn_tip_height.into(),
-                burn_dbconn,
-                sortition_dbconn,
-                &mut clarity_tx,
-                chain_tip,
-                &parent_sortition_id,
-            )?;
-        }
-
         let matured_miner_rewards_opt = match StacksChainState::find_mature_miner_rewards(
             &mut clarity_tx,
             conn,
@@ -5289,6 +5277,18 @@ impl StacksChainState {
         // if we get here, then we need to reset the block-cost back to 0 since this begins the
         // epoch defined by this miner.
         clarity_tx.reset_cost(ExecutionCost::zero());
+
+        debug!("Evaluating block with epoch = {}", evaluated_epoch);
+        if evaluated_epoch >= StacksEpochId::Epoch21 {
+            Self::check_and_handle_reward_start(
+                burn_tip_height.into(),
+                burn_dbconn,
+                sortition_dbconn,
+                &mut clarity_tx,
+                chain_tip,
+                &parent_sortition_id,
+            )?;
+        }
 
         // is this stacks block the first of a new epoch?
         let (applied_epoch_transition, mut tx_receipts) =

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5147,7 +5147,7 @@ impl StacksChainState {
         let evaluated_epoch = clarity_tx.get_epoch();
         clarity_tx.reset_cost(parent_block_cost.clone());
 
-        info!("Evaluated epoch = {}", evaluated_epoch);
+        debug!("Evaluating block with epoch = {}", evaluated_epoch);
         if evaluated_epoch >= StacksEpochId::Epoch21 {
             let mut pox_reward_cycle = Burnchain::static_block_height_to_reward_cycle(
                 burn_tip_height.into(),
@@ -5168,7 +5168,7 @@ impl StacksChainState {
                 let handled = clarity_tx.with_clarity_db_readonly(|clarity_db| {
                     Self::handled_pox_cycle_start(clarity_db, pox_reward_cycle)
                 });
-                info!("Check handled"; "pox_cycle" => pox_reward_cycle, "handled" => handled);
+
                 if !handled {
                     let pox_start_cycle_info = sortition_dbconn.get_pox_start_cycle_info(
                         &parent_sortition_id,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -118,6 +118,8 @@ pub struct MinerEpochInfo<'a> {
     pub chainstate_tx: ChainstateTx<'a>,
     pub clarity_instance: &'a mut ClarityInstance,
     pub burn_tip: BurnchainHeaderHash,
+    /// This is the expected burn tip height (i.e., the current burnchain tip + 1)
+    ///  of the mined block
     pub burn_tip_height: u32,
     pub parent_microblocks: Vec<StacksMicroblock>,
     pub mainnet: bool,
@@ -1880,6 +1882,7 @@ impl StacksBlockBuilder {
         } = StacksChainState::setup_block(
             &mut info.chainstate_tx,
             info.clarity_instance,
+            burn_dbconn,
             burn_dbconn,
             burn_dbconn.conn(),
             &self.chain_tip,

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -1148,6 +1148,10 @@ impl<'a, 'b> ClarityTransactionConnection<'a, 'b> {
         .and_then(|(value, ..)| Ok(value))
     }
 
+    pub fn is_mainnet(&self) -> bool {
+        return self.mainnet;
+    }
+
     /// Commit the changes from the edit log.
     /// panics if there is more than one open savepoint
     pub fn commit(mut self) {

--- a/src/clarity_vm/database/mod.rs
+++ b/src/clarity_vm/database/mod.rs
@@ -255,6 +255,10 @@ fn get_pox_start_cycle_info(
     }
 
     let start_info = handle.get_reward_cycle_unlocks(cycle_index)?;
+    info!(
+        "get_pox_start_cycle_info";
+        "start_info" => ?start_info,
+    );
     Ok(start_info)
 }
 

--- a/src/clarity_vm/database/mod.rs
+++ b/src/clarity_vm/database/mod.rs
@@ -1,3 +1,4 @@
+use clarity::vm::types::PrincipalData;
 use rusqlite::{Connection, OptionalExtension};
 
 use crate::chainstate::burn::db::sortdb::{
@@ -18,6 +19,7 @@ use clarity::vm::errors::{InterpreterResult, RuntimeErrorType};
 use crate::chainstate::stacks::db::ChainstateTx;
 use crate::chainstate::stacks::index::marf::{MarfConnection, MARF};
 use crate::chainstate::stacks::index::{ClarityMarfTrieId, TrieMerkleProof};
+use crate::chainstate::stacks::Error as ChainstateError;
 use crate::types::chainstate::StacksBlockId;
 use crate::types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, SortitionId};
 use crate::types::chainstate::{StacksAddress, VRFSeed};
@@ -219,6 +221,73 @@ fn get_matured_reward(conn: &DBConn, child_id_bhh: &StacksBlockId) -> Option<Min
             .expect("Unexpected SQL failure querying miner reward table")
     } else {
         None
+    }
+}
+
+/// This trait describes SortitionDB connections. This is used
+/// for methods that the chainstate needs to be in common between
+/// different sortition db connections or handles, but that aren't
+/// used by the `clarity_db` (and therefore shouldn't appear in BurnStateDB)
+pub trait SortitionDBRef: BurnStateDB {
+    fn get_pox_start_cycle_info(
+        &self,
+        sortition_id: &SortitionId,
+        parent_stacks_block_burn_ht: u64,
+        cycle_index: u64,
+    ) -> Result<Option<PoxStartCycleInfo>, ChainstateError>;
+}
+
+pub struct PoxStartCycleInfo {
+    pub missed_reward_slots: Vec<(PrincipalData, u128)>,
+}
+
+impl SortitionDBRef for SortitionHandleTx<'_> {
+    fn get_pox_start_cycle_info(
+        &self,
+        sortition_id: &SortitionId,
+        parent_stacks_block_burn_ht: u64,
+        cycle_index: u64,
+    ) -> Result<Option<PoxStartCycleInfo>, ChainstateError> {
+        let readonly_marf = self
+            .index()
+            .reopen_readonly()
+            .expect("BUG: failure trying to get a read-only interface into the sortition db.");
+        let mut context = self.context.clone();
+        context.chain_tip = sortition_id.clone();
+        let mut handle = SortitionHandleConn::new(&readonly_marf, context);
+
+        let descended_from_last_pox_anchor = match handle.get_last_anchor_block_hash()? {
+            Some(pox_anchor) => handle.descended_from(parent_stacks_block_burn_ht, &pox_anchor)?,
+            None => return Ok(None),
+        };
+
+        if !descended_from_last_pox_anchor {
+            return Ok(None);
+        }
+
+        Ok(Some(PoxStartCycleInfo {
+            missed_reward_slots: vec![],
+        }))
+    }
+}
+
+impl SortitionDBRef for SortitionDBConn<'_> {
+    fn get_pox_start_cycle_info(
+        &self,
+        sortition_id: &SortitionId,
+        parent_stacks_block_burn_ht: u64,
+        cycle_index: u64,
+    ) -> Result<Option<PoxStartCycleInfo>, ChainstateError> {
+        let mut handle = self.as_handle(sortition_id);
+
+        let descended_from_last_pox_anchor = match handle.get_last_anchor_block_hash()? {
+            Some(pox_anchor) => handle.descended_from(parent_stacks_block_burn_ht, &pox_anchor)?,
+            None => return Ok(None),
+        };
+
+        Ok(Some(PoxStartCycleInfo {
+            missed_reward_slots: vec![],
+        }))
     }
 }
 

--- a/src/clarity_vm/database/mod.rs
+++ b/src/clarity_vm/database/mod.rs
@@ -2,7 +2,7 @@ use clarity::vm::types::PrincipalData;
 use rusqlite::{Connection, OptionalExtension};
 
 use crate::chainstate::burn::db::sortdb::{
-    get_ancestor_sort_id, get_ancestor_sort_id_tx, SortitionDB, SortitionDBConn,
+    get_ancestor_sort_id, get_ancestor_sort_id_tx, SortitionDB, SortitionDBConn, SortitionHandle,
     SortitionHandleConn, SortitionHandleTx,
 };
 use crate::chainstate::stacks::boot::PoxStartCycleInfo;

--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -65,7 +65,7 @@ fn print_msg_header(mut rd: &mut dyn RecordDecorator, record: &Record) -> io::Re
     write!(rd, " ")?;
     match thread::current().name() {
         None => write!(rd, "[{:?}]", thread::current().id())?,
-        Some(name) => write!(rd, "[{}]", name)?,
+        Some(name) => write!(rd, "[{:.15}]", name)?,
     }
 
     rd.start_whitespace()?;


### PR DESCRIPTION
This PR implements automatic unlocks for PoX 2.

Stackers who do not qualify for a slot in a reward set when the reward set is selected will be automatically unlocked after the reward set is selected. The auto unlock occurs 1 bitcoin block after the auto-unlock.

This requires a _lot_ of complexity in `pox-2`. This PR adds a test for the simple use case, but probably more testing is needed.