### PR TITLE
fix: avoid pegging system resources during initial header sync when bitcoind rpc isn't yet available

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -72,7 +72,7 @@ use crate::util_lib::db::Error as db_error;
 use stacks_common::address::public_keys_to_address_hash;
 use stacks_common::address::AddressHashMode;
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash as BitcoinSha256dHash;
-use stacks_common::util::get_epoch_time_ms;
+use stacks_common::util::{get_epoch_time_ms, sleep_ms};
 use stacks_common::util::get_epoch_time_secs;
 use stacks_common::util::hash::to_hex;
 use stacks_common::util::log;
@@ -584,6 +584,7 @@ impl Burnchain {
             debug!("Fetch initial headers");
             indexer.sync_headers(headers_height, None).map_err(|e| {
                 error!("Failed to sync initial headers");
+                sleep_ms(100);
                 e
             })?;
         }


### PR DESCRIPTION
Minor tweak to the initial burnchain header sync. If no headers are synced, add a small delay before retrying. 

Without a retry delay, if the bitcoind rpc endpoint isn't yet ready, this function pegs system resources and generates a ton of logs in a brief period of time. 

This happens when spinning up bitcoind regtest environments in something like docker-compose. There of course are other work arounds with deployment & configuration scripts that try to wait for bitcoin rpc to be ready before initializing the stacks-node, but it's cumbersome and this tweak is cleaner IMO.