### PR TITLE
2.1: Feature: `stack-increase` for PoX-2

### DIFF
--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -1186,10 +1186,6 @@ pub mod test {
         lock_period: u128,
         burn_ht: u64,
     ) -> StacksTransaction {
-        // (define-public (stack-stx (amount-ustx uint)
-        //                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
-        //                           (burn-height uint)
-        //                           (lock-period uint))
         make_pox_contract_call(
             key,
             nonce,
@@ -1212,10 +1208,6 @@ pub mod test {
         lock_period: u128,
         burn_ht: u64,
     ) -> StacksTransaction {
-        // (define-public (stack-stx (amount-ustx uint)
-        //                           (pox-addr (tuple (version (buff 1)) (hashbytes (buff 20))))
-        //                           (burn-height uint)
-        //                           (lock-period uint))
         let payload = TransactionPayload::new_contract_call(
             boot_code_test_addr(),
             POX_2_NAME,
@@ -1226,6 +1218,22 @@ pub mod test {
                 Value::UInt(burn_ht as u128),
                 Value::UInt(lock_period),
             ],
+        )
+        .unwrap();
+
+        make_tx(key, nonce, 0, payload)
+    }
+
+    pub fn make_pox_2_increase(
+        key: &StacksPrivateKey,
+        nonce: u64,
+        amount: u128,
+    ) -> StacksTransaction {
+        let payload = TransactionPayload::new_contract_call(
+            boot_code_test_addr(),
+            POX_2_NAME,
+            "stack-increase",
+            vec![Value::UInt(amount)],
         )
         .unwrap();
 

--- a/src/chainstate/stacks/boot/pox-2.clar
+++ b/src/chainstate/stacks/boot/pox-2.clar
@@ -806,6 +806,9 @@
                 (err ERR_STACKING_INSUFFICIENT_FUNDS))
       (asserts! (check-caller-allowed)
                 (err ERR_STACKING_PERMISSION_DENIED))
+      ;; stacker must be directly stacking
+      (asserts! (> (len (get reward-set-indexes stacker-state)) u0)
+                (err ERR_STACKING_ALREADY_DELEGATED))
       ;; update reward cycle amounts
       (asserts! (is-some (fold increase-reward-cycle-entry 
             (get reward-set-indexes stacker-state)

--- a/src/chainstate/stacks/boot/pox-2.clar
+++ b/src/chainstate/stacks/boot/pox-2.clar
@@ -891,7 +891,7 @@
 
      ;; must be called with positive `increase-by`
      (asserts! (>= increase-by u1)
-               (err ERR_STACKING_INVALID_LOCK_PERIOD))
+               (err ERR_STACKING_INVALID_AMOUNT))
 
      (let ((unlock-in-cycle (burn-height-to-reward-cycle unlock-height))
            (cur-cycle (current-pox-reward-cycle))
@@ -947,7 +947,7 @@
       ;; stacking-state is unchanged, so no need to update
 
       ;; return the lock-up information, so the node can actually carry out the lock. 
-      (ok { stacker: tx-sender, total-locked: new-total-locked}))))
+      (ok { stacker: stacker, total-locked: new-total-locked}))))
 
 ;; As a delegator, extend an active stacking lock, issuing a "partial commitment" for the
 ;;   extended-to cycles.

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -909,7 +909,7 @@ fn delegate_stack_increase() {
 
     let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
-        &format!("test_simple_pox_2_increase"),
+        &format!("pox_2_delegate_stack_increase"),
         6002,
         Some(epochs.clone()),
         Some(&observer),
@@ -1016,6 +1016,15 @@ fn delegate_stack_increase() {
 
     let mut txs_to_submit = vec![];
 
+    let fail_direct_increase_delegation = alice_nonce;
+    txs_to_submit.push(make_pox_2_contract_call(
+        &alice,
+        alice_nonce,
+        "stack-increase",
+        vec![Value::UInt(1)],
+    ));
+    alice_nonce += 1;
+
     let fail_delegate_too_much_locked = bob_nonce;
     txs_to_submit.push(make_pox_2_contract_call(
         &bob,
@@ -1118,8 +1127,15 @@ fn delegate_stack_increase() {
         }
     }
 
-    assert_eq!(alice_txs.len() as u64, 1);
+    assert_eq!(alice_txs.len() as u64, 2);
     assert_eq!(bob_txs.len() as u64, 5);
+
+    assert_eq!(
+        &alice_txs[&fail_direct_increase_delegation]
+            .result
+            .to_string(),
+        "(err 20)"
+    );
 
     // transaction should fail because Alice did not delegate enough funds to Bob
     assert_eq!(

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -421,8 +421,8 @@ impl StacksChainState {
             return Err(Error::PoxInsufficientBalance);
         }
 
-        if bal.amount_locked() < new_total_locked {
-            return Err(Error::PoxInsufficientBalance);
+        if bal.amount_locked() > new_total_locked {
+            return Err(Error::PoxInvalidIncrease);
         }
 
         snapshot.increase_lock_v2(new_total_locked);

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -124,6 +124,7 @@ pub enum Error {
     PoxInsufficientBalance,
     PoxNoRewardCycle,
     PoxExtendNotLocked,
+    PoxIncreaseOnV1,
     DefunctPoxContract,
     ProblematicTransaction(Txid),
 }
@@ -207,6 +208,7 @@ impl fmt::Display for Error {
                 "Transaction {} is problematic and will not be mined again",
                 txid
             ),
+            Error::PoxIncreaseOnV1 => write!(f, "PoX increase only allowed for pox-2 locks"),
         }
     }
 }
@@ -243,6 +245,7 @@ impl error::Error for Error {
             Error::DefunctPoxContract => None,
             Error::StacksTransactionSkipped(ref _r) => None,
             Error::ProblematicTransaction(ref _txid) => None,
+            Error::PoxIncreaseOnV1 => None,
         }
     }
 }
@@ -279,6 +282,7 @@ impl Error {
             Error::DefunctPoxContract => "DefunctPoxContract",
             Error::StacksTransactionSkipped(ref _r) => "StacksTransactionSkipped",
             Error::ProblematicTransaction(ref _txid) => "ProblematicTransaction",
+            Error::PoxIncreaseOnV1 => "PoxIncreaseOnV1",
         }
     }
 

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -125,6 +125,7 @@ pub enum Error {
     PoxNoRewardCycle,
     PoxExtendNotLocked,
     PoxIncreaseOnV1,
+    PoxInvalidIncrease,
     DefunctPoxContract,
     ProblematicTransaction(Txid),
 }
@@ -209,6 +210,7 @@ impl fmt::Display for Error {
                 txid
             ),
             Error::PoxIncreaseOnV1 => write!(f, "PoX increase only allowed for pox-2 locks"),
+            Error::PoxInvalidIncrease => write!(f, "PoX increase was invalid"),
         }
     }
 }
@@ -246,6 +248,7 @@ impl error::Error for Error {
             Error::StacksTransactionSkipped(ref _r) => None,
             Error::ProblematicTransaction(ref _txid) => None,
             Error::PoxIncreaseOnV1 => None,
+            Error::PoxInvalidIncrease => None,
         }
     }
 }
@@ -283,6 +286,7 @@ impl Error {
             Error::StacksTransactionSkipped(ref _r) => "StacksTransactionSkipped",
             Error::ProblematicTransaction(ref _txid) => "ProblematicTransaction",
             Error::PoxIncreaseOnV1 => "PoxIncreaseOnV1",
+            Error::PoxInvalidIncrease => "PoxInvalidIncrease",
         }
     }
 

--- a/src/clarity_vm/database/mod.rs
+++ b/src/clarity_vm/database/mod.rs
@@ -255,7 +255,7 @@ fn get_pox_start_cycle_info(
     }
 
     let start_info = handle.get_reward_cycle_unlocks(cycle_index)?;
-    info!(
+    debug!(
         "get_pox_start_cycle_info";
         "start_info" => ?start_info,
     );

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -316,7 +316,7 @@ fn handle_pox_v2_api_contract_call(
             //  error response type.
             return Ok(());
         }
-    } else if function_name == "stack-increase" {
+    } else if function_name == "stack-increase" || function_name == "delegate-stack-increase" {
         // in this branch case, the PoX-2 contract has stored the increase information
         //  and performed the increase checks. Now, the VM needs to update the account locks
         //  (because the locks cannot be applied directly from the Clarity code itself)

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -107,6 +107,33 @@ fn parse_pox_extend_result(result: &Value) -> std::result::Result<(PrincipalData
     }
 }
 
+/// Parse the returned value from PoX2 `stack-increase` function
+///  into a format more readily digestible in rust.
+/// Panics if the supplied value doesn't match the expected tuple structure
+fn parse_pox_increase(result: &Value) -> std::result::Result<(PrincipalData, u128), i128> {
+    match result.clone().expect_result() {
+        Ok(res) => {
+            // should have gotten back (ok { stacker: principal, total-locked: uint })
+            let tuple_data = res.expect_tuple();
+            let stacker = tuple_data
+                .get("stacker")
+                .expect(&format!("FATAL: no 'stacker'"))
+                .to_owned()
+                .expect_principal();
+
+            let total_locked = tuple_data
+                .get("total-locked")
+                .expect(&format!("FATAL: no 'total-locked'"))
+                .to_owned()
+                .expect_u128();
+
+            Ok((stacker, total_locked))
+        }
+        // in the error case, the function should have returned `int` error code
+        Err(e) => Err(e.expect_i128()),
+    }
+}
+
 /// Handle special cases when calling into the PoX API contract
 fn handle_pox_v1_api_contract_call(
     global_context: &mut GlobalContext,
@@ -289,6 +316,57 @@ fn handle_pox_v2_api_contract_call(
             //  error response type.
             return Ok(());
         }
+    } else if function_name == "stack-increase" {
+        // in this branch case, the PoX-2 contract has stored the increase information
+        //  and performed the increase checks. Now, the VM needs to update the account locks
+        //  (because the locks cannot be applied directly from the Clarity code itself)
+        // applying a pox lock at this point is equivalent to evaluating a transfer
+        debug!(
+            "Handle special-case contract-call";
+            "contract" => ?boot_code_id("pox-2", global_context.mainnet),
+            "function" => function_name,
+            "return-value" => %value,
+        );
+
+        runtime_cost(
+            ClarityCostFunction::StxTransfer,
+            &mut global_context.cost_track,
+            1,
+        )?;
+
+        if let Ok((stacker, total_locked)) = parse_pox_increase(value) {
+            match StacksChainState::pox_lock_increase_v2(
+                &mut global_context.database,
+                &stacker,
+                total_locked,
+            ) {
+                Ok(new_balance) => {
+                    if let Some(batch) = global_context.event_batches.last_mut() {
+                        batch.events.push(StacksTransactionEvent::STXEvent(
+                            STXEventType::STXLockEvent(STXLockEventData {
+                                locked_amount: new_balance.amount_locked(),
+                                unlock_height: new_balance.unlock_height(),
+                                locked_address: stacker,
+                            }),
+                        ));
+                    }
+                }
+                Err(ChainstateError::DefunctPoxContract) => {
+                    return Err(Error::Runtime(RuntimeErrorType::DefunctPoxContract, None))
+                }
+                Err(e) => {
+                    // Error results *other* than a DefunctPoxContract panic, because
+                    //  those errors should have been caught by the PoX contract before
+                    //  getting to this code path.
+                    panic!(
+                        "FATAL: failed to increase lock from {}: '{:?}'",
+                        stacker, &e
+                    );
+                }
+            }
+        }
+
+        return Ok(());
     }
     // nothing to do
     Ok(())


### PR DESCRIPTION
This PR adds two new methods to `pox-2`:

* `stack-increase`: this method increases the lockup for the stacker, and adds the new amount to the reward sets of the remaining cycles for the user
* `delegate-stack-increase`: this method increases the lockup for the supplied stacker, adding the new amount to the partially-stacked state

As part of this work, this also removes the `total-ustx` field from the `stacking-state` map. The rationale for this is to normalize some of the state in the PoX-2 contract: this field is not used for any checks, but it would be "replicated" in several other states: that's at least the `stx-account` lock amount and the reward-set entries for the stacker in each cycle. Because of the "increase" methods, the `total-ustx` field would either be out of sync with the increased amount or the previous cycle entries. To keep this field meaningful, it would need to be a list of `total-ustx` for each cycle, but because the field isn't used in the contract anywhere then it seemed better to just remove the state.