### PR TITLE
2.1 Fix: usable version checks for DBs and epochs

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2588,7 +2588,7 @@ impl SortitionDB {
     /// Is a particular database version supported by a given epoch?
     pub fn is_db_version_supported_in_epoch(epoch: StacksEpochId, version: &str) -> bool {
         match epoch {
-            StacksEpochId::Epoch10 => false,
+            StacksEpochId::Epoch10 => true,
             StacksEpochId::Epoch20 => (version == "1" || version == "2" || version == "3"),
             StacksEpochId::Epoch2_05 => (version == "2" || version == "3"),
             StacksEpochId::Epoch21 => (version == "3"),

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -198,7 +198,9 @@ impl DBConfig {
     pub fn supports_epoch(&self, epoch_id: StacksEpochId) -> bool {
         match epoch_id {
             StacksEpochId::Epoch10 => true,
-            StacksEpochId::Epoch20 => self.version == "1" || self.version == "2" || self.version == "3",
+            StacksEpochId::Epoch20 => {
+                self.version == "1" || self.version == "2" || self.version == "3"
+            }
             StacksEpochId::Epoch2_05 => self.version == "2" || self.version == "3",
             StacksEpochId::Epoch21 => self.version == "3",
         }

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -197,10 +197,10 @@ pub struct DBConfig {
 impl DBConfig {
     pub fn supports_epoch(&self, epoch_id: StacksEpochId) -> bool {
         match epoch_id {
-            StacksEpochId::Epoch10 => false,
-            StacksEpochId::Epoch20 => (self.version == "1" || self.version == "2"),
-            StacksEpochId::Epoch2_05 => self.version == "2",
-            StacksEpochId::Epoch21 => self.version == "2",
+            StacksEpochId::Epoch10 => true,
+            StacksEpochId::Epoch20 => self.version == "1" || self.version == "2" || self.version == "3",
+            StacksEpochId::Epoch2_05 => self.version == "2" || self.version == "3",
+            StacksEpochId::Epoch21 => self.version == "3",
         }
     }
 }


### PR DESCRIPTION
The current db version <-> epoch checks in `next` do not work -- on restarting a node, the DB version cannot run in 2.1. If restarted while in "Epoch 1.0", that also will cause a panic.

This PR changes the version/epoch checks to make it possible to restart in 2.1, and to make Epoch 1.0 supported by all DB versions.