### PR TITLE
CI: use rust stable for code coverage tests

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.code-cov
@@ -4,13 +4,12 @@ WORKDIR /build
 
 ENV CARGO_MANIFEST_DIR="$(pwd)"
 
-RUN rustup override set nightly-2022-01-14 && \
-    rustup component add llvm-tools-preview && \
+RUN rustup component add llvm-tools-preview && \
     cargo install grcov
 
-ENV RUSTFLAGS="-Zinstrument-coverage" \
+ENV RUSTFLAGS="-Cinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
-    
+
 COPY . .
 
 RUN cargo build --workspace && \

--- a/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests
@@ -6,11 +6,10 @@ COPY . .
 
 WORKDIR /src/testnet/stacks-node
 
-RUN rustup override set nightly-2022-01-14 && \
-    rustup component add llvm-tools-preview && \
+RUN rustup component add llvm-tools-preview && \
     cargo install grcov
 
-ENV RUSTFLAGS="-Zinstrument-coverage" \
+ENV RUSTFLAGS="-Cinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
 RUN cargo test --no-run && \

--- a/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.large-genesis
@@ -9,11 +9,10 @@ RUN cd / && tar -xvzf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 
 RUN ln -s /bitcoin-0.20.0/bin/bitcoind /bin/
 
-RUN rustup override set nightly-2022-01-14 && \
-    rustup component add llvm-tools-preview && \
+RUN rustup component add llvm-tools-preview && \
     cargo install grcov
 
-ENV RUSTFLAGS="-Zinstrument-coverage" \
+ENV RUSTFLAGS="-Cinstrument-coverage" \
     LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
 
 RUN cargo test --no-run --workspace && \


### PR DESCRIPTION
This fixes the currently broken CI by using rust stable for all our testing. `grcov` is for some reason broken in _only one_ of the Docker actions, so the coverage doesn't get uploaded from the unit tests, but fixing that can be done separately from just fixing the build.