### PR TITLE
feat: Sort keywords and functions by name in the docs

### DIFF
--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2229,10 +2229,10 @@ fn make_all_api_reference() -> ReferenceAPIs {
         .iter()
         .map(|x| make_api_reference(x))
         .collect();
-
     for data_type in DefineFunctions::ALL.iter() {
         functions.push(make_define_reference(data_type))
     }
+    functions.sort_by(|x, y| x.name.cmp(&y.name));
 
     let mut keywords = Vec::new();
     for variable in NativeVariables::ALL.iter() {
@@ -2241,6 +2241,7 @@ fn make_all_api_reference() -> ReferenceAPIs {
             keywords.push(api_ref)
         }
     }
+    keywords.sort_by(|x, y| x.name.cmp(&y.name));
 
     ReferenceAPIs {
         functions,


### PR DESCRIPTION
### Description
Change the docs so that Functions and Keywords are sorted by name.

This change was proposed in the comments of #2716.

### Applicable issues
- towards #2716 

### Checklist
- [ ] Is there a way to test this?
