### PR TITLE
Feat/configurable pox

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -307,10 +307,7 @@ impl BitcoinRegtestController {
         let (network_name, _network_type) = config.burnchain.get_bitcoin_network();
         let working_dir = config.get_burn_db_path();
         let mut burnchain = Burnchain::new(&working_dir, &config.burnchain.chain, &network_name)
-            .unwrap_or_else(|e| {
-                error!("Failed to instantiate burnchain: {}", e);
-                panic!()
-            });
+            .expect("Failed to instantiate burnchain");
         config.update_pox_constants(&mut burnchain.pox_constants);
 
         burnchain

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -75,7 +75,7 @@ pub struct BitcoinRegtestController {
     burnchain_db: Option<BurnchainDB>,
     chain_tip: Option<BurnchainTip>,
     use_coordinator: Option<CoordinatorChannels>,
-    burnchain_config: Option<Burnchain>,
+    burnchain_config: Burnchain,
     ongoing_block_commit: Option<OngoingBlockCommit>,
     should_keep_running: Option<Arc<AtomicBool>>,
     allow_rbf: bool,
@@ -190,7 +190,7 @@ impl BitcoinRegtestController {
     pub fn with_burnchain(
         config: Config,
         coordinator_channel: Option<CoordinatorChannels>,
-        burnchain_config: Option<Burnchain>,
+        burnchain: Option<Burnchain>,
         should_keep_running: Option<Arc<AtomicBool>>,
     ) -> Self {
         std::fs::create_dir_all(&config.get_burnchain_path_str())
@@ -242,6 +242,8 @@ impl BitcoinRegtestController {
             runtime: indexer_runtime,
         };
 
+        let burnchain_config = burnchain.unwrap_or_else(|| Self::default_burnchain(&config));
+
         Self {
             use_coordinator: coordinator_channel,
             config,
@@ -258,7 +260,7 @@ impl BitcoinRegtestController {
 
     /// create a dummy bitcoin regtest controller.
     ///   used just for submitting bitcoin ops.
-    pub fn new_dummy(config: Config) -> Self {
+    pub fn new_dummy(config: Config, burnchain: Burnchain) -> Self {
         let (network, _) = config.burnchain.get_bitcoin_network();
         let burnchain_params = BurnchainParameters::from_params(&config.burnchain.chain, &network)
             .expect("Bitcoin network unsupported");
@@ -294,28 +296,24 @@ impl BitcoinRegtestController {
             db: None,
             burnchain_db: None,
             chain_tip: None,
-            burnchain_config: None,
+            burnchain_config: burnchain,
             ongoing_block_commit: None,
             should_keep_running: None,
             allow_rbf: true,
         }
     }
 
-    fn default_burnchain(&self) -> Burnchain {
-        let (network_name, _network_type) = self.config.burnchain.get_bitcoin_network();
-        match &self.burnchain_config {
-            Some(burnchain) => burnchain.clone(),
-            None => {
-                let working_dir = self.config.get_burn_db_path();
-                match Burnchain::new(&working_dir, &self.config.burnchain.chain, &network_name) {
-                    Ok(burnchain) => burnchain,
-                    Err(e) => {
-                        error!("Failed to instantiate burnchain: {}", e);
-                        panic!()
-                    }
-                }
-            }
-        }
+    fn default_burnchain(config: &Config) -> Burnchain {
+        let (network_name, _network_type) = config.burnchain.get_bitcoin_network();
+        let working_dir = config.get_burn_db_path();
+        let mut burnchain = Burnchain::new(&working_dir, &config.burnchain.chain, &network_name)
+            .unwrap_or_else(|e| {
+                error!("Failed to instantiate burnchain: {}", e);
+                panic!()
+            });
+        config.update_pox_constants(&mut burnchain.pox_constants);
+
+        burnchain
     }
 
     pub fn get_pox_constants(&self) -> PoxConstants {
@@ -324,10 +322,7 @@ impl BitcoinRegtestController {
     }
 
     pub fn get_burnchain(&self) -> Burnchain {
-        match self.burnchain_config {
-            Some(ref burnchain) => burnchain.clone(),
-            None => self.default_burnchain(),
-        }
+        self.burnchain_config.clone()
     }
 
     fn receive_blocks_helium(&mut self) -> BurnchainTip {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1022,7 +1022,8 @@ fn spawn_miner_relayer(
     > = HashMap::new();
     let burn_fee_cap = config.burnchain.burn_fee_cap;
 
-    let mut bitcoin_controller = BitcoinRegtestController::new_dummy(config.clone());
+    let mut bitcoin_controller =
+        BitcoinRegtestController::new_dummy(config.clone(), burnchain.clone());
     let mut microblock_miner_state: Option<MicroblockMinerState> = None;
     let mut miner_tip = None; // only set if we won the last sortition
     let mut last_microblock_tenure_time = 0;

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -449,7 +449,8 @@ impl Node {
         // we can call _open_ here rather than _connect_, since connect is first called in
         //   make_genesis_block
         let mut burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
-        self.config.update_pox_constants(&mut burnchain.pox_constants);
+        self.config
+            .update_pox_constants(&mut burnchain.pox_constants);
 
         let sortdb = SortitionDB::open(
             &self.config.get_burn_db_file_path(),
@@ -1006,7 +1007,8 @@ impl Node {
         };
 
         let mut burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
-        self.config.update_pox_constants(&mut burnchain.pox_constants);
+        self.config
+            .update_pox_constants(&mut burnchain.pox_constants);
 
         let commit_outs =
             if !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1) {

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -300,11 +300,12 @@ impl Node {
             .iter()
             .map(|e| (e.address.clone(), e.amount))
             .collect();
-        let pox_constants = match config.burnchain.get_bitcoin_network() {
+        let mut pox_constants = match config.burnchain.get_bitcoin_network() {
             (_, BitcoinNetworkType::Mainnet) => PoxConstants::mainnet_default(),
             (_, BitcoinNetworkType::Testnet) => PoxConstants::testnet_default(),
             (_, BitcoinNetworkType::Regtest) => PoxConstants::regtest_default(),
         };
+        config.update_pox_constants(&mut pox_constants);
 
         let mut boot_data = ChainStateBootData {
             initial_balances,
@@ -447,7 +448,8 @@ impl Node {
     pub fn spawn_peer_server(&mut self, attachments_rx: Receiver<HashSet<AttachmentInstance>>) {
         // we can call _open_ here rather than _connect_, since connect is first called in
         //   make_genesis_block
-        let burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
+        let mut burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
+        &self.config.update_pox_constants(&mut burnchain.pox_constants);
 
         let sortdb = SortitionDB::open(
             &self.config.get_burn_db_file_path(),
@@ -1003,7 +1005,9 @@ impl Node {
             ),
         };
 
-        let burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
+        let mut burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
+        &self.config.update_pox_constants(&mut burnchain.pox_constants);
+
         let commit_outs =
             if !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1) {
                 RewardSetInfo::into_commit_outs(None, self.config.is_mainnet())

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -449,7 +449,7 @@ impl Node {
         // we can call _open_ here rather than _connect_, since connect is first called in
         //   make_genesis_block
         let mut burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
-        &self.config.update_pox_constants(&mut burnchain.pox_constants);
+        self.config.update_pox_constants(&mut burnchain.pox_constants);
 
         let sortdb = SortitionDB::open(
             &self.config.get_burn_db_file_path(),
@@ -1006,7 +1006,7 @@ impl Node {
         };
 
         let mut burnchain = Burnchain::regtest(&self.config.get_burn_db_path());
-        &self.config.update_pox_constants(&mut burnchain.pox_constants);
+        self.config.update_pox_constants(&mut burnchain.pox_constants);
 
         let commit_outs =
             if !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1) {

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -545,8 +545,9 @@ fn transition_empty_blocks() {
     // second block will be the first mined Stacks block
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
-    let mut bitcoin_controller = BitcoinRegtestController::new_dummy(conf.clone());
     let burnchain = Burnchain::regtest(&conf.get_burn_db_path());
+    let mut bitcoin_controller =
+        BitcoinRegtestController::new_dummy(conf.clone(), burnchain.clone());
 
     // these should all succeed across the epoch boundary
     for _i in 0..5 {


### PR DESCRIPTION
Feature from @kantai which adds a configuration option to specify the burn block height at which PoX-2 is activated. The option is ignored when running in mainnet mode.

Use by specifying `burnchain.pox_2_activation` in the config toml, e.g.:
```toml
[burnchain]
chain = "bitcoin"
mode = "krypton"
pox_2_activation = 150
```

Creating a PR because we need something like this in order to test PoX-2 in regtest mode. Without this feature, it's not really possible.


### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
