### PR TITLE
Add PoX-2 info to `/v2/pox` RPC endpoint

### DIFF
--- a/docs/rpc/api/core-node/get-pox.example.json
+++ b/docs/rpc/api/core-node/get-pox.example.json
@@ -2,6 +2,7 @@
   "contract_id": "SP000000000000000000002Q6VF78.pox",
   "pox_activation_threshold_ustx": 52329761604388,
   "first_burnchain_block_height": 666050,
+  "current_burnchain_block_height": 812345,
   "prepare_phase_block_length": 100,
   "reward_phase_block_length": 2000,
   "reward_slots": 4000,
@@ -29,5 +30,17 @@
   "reward_cycle_id": 2,
   "reward_cycle_length": 2100,
   "rejection_votes_left_required": 261648808021925,
-  "next_reward_cycle_in": 507
+  "next_reward_cycle_in": 507,
+  "contract_versions": [
+    {
+      "contract_id": "SP000000000000000000002Q6VF78.pox",
+      "activation_burnchain_block_height": 666050,
+      "first_reward_cycle_id": 0
+    },
+    {
+      "contract_id": "SP000000000000000000002Q6VF78.pox-2",
+      "activation_burnchain_block_height": 712345,
+      "first_reward_cycle_id": 123
+    }
+ ]
 }

--- a/docs/rpc/api/core-node/get-pox.schema.json
+++ b/docs/rpc/api/core-node/get-pox.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "contract_id",
+    "current_burnchain_block_height",
     "first_burnchain_block_height",
     "pox_activation_threshold_ustx",
     "prepare_phase_block_length",
@@ -19,7 +20,8 @@
     "min_amount_ustx",
     "reward_cycle_id",
     "prepare_cycle_length",
-    "rejection_votes_left_required"
+    "rejection_votes_left_required",
+    "contract_versions"
   ],
   "properties": {
     "contract_id": {
@@ -29,6 +31,10 @@
     "first_burnchain_block_height": {
       "type": "integer",
       "description": "The first burn block evaluated in this Stacks chain"
+    },
+    "current_burnchain_block_height": {
+      "type": "integer",
+      "description": "The latest Bitcoin chain block height"
     },
     "pox_activation_threshold_ustx": {
       "type": "integer",
@@ -83,7 +89,7 @@
         "is_pox_active": {
           "type": "boolean",
           "description": "Whether or not PoX is active during this reward cycle."
-        },
+        }
       }
     },
     "next_cycle": {
@@ -146,15 +152,42 @@
     },
     "min_amount_ustx": {
       "type": "integer",
-      "deprecated": true,
+      "deprecated": true
     },
     "prepare_cycle_length": {
       "type": "integer",
-      "deprecated": true,
+      "deprecated": true
     },
     "rejection_votes_left_required": {
       "type": "integer",
-      "deprecated": true,
+      "deprecated": true
+    },
+    "contract_versions": {
+      "type": "array",
+      "description": "Versions of each PoX",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "contract_id", 
+          "activation_burnchain_block_height", 
+          "first_reward_cycle_id"
+        ],
+        "properties": {
+          "contract_id": {
+            "type": "string",
+            "description": "The contract identifier for the PoX contract"
+          },
+          "activation_burnchain_block_height": {
+            "type": "integer",
+            "description": "The burn block height at which this version of PoX is activated"
+          },
+          "first_reward_cycle_id": {
+            "type": "integer",
+            "description": "The first reward cycle number that uses this version of PoX"
+          }
+        }
+      }
     }
   }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1085,6 +1085,7 @@ pub struct RPCPoxInfoData {
     pub contract_id: String,
     pub pox_activation_threshold_ustx: u64,
     pub first_burnchain_block_height: u64,
+    pub current_burnchain_block_height: u64,
     pub prepare_phase_block_length: u64,
     pub reward_phase_block_length: u64,
     pub reward_slots: u64,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1072,6 +1072,13 @@ pub struct RPCPoxNextCycleInfo {
     pub ustx_until_pox_rejection: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RPCPoxContractVersion {
+    pub contract_id: String,
+    pub activation_burnchain_block_height: u64,
+    pub first_reward_cycle_id: u64,
+}
+
 /// The data we return on GET /v2/pox
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RPCPoxInfoData {
@@ -1094,9 +1101,8 @@ pub struct RPCPoxInfoData {
     pub rejection_votes_left_required: u64,
     pub next_reward_cycle_in: u64,
 
-    // Stacks 2.1 / PoX-2 info
-    pub pox_2_activation_burnchain_block_height: u64,
-    pub pox_2_first_cycle_id: u64,
+    // Information specific to each PoX contract version
+    pub contract_versions: Vec<RPCPoxContractVersion>,
 }
 
 /// Headers response payload

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1093,6 +1093,10 @@ pub struct RPCPoxInfoData {
     pub reward_cycle_length: u64,
     pub rejection_votes_left_required: u64,
     pub next_reward_cycle_in: u64,
+
+    // Stacks 2.1 / PoX-2 info
+    pub pox_2_activation_burnchain_block_height: u64,
+    pub pox_2_first_cycle_id: u64,
 }
 
 /// Headers response payload

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -451,6 +451,7 @@ impl RPCPoxInfoData {
             contract_id: boot_code_id(cur_cycle_pox_contract, chainstate.mainnet).to_string(),
             pox_activation_threshold_ustx,
             first_burnchain_block_height,
+            current_burnchain_block_height: burnchain_tip.block_height,
             prepare_phase_block_length: prepare_cycle_length,
             reward_phase_block_length: reward_cycle_length - prepare_cycle_length,
             reward_slots,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -448,7 +448,7 @@ impl RPCPoxInfoData {
         let cur_cycle_pox_active = sortdb.is_pox_active(burnchain, &burnchain_tip)?;
 
         Ok(RPCPoxInfoData {
-            contract_id: boot_code_id(next_cycle_pox_contract, chainstate.mainnet).to_string(),
+            contract_id: boot_code_id(cur_cycle_pox_contract, chainstate.mainnet).to_string(),
             pox_activation_threshold_ustx,
             first_burnchain_block_height,
             prepare_phase_block_length: prepare_cycle_length,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -270,12 +270,11 @@ impl RPCPoxInfoData {
         let chain_id = chainstate.chain_id;
 
         let current_burn_height = chainstate
-            .maybe_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
+            .with_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
                 clarity_tx.with_clarity_db_readonly(|clarity_db| {
                     clarity_db.get_current_burnchain_block_height() as u64
                 })
             })
-            .map_err(|_| net_error::NotFoundError)?
             .ok_or(net_error::NotFoundError)?;
 
         let reward_cycle = burnchain

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -278,13 +278,9 @@ impl RPCPoxInfoData {
             })
             .ok_or(net_error::NotFoundError)?;
 
-        let reward_cycle = burnchain
-            .block_height_to_reward_cycle(current_burn_height)
-            .ok_or(net_error::ChainstateError("PoxNoRewardCycle".to_string()))?;
-        let reward_cycle_start_height = burnchain.reward_cycle_to_block_height(reward_cycle);
         let pox_contract_name = burnchain
             .pox_constants
-            .active_pox_contract(reward_cycle_start_height);
+            .active_pox_contract(current_burn_height);
 
         let contract_identifier = boot_code_id(pox_contract_name, mainnet);
         let function = "get-pox-info";

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -282,11 +282,6 @@ impl RPCPoxInfoData {
         let pox_contract_name = burnchain
             .pox_constants
             .active_pox_contract(reward_cycle_start_height);
-        let clarity_ver = match pox_contract_name {
-            POX_2_NAME => ClarityVersion::Clarity1,
-            POX_2_NAME => ClarityVersion::Clarity2,
-            _ => return Err(net_error::ChainstateError(format!("Unexpected PoX contract: {}", pox_contract_name)))
-        };
 
         let contract_identifier = boot_code_id(pox_contract_name, mainnet);
         let function = "get-pox-info";
@@ -303,7 +298,7 @@ impl RPCPoxInfoData {
                 clarity_tx.with_readonly_clarity_env(
                     mainnet,
                     chain_id,
-                    clarity_ver,
+                    ClarityVersion::Clarity1,
                     sender,
                     None,
                     cost_track,


### PR DESCRIPTION
Fixes https://github.com/stacks-network/stacks-blockchain/issues/3262

Fixes the `contract_id` value in the `GET /v2/pox` response, along with the associated contract variables, so that it uses the active PoX contract.

Also adds an additional properties to the response in order to help clients perform the correct Stacking operations.
The `contract_versions` array which exposes contract ID and PoX activation information for each PoX version, and a simple `current_burnchain_block_height` property so that clients do not have to perform an additional lookup to `/v2/info` for the value while constructing a PoX transaction. 

Example:
```json
{
  "contract_id": "ST000000000000000000002AMW42H.pox-2", <-- fixed
  "first_burnchain_block_height": 0,
  "current_burnchain_block_height": 123, <-- new
  "contract_versions": [ <-- new
    {
      "contract_id": "ST000000000000000000002AMW42H.pox",
      "activation_burnchain_block_height": 0,
      "first_reward_cycle_id": 0
    },
    {
      "contract_id": "ST000000000000000000002AMW42H.pox-2",
      "activation_burnchain_block_height": 100,
      "first_reward_cycle_id": 21
    }
  ]
}
```

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [x] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
