### PR TITLE
disable arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,14 +141,14 @@ jobs:
           name: ${{ matrix.platform }}
           path: ${{ matrix.platform }}.zip
 
-  call-docker-platforms-workflow:
-    if: ${{ github.event.inputs.tag != '' }}
-    uses: stacks-network/stacks-blockchain/.github/workflows/docker-platforms.yml@master
-    with:
-      tag: ${{ github.event.inputs.tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+#  call-docker-platforms-workflow:
+#    if: ${{ github.event.inputs.tag != '' }}
+#    uses: stacks-network/stacks-blockchain/.github/workflows/docker-platforms.yml@master
+#    with:
+#      tag: ${{ github.event.inputs.tag }}
+#    secrets:
+#      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+#      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   # Build docker image, tag it with the git tag and `latest` if running on master branch, and publish under the following conditions
   # Will publish if:


### PR DESCRIPTION
This disables the arm64 builds since they overwrite the amd64 builds. 
https://hub.docker.com/r/blockstack/stacks-blockchain/tags

This will be superseded by https://github.com/stacks-network/stacks-blockchain/pull/3199 which will re-enable arm64 builds. 

