### PR TITLE
Mempool improvements

### DIFF
--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -153,6 +153,10 @@ impl StacksChainState {
         })
     }
 
+    pub fn get_nonce<T: ClarityConnection>(clarity_tx: &mut T, principal: &PrincipalData) -> u64 {
+        clarity_tx.with_clarity_db_readonly(|ref mut db| db.get_account_nonce(principal))
+    }
+
     pub fn get_account_ft(
         clarity_tx: &mut ClarityTx,
         contract_id: &QualifiedContractIdentifier,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -11256,6 +11256,190 @@ pub mod test {
         assert_eq!(stacks_block.txs.len(), 11);
     }
 
+    #[test]
+    fn mempool_walk_test_users_1_rounds_10_cache_size_2_null_prob_0() {
+        paramaterized_mempool_walk_test(1, 10, 2, 0)
+    }
+
+    #[test]
+    fn mempool_walk_test_users_10_rounds_3_cache_size_2_null_prob_0() {
+        paramaterized_mempool_walk_test(10, 3, 2, 0)
+    }
+
+    #[test]
+    fn mempool_walk_test_users_1_rounds_10_cache_size_2_null_prob_50() {
+        paramaterized_mempool_walk_test(1, 10, 2, 50)
+    }
+
+    #[test]
+    fn mempool_walk_test_users_10_rounds_3_cache_size_2_null_prob_50() {
+        paramaterized_mempool_walk_test(10, 3, 2, 50)
+    }
+
+    #[test]
+    fn mempool_walk_test_users_1_rounds_10_cache_size_2_null_prob_100() {
+        paramaterized_mempool_walk_test(1, 10, 2, 100)
+    }
+
+    #[test]
+    fn mempool_walk_test_users_10_rounds_3_cache_size_2_null_prob_100() {
+        paramaterized_mempool_walk_test(10, 3, 2, 100)
+    }
+
+    /// With the parameters given, create `num_rounds` transactions per each user in `num_users`.
+    /// `nonce_and_candidate_cache_size` is the cache size used for both of the nonce cache
+    /// and the candidate cache.
+    fn paramaterized_mempool_walk_test(
+        num_users: usize,
+        num_rounds: usize,
+        nonce_and_candidate_cache_size: u64,
+        consider_no_estimate_tx_prob: u8,
+    ) {
+        let key_address_pairs: Vec<(Secp256k1PrivateKey, StacksAddress)> = (0..num_users)
+            .map(|_user_index| {
+                let privk = StacksPrivateKey::new();
+                let addr = StacksAddress::from_public_keys(
+                    C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+                    &AddressHashMode::SerializeP2PKH,
+                    1,
+                    &vec![StacksPublicKey::from_private(&privk)],
+                )
+                .unwrap();
+                (privk, addr)
+            })
+            .collect();
+
+        let mut peer_config = TestPeerConfig::new(
+            &format!(
+                "mempool_walk_test_users_{}_rounds_{}_cache_size_{}_null_prob_{}",
+                num_users, num_rounds, nonce_and_candidate_cache_size, consider_no_estimate_tx_prob
+            ),
+            2002,
+            2003,
+        );
+
+        peer_config.initial_balances = vec![];
+        for (privk, addr) in &key_address_pairs {
+            peer_config
+                .initial_balances
+                .push((addr.to_account_principal(), 1000000000));
+        }
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
+        let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+        let mut sender_nonce = 0;
+
+        let mut last_block = None;
+        // send transactions to the mempool
+        let tip = SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+            .unwrap();
+
+        let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+            |ref mut miner,
+             ref mut sortdb,
+             ref mut chainstate,
+             vrf_proof,
+             ref parent_opt,
+             ref parent_microblock_header_opt| {
+                let parent_tip = match parent_opt {
+                    None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                    Some(block) => {
+                        let ic = sortdb.index_conn();
+                        let snapshot = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                            &ic,
+                            &tip.sortition_id,
+                            &block.block_hash(),
+                        )
+                        .unwrap()
+                        .unwrap(); // succeeds because we don't fork
+                        StacksChainState::get_anchored_block_header_info(
+                            chainstate.db(),
+                            &snapshot.consensus_hash,
+                            &snapshot.winning_stacks_block_hash,
+                        )
+                        .unwrap()
+                        .unwrap()
+                    }
+                };
+
+                let parent_header_hash = parent_tip.anchored_header.block_hash();
+                let parent_consensus_hash = parent_tip.consensus_hash.clone();
+
+                let mut mempool =
+                    MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+
+                let coinbase_tx = make_coinbase(miner, 0);
+
+                for round_index in 0..num_rounds {
+                    for user_index in 0..num_users {
+                        let stx_transfer = make_user_stacks_transfer(
+                            &key_address_pairs[user_index].0,
+                            round_index as u64,
+                            200,
+                            &recipient.to_account_principal(),
+                            1,
+                        );
+
+                        mempool
+                            .submit(
+                                chainstate,
+                                &parent_consensus_hash,
+                                &parent_header_hash,
+                                &stx_transfer,
+                                None,
+                                &ExecutionCost::max_value(),
+                                &StacksEpochId::Epoch20,
+                            )
+                            .unwrap();
+                    }
+                }
+
+                let mut settings = BlockBuilderSettings::max_value();
+                settings.mempool_settings.nonce_cache_size = nonce_and_candidate_cache_size;
+                settings.mempool_settings.candidate_retry_cache_size =
+                    nonce_and_candidate_cache_size;
+                settings.mempool_settings.consider_no_estimate_tx_prob =
+                    consider_no_estimate_tx_prob;
+                let anchored_block = StacksBlockBuilder::build_anchored_block(
+                    chainstate,
+                    &sortdb.index_conn(),
+                    &mut mempool,
+                    &parent_tip,
+                    tip.total_burn,
+                    vrf_proof,
+                    Hash160([0 as u8; 20]),
+                    &coinbase_tx,
+                    settings,
+                    None,
+                )
+                .unwrap();
+                (anchored_block.0, vec![])
+            },
+        );
+
+        last_block = Some(stacks_block.clone());
+
+        peer.next_burnchain_block(burn_ops.clone());
+        peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+
+        // Both user transactions and the coinbase should have been mined.
+        assert_eq!(
+            stacks_block.txs.len() as u64,
+            (1 + num_rounds * num_users) as u64
+        );
+    }
+
     static CONTRACT: &'static str = "
 (define-map my-map int int)
 (define-private (do (input bool))

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -2425,7 +2425,7 @@ impl StacksBlockBuilder {
             );
         }
 
-        debug!(
+        info!(
             "Miner: mined anchored block";
             "block_hash" => %block.block_hash(),
             "height" => block.header.total_work.work,
@@ -2435,6 +2435,7 @@ impl StacksBlockBuilder {
             "parent_stacks_microblock_seq" => block.header.parent_microblock_sequence,
             "block_size" => size,
             "execution_consumed" => %consumed,
+            "%-full" => block_limit.proportion_largest_dimension(&consumed),
             "assembly_time_ms" => ts_end.saturating_sub(ts_start),
             "tx_fees_microstacks" => block.txs.iter().fold(0, |agg: u64, tx| {
                 agg.saturating_add(tx.get_tx_fee())

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -11323,9 +11323,16 @@ pub mod test {
                             |_, available_tx, _| {
                                 count_txs += 1;
                                 Ok(Some(
-                                    TransactionResult::skipped(
+                                    // Generate any success result
+                                    TransactionResult::success(
                                         &available_tx.tx.tx,
-                                        "event not relevant to test".to_string(),
+                                        available_tx.tx.metadata.tx_fee,
+                                        StacksTransactionReceipt::from_stx_transfer(
+                                            available_tx.tx.tx.clone(),
+                                            vec![],
+                                            Value::okay(Value::Bool(true)).unwrap(),
+                                            ExecutionCost::zero(),
+                                        ),
                                     )
                                     .convert_to_event(),
                                 ))

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -11125,6 +11125,137 @@ pub mod test {
         assert_eq!(stacks_block.txs.len(), 3);
     }
 
+    #[test]
+    /// Test with a number of transactions (10) that is "much greater" than the cache size (2).
+    /// Test that all transactions get into the block.
+    fn test_1_user_10_transactions_with_cache_size_2() {
+        let privk = StacksPrivateKey::from_hex(
+            "42faca653724860da7a41bfcef7e6ba78db55146f6900de8cb2a9f760ffac70c01",
+        )
+        .unwrap();
+        let addr = StacksAddress::from_public_keys(
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            &AddressHashMode::SerializeP2PKH,
+            1,
+            &vec![StacksPublicKey::from_private(&privk)],
+        )
+        .unwrap();
+
+        let mut peer_config = TestPeerConfig::new(
+            "test_build_anchored_blocks_stx_transfers_single",
+            2002,
+            2003,
+        );
+        peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
+
+        let mut peer = TestPeer::new(peer_config);
+
+        let chainstate_path = peer.chainstate_path.clone();
+
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height
+        };
+
+        let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
+        let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+        let mut sender_nonce = 0;
+
+        let mut last_block = None;
+        // send transactions to the mempool
+        let tip = SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+            .unwrap();
+
+        let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+            |ref mut miner,
+             ref mut sortdb,
+             ref mut chainstate,
+             vrf_proof,
+             ref parent_opt,
+             ref parent_microblock_header_opt| {
+                let parent_tip = match parent_opt {
+                    None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                    Some(block) => {
+                        let ic = sortdb.index_conn();
+                        let snapshot = SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                            &ic,
+                            &tip.sortition_id,
+                            &block.block_hash(),
+                        )
+                        .unwrap()
+                        .unwrap(); // succeeds because we don't fork
+                        StacksChainState::get_anchored_block_header_info(
+                            chainstate.db(),
+                            &snapshot.consensus_hash,
+                            &snapshot.winning_stacks_block_hash,
+                        )
+                        .unwrap()
+                        .unwrap()
+                    }
+                };
+
+                let parent_header_hash = parent_tip.anchored_header.block_hash();
+                let parent_consensus_hash = parent_tip.consensus_hash.clone();
+
+                let mut mempool =
+                    MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+
+                let coinbase_tx = make_coinbase(miner, 0);
+
+                for i in 0..10 {
+                    let stx_transfer = make_user_stacks_transfer(
+                        &privk,
+                        i,
+                        200,
+                        &recipient.to_account_principal(),
+                        1,
+                    );
+
+                    mempool
+                        .submit(
+                            chainstate,
+                            &parent_consensus_hash,
+                            &parent_header_hash,
+                            &stx_transfer,
+                            None,
+                            &ExecutionCost::max_value(),
+                            &StacksEpochId::Epoch20,
+                        )
+                        .unwrap();
+                }
+
+                let mut settings = BlockBuilderSettings::max_value();
+                settings.mempool_settings.nonce_cache_size = 2;
+                settings.mempool_settings.consider_no_estimate_tx_prob = 50;
+                settings.mempool_settings.candidate_retry_cache_size = 2;
+                let anchored_block = StacksBlockBuilder::build_anchored_block(
+                    chainstate,
+                    &sortdb.index_conn(),
+                    &mut mempool,
+                    &parent_tip,
+                    tip.total_burn,
+                    vrf_proof,
+                    Hash160([0 as u8; 20]),
+                    &coinbase_tx,
+                    settings,
+                    None,
+                )
+                .unwrap();
+                (anchored_block.0, vec![])
+            },
+        );
+
+        last_block = Some(stacks_block.clone());
+
+        peer.next_burnchain_block(burn_ops.clone());
+        peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+
+        // Both user transactions and the coinbase should have been mined.
+        assert_eq!(stacks_block.txs.len(), 11);
+    }
+
     static CONTRACT: &'static str = "
 (define-map my-map int int)
 (define-private (do (input bool))

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -11427,7 +11427,11 @@ pub mod test {
             }
         }
 
-        mempool_settings.consider_no_estimate_tx_prob = consider_no_estimate_tx_prob;
+        mempool_settings.nonce_cache_size = nonce_and_candidate_cache_size;
+        mempool_settings.candidate_retry_cache_size =
+            nonce_and_candidate_cache_size;
+        mempool_settings.consider_no_estimate_tx_prob =
+            consider_no_estimate_tx_prob;
         chainstate.with_read_only_clarity_tx(
             &TEST_BURN_STATE_DB,
             &StacksBlockHeader::make_index_block_hash(&b_2.0, &b_2.1),

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -11018,7 +11018,6 @@ pub mod test {
 
         let chainstate_path = peer.chainstate_path.clone();
 
-        let num_blocks = 10;
         let first_stacks_block_height = {
             let sn =
                 SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -853,8 +853,8 @@ fn db_set_nonce(conn: &DBConn, address: &StacksAddress, nonce: u64) -> Result<()
     let addr_str = address.to_string();
     let nonce_i64 = u64_to_sql(nonce)?;
 
-    let sql = "UPDATE nonces SET nonce = ? WHERE address = ?";
-    conn.execute(sql, rusqlite::params![nonce_i64, &addr_str])?;
+    let sql = "INSERT OR REPLACE INTO nonces (address, nonce) VALUES (?1, ?2)";
+    conn.execute(sql, rusqlite::params![&addr_str, nonce_i64])?;
     Ok(())
 }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -815,19 +815,24 @@ impl NonceCache {
                     }
                 };
                 match opt_nonce {
-                    Some(nonce) => nonce,
+                    Some(nonce) => {
+                        // Copy this into the in-memory cache if there is space
+                        if self.cache.len() < self.max_cache_size {
+                            self.cache.insert(address.clone(), nonce);
+                        }
+                        nonce
+                    }
                     None => {
                         let nonce =
                             StacksChainState::get_nonce(clarity_tx, &address.clone().into());
-                        // Simple size cap to the cache -- once it's full, all nonces
-                        // will be looked up every time. This is bad for performance
-                        // but is unlikely to occur due to the typical number of
-                        // transactions processed before filling a block.
+
+                        match db_set_nonce(mempool_db, address, nonce) {
+                            Ok(_) => (),
+                            Err(e) => warn!("error caching nonce to sqlite: {}", e),
+                        }
+
                         if self.cache.len() < self.max_cache_size {
                             self.cache.insert(address.clone(), nonce);
-                        } else {
-                            // The in-memory cache is full, write it to the db cache
-                            let _ = db_set_nonce(mempool_db, address, nonce);
                         }
                         nonce
                     }
@@ -837,14 +842,18 @@ impl NonceCache {
     }
 
     fn update(&mut self, address: StacksAddress, value: u64, mempool_db: &DBConn) {
+        // Sqlite cache
+        match db_set_nonce(mempool_db, &address, value) {
+            Ok(_) => (),
+            Err(e) => warn!("error caching nonce to sqlite: {}", e),
+        }
+
+        // In-memory cache
         match self.cache.get_mut(&address) {
             Some(nonce) => {
                 *nonce = value;
             }
-            None => {
-                // The in-memory cache is full, write to the db cache
-                let _ = db_set_nonce(mempool_db, &address, value);
-            }
+            None => (),
         }
     }
 }
@@ -1182,6 +1191,7 @@ impl MemPoolDB {
     }
 
     pub fn reset_nonce_cache(&mut self) -> Result<(), db_error> {
+        debug!("reset nonce cache");
         let sql = "DELETE FROM nonces";
         self.db.execute(sql, rusqlite::NO_PARAMS)?;
         Ok(())
@@ -1292,17 +1302,24 @@ impl MemPoolDB {
 
     ///
     /// Iterate over candidates in the mempool
-    ///  `todo` will be called once for each transaction whose origin nonce is equal
-    ///  to the origin account's nonce. At most one transaction per origin will be
-    ///  considered by this method, and transactions will be considered in
-    ///  highest-fee-first order.  This method is interruptable -- in the `settings` struct, the
-    ///  caller may choose how long to spend iterating before this method stops.
+    /// `todo` will be called once for each transaction that is a valid
+    /// candidate for inclusion in the next block, meaning its origin and
+    /// sponsor nonces are equal to the nonces of the corresponding accounts. 
+    /// Best effort will be made to process the transactions in fee-rate order
+    /// until the candidate cache is full, at which point, transactions with
+    /// a lower fee-rate may execute before those with a higher fee-rate.
+    /// The size of the candidate cache and the nonce cache are configurable
+    /// in the settings struct. This method is interruptable -- in the
+    /// `settings` struct, the caller may choose how long to spend iterating
+    /// before this method stops.
     ///
-    ///  `todo` returns an option to a `TransactionEvent` representing the outcome, or None to indicate
-    ///  that iteration through the mempool should be halted.
+    /// `todo` returns an option to a `TransactionEvent` representing the
+    /// outcome, or None to indicate that iteration through the mempool should
+    /// be halted.
     ///
-    /// `output_events` is modified in place, adding all substantive transaction events (success and error
-    /// events, but not skipped) output by `todo`.
+    /// `output_events` is modified in place, adding all substantive
+    /// transaction events (success and error events, but not skipped) output
+    /// by `todo`.
     pub fn iterate_candidates<F, E, C>(
         &mut self,
         clarity_tx: &mut C,

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -295,6 +295,11 @@ pub struct MemPoolWalkSettings {
     /// That is, with x%, when picking the next transaction to include a block, select one that
     /// either failed to get a cost estimate or has not been estimated yet.
     pub consider_no_estimate_tx_prob: u8,
+    /// Size of the nonce cache. This avoids MARF look-ups.
+    pub nonce_cache_size: u64,
+    /// Size of the candidate cache. These are the candidates that will be retried after each
+    /// transaction is mined.
+    pub candidate_retry_cache_size: u64,
 }
 
 impl MemPoolWalkSettings {
@@ -303,6 +308,8 @@ impl MemPoolWalkSettings {
             min_tx_fee: 1,
             max_walk_time_ms: u64::max_value(),
             consider_no_estimate_tx_prob: 5,
+            nonce_cache_size: 10_000,
+            candidate_retry_cache_size: 10_000,
         }
     }
     pub fn zero() -> MemPoolWalkSettings {
@@ -310,6 +317,8 @@ impl MemPoolWalkSettings {
             min_tx_fee: 0,
             max_walk_time_ms: u64::max_value(),
             consider_no_estimate_tx_prob: 5,
+            nonce_cache_size: 10_000,
+            candidate_retry_cache_size: 10_000,
         }
     }
 }

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -807,8 +807,14 @@ impl NonceCache {
     }
 
     fn increment(&mut self, address: StacksAddress) {
-        let nonce = self.cache.entry(address).or_insert(0);
-        *nonce += 1;
+        match self.cache.get_mut(&address) {
+            Some(mut nonce) => {
+                *nonce += 1;
+            }
+            None => {
+                // do nothing, not in cache yet
+            }
+        }
     }
 }
 
@@ -847,7 +853,8 @@ impl CandidateCache {
             self.next.push_back(tx);
         }
 
-        #[cfg(test)] {
+        #[cfg(test)]
+        {
             assert!(self.cache.len() <= self.max_cache_size + 1);
             assert!(self.next.len() <= self.max_cache_size + 1);
         }
@@ -864,7 +871,8 @@ impl CandidateCache {
         self.next.append(&mut self.cache);
         self.cache = std::mem::take(&mut self.next);
 
-        #[cfg(test)] {
+        #[cfg(test)]
+        {
             assert!(self.cache.len() <= self.max_cache_size + 1);
             assert!(self.next.len() <= self.max_cache_size + 1);
         }

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1300,14 +1300,18 @@ impl MemPoolDB {
         Ok(updated)
     }
 
-    ///
     /// Iterate over candidates in the mempool
     /// `todo` will be called once for each transaction that is a valid
     /// candidate for inclusion in the next block, meaning its origin and
-    /// sponsor nonces are equal to the nonces of the corresponding accounts. 
+    /// sponsor nonces are equal to the nonces of the corresponding accounts.
     /// Best effort will be made to process the transactions in fee-rate order
     /// until the candidate cache is full, at which point, transactions with
-    /// a lower fee-rate may execute before those with a higher fee-rate.
+    /// a lower fee-rate may be considered before those with a higher fee-rate.
+    /// When the candidate cache fills, a subsequent call to
+    /// `iterate_candidates` will be needed to reconsider transactions which
+    /// were skipped on the first pass, but become valid after some lower
+    /// fee-rate transactions are considered.
+    ///
     /// The size of the candidate cache and the nonce cache are configurable
     /// in the settings struct. This method is interruptable -- in the
     /// `settings` struct, the caller may choose how long to spend iterating

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -774,8 +774,10 @@ struct NonceCache {
 }
 
 impl NonceCache {
-    fn new(nonce_cache_size:u64) -> Self {
-        let max_size:usize = nonce_cache_size.try_into().expect("Could not cast `nonce_cache_size` as `usize`.");
+    fn new(nonce_cache_size: u64) -> Self {
+        let max_size: usize = nonce_cache_size
+            .try_into()
+            .expect("Could not cast `nonce_cache_size` as `usize`.");
         Self {
             cache: HashMap::new(),
             size: 0,
@@ -823,8 +825,10 @@ struct CandidateCache {
 }
 
 impl CandidateCache {
-    fn new(candidate_retry_cache_size:u64) -> Self {
-        let max_size:usize = candidate_retry_cache_size.try_into().expect("Could not cast `candidate_retry_cache_size` as usize.");
+    fn new(candidate_retry_cache_size: u64) -> Self {
+        let max_size: usize = candidate_retry_cache_size
+            .try_into()
+            .expect("Could not cast `candidate_retry_cache_size` as usize.");
         Self {
             cache: VecDeque::new(),
             next: VecDeque::new(),

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -802,7 +802,6 @@ impl NonceCache {
 struct CandidateCache {
     cache: VecDeque<MemPoolTxInfoPartial>,
     next: VecDeque<MemPoolTxInfoPartial>,
-    size: usize,
 }
 
 impl CandidateCache {
@@ -812,7 +811,6 @@ impl CandidateCache {
         Self {
             cache: VecDeque::new(),
             next: VecDeque::new(),
-            size: 0,
         }
     }
 
@@ -821,16 +819,18 @@ impl CandidateCache {
     }
 
     fn push(&mut self, tx: MemPoolTxInfoPartial) {
-        if self.size < Self::MAX_SIZE {
+        if self.next.len() < Self::MAX_SIZE {
             self.next.push_back(tx);
-            self.size += 1;
         }
     }
 
     fn reset(&mut self) {
         self.next.append(&mut self.cache);
         self.cache = std::mem::take(&mut self.next);
-        self.size = 0;
+    }
+
+    fn len(&self) -> usize {
+        self.cache.len() + self.next.len()
     }
 }
 
@@ -1377,7 +1377,7 @@ impl MemPoolDB {
             // Reset for finding the next transaction to process
             debug!(
                 "Mempool: reset: retry list has {} entries",
-                candidate_cache.size
+                candidate_cache.len()
             );
             candidate_cache.reset();
         }

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -768,7 +768,6 @@ impl MemPoolTxInfo {
 /// Used to locally cache nonces to avoid repeatedly looking them up in the nonce.
 struct NonceCache {
     cache: HashMap<StacksAddress, u64>,
-    size: usize,
     /// The maximum size that this cache can be.
     max_size: usize,
 }
@@ -780,7 +779,6 @@ impl NonceCache {
             .expect("Could not cast `nonce_cache_size` as `usize`.");
         Self {
             cache: HashMap::new(),
-            size: 0,
             max_size,
         }
     }
@@ -797,9 +795,8 @@ impl NonceCache {
                 // will be looked up every time. This is bad for performance
                 // but is unlikely to occur due to the typical number of
                 // transactions processed before filling a block.
-                if self.size < self.max_size {
+                if self.cache.len() < self.max_size {
                     self.cache.insert(address.clone(), nonce);
-                    self.size += 1;
                 }
                 nonce
             }

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -1304,9 +1304,10 @@ impl MemPoolDB {
     /// `todo` will be called once for each transaction that is a valid
     /// candidate for inclusion in the next block, meaning its origin and
     /// sponsor nonces are equal to the nonces of the corresponding accounts.
-    /// Best effort will be made to process the transactions in fee-rate order
-    /// until the candidate cache is full, at which point, transactions with
-    /// a lower fee-rate may be considered before those with a higher fee-rate.
+    /// Best effort will be made to process the transactions in fee-rate order.
+    /// That is, transactions will be processed in fee-rate order until the
+    /// candidate cache is full, at which point, transactions with a lower
+    /// fee-rate may be considered before those with a higher fee-rate.
     /// When the candidate cache fills, a subsequent call to
     /// `iterate_candidates` will be needed to reconsider transactions which
     /// were skipped on the first pass, but become valid after some lower

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -823,11 +823,14 @@ impl CandidateCache {
     fn push(&mut self, tx: MemPoolTxInfoPartial) {
         if self.size < Self::MAX_SIZE {
             self.next.push_back(tx);
+            self.size += 1;
         }
     }
 
     fn reset(&mut self) {
+        self.next.append(&mut self.cache);
         self.cache = std::mem::take(&mut self.next);
+        self.size = 0;
     }
 }
 

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -817,7 +817,7 @@ impl CandidateCache {
     }
 
     fn next(&mut self) -> Option<MemPoolTxInfoPartial> {
-        self.cache.pop_back()
+        self.cache.pop_front()
     }
 
     fn push(&mut self, tx: MemPoolTxInfoPartial) {

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -96,7 +96,7 @@ fn mempool_db_init() {
     let _mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 }
 
-fn make_block(
+pub fn make_block(
     chainstate: &mut StacksChainState,
     block_consensus: ConsensusHash,
     parent: &(ConsensusHash, BlockHeaderHash),

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -25,6 +25,7 @@ use crate::chainstate::stacks::db::test::chainstate_path;
 use crate::chainstate::stacks::db::test::instantiate_chainstate;
 use crate::chainstate::stacks::db::test::instantiate_chainstate_with_balances;
 use crate::chainstate::stacks::db::StreamCursor;
+use crate::chainstate::stacks::events::StacksTransactionReceipt;
 use crate::chainstate::stacks::miner::TransactionResult;
 use crate::chainstate::stacks::test::codec_all_transactions;
 use crate::chainstate::stacks::{
@@ -290,9 +291,16 @@ fn mempool_walk_over_fork() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -322,9 +330,16 @@ fn mempool_walk_over_fork() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -353,9 +368,16 @@ fn mempool_walk_over_fork() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -389,9 +411,16 @@ fn mempool_walk_over_fork() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -423,9 +452,16 @@ fn mempool_walk_over_fork() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -656,9 +692,16 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -670,6 +713,7 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
     );
 
     // Next with 0%
+    let _ = mempool.reset_nonce_cache();
     mempool_settings.consider_no_estimate_tx_prob = 0;
 
     chainstate.with_read_only_clarity_tx(
@@ -686,9 +730,16 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))
@@ -700,6 +751,7 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
     );
 
     // Then with with 100%
+    let _ = mempool.reset_nonce_cache();
     mempool_settings.consider_no_estimate_tx_prob = 100;
 
     chainstate.with_read_only_clarity_tx(
@@ -716,9 +768,16 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
                     |_, available_tx, _| {
                         count_txs += 1;
                         Ok(Some(
-                            TransactionResult::skipped(
+                            // Generate any success result
+                            TransactionResult::success(
                                 &available_tx.tx.tx,
-                                "event not relevant to test".to_string(),
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
                             )
                             .convert_to_event(),
                         ))

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -790,6 +790,361 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
 }
 
 #[test]
+/// This test verifies that when a transaction is skipped, other transactions
+/// from the same address with higher nonces are not included in a block.
+fn test_iterate_candidates_skipped_transaction() {
+    let mut chainstate = instantiate_chainstate_with_balances(
+        false,
+        0x80000000,
+        "test_iterate_candidates_skipped_transaction",
+        vec![],
+    );
+    let chainstate_path = chainstate_path("test_iterate_candidates_skipped_transaction");
+    let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+    let b_1 = make_block(
+        &mut chainstate,
+        ConsensusHash([0x1; 20]),
+        &(
+            FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+            FIRST_STACKS_BLOCK_HASH.clone(),
+        ),
+        1,
+        1,
+    );
+    let b_2 = make_block(&mut chainstate, ConsensusHash([0x2; 20]), &b_1, 2, 2);
+
+    let mut mempool_settings = MemPoolWalkSettings::default();
+    mempool_settings.min_tx_fee = 10;
+    let mut tx_events = Vec::new();
+
+    let mut txs = codec_all_transactions(
+        &TransactionVersion::Testnet,
+        0x80000000,
+        &TransactionAnchorMode::Any,
+        &TransactionPostConditionMode::Allow,
+    );
+
+    // Load 3 transactions into the mempool
+    for nonce in 0..3 {
+        let mut tx = txs.pop().unwrap();
+        let mut mempool_tx = mempool.tx_begin().unwrap();
+
+        let origin_address = tx.origin_address();
+        let origin_nonce = tx.get_origin_nonce();
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+
+        tx.set_tx_fee(100);
+        let txid = tx.txid();
+        let tx_bytes = tx.serialize_to_vec();
+        let tx_fee = tx.get_tx_fee();
+        let height = 100;
+
+        MemPoolDB::try_add_tx(
+            &mut mempool_tx,
+            &mut chainstate,
+            &b_1.0,
+            &b_1.1,
+            txid,
+            tx_bytes,
+            tx_fee,
+            height,
+            &origin_address,
+            nonce,
+            &sponsor_address,
+            nonce,
+            None,
+        )
+        .unwrap();
+
+        mempool_tx.commit().unwrap();
+    }
+
+    chainstate.with_read_only_clarity_tx(
+        &TEST_BURN_STATE_DB,
+        &StacksBlockHeader::make_index_block_hash(&b_2.0, &b_2.1),
+        |clarity_conn| {
+            let mut count_txs = 0;
+            mempool
+                .iterate_candidates::<_, ChainstateError, _>(
+                    clarity_conn,
+                    &mut tx_events,
+                    2,
+                    mempool_settings.clone(),
+                    |_, available_tx, _| {
+                        count_txs += 1;
+                        // For the second transaction, return a `Skipped` result
+                        let result = if count_txs == 2 {
+                            TransactionResult::skipped(
+                                &available_tx.tx.tx,
+                                "event not relevant to test".to_string(),
+                            )
+                            .convert_to_event()
+                        } else {
+                            // Generate any success result
+                            TransactionResult::success(
+                                &available_tx.tx.tx,
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
+                            )
+                            .convert_to_event()
+                        };
+                        Ok(Some(result))
+                    },
+                )
+                .unwrap();
+            assert_eq!(
+                count_txs, 2,
+                "Mempool iteration should not proceed past the skipped transaction"
+            );
+        },
+    );
+}
+
+#[test]
+/// This test verifies that when a transaction reports a processing error, other transactions
+/// from the same address with higher nonces are not included in a block.
+fn test_iterate_candidates_processing_error_transaction() {
+    let mut chainstate = instantiate_chainstate_with_balances(
+        false,
+        0x80000000,
+        "test_iterate_candidates_processing_error_transaction",
+        vec![],
+    );
+    let chainstate_path = chainstate_path("test_iterate_candidates_processing_error_transaction");
+    let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+    let b_1 = make_block(
+        &mut chainstate,
+        ConsensusHash([0x1; 20]),
+        &(
+            FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+            FIRST_STACKS_BLOCK_HASH.clone(),
+        ),
+        1,
+        1,
+    );
+    let b_2 = make_block(&mut chainstate, ConsensusHash([0x2; 20]), &b_1, 2, 2);
+
+    let mut mempool_settings = MemPoolWalkSettings::default();
+    mempool_settings.min_tx_fee = 10;
+    let mut tx_events = Vec::new();
+
+    let mut txs = codec_all_transactions(
+        &TransactionVersion::Testnet,
+        0x80000000,
+        &TransactionAnchorMode::Any,
+        &TransactionPostConditionMode::Allow,
+    );
+
+    // Load 3 transactions into the mempool
+    for nonce in 0..3 {
+        let mut tx = txs.pop().unwrap();
+        let mut mempool_tx = mempool.tx_begin().unwrap();
+
+        let origin_address = tx.origin_address();
+        let origin_nonce = tx.get_origin_nonce();
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+
+        tx.set_tx_fee(100);
+        let txid = tx.txid();
+        let tx_bytes = tx.serialize_to_vec();
+        let tx_fee = tx.get_tx_fee();
+        let height = 100;
+
+        MemPoolDB::try_add_tx(
+            &mut mempool_tx,
+            &mut chainstate,
+            &b_1.0,
+            &b_1.1,
+            txid,
+            tx_bytes,
+            tx_fee,
+            height,
+            &origin_address,
+            nonce,
+            &sponsor_address,
+            nonce,
+            None,
+        )
+        .unwrap();
+
+        mempool_tx.commit().unwrap();
+    }
+
+    chainstate.with_read_only_clarity_tx(
+        &TEST_BURN_STATE_DB,
+        &StacksBlockHeader::make_index_block_hash(&b_2.0, &b_2.1),
+        |clarity_conn| {
+            let mut count_txs = 0;
+            mempool
+                .iterate_candidates::<_, ChainstateError, _>(
+                    clarity_conn,
+                    &mut tx_events,
+                    2,
+                    mempool_settings.clone(),
+                    |_, available_tx, _| {
+                        count_txs += 1;
+                        // For the second transaction, return a `Skipped` result
+                        let result = if count_txs == 2 {
+                            TransactionResult::error(
+                                &available_tx.tx.tx,
+                                crate::chainstate::stacks::Error::StacksTransactionSkipped(
+                                    "error for testing".to_string(),
+                                ),
+                            )
+                            .convert_to_event()
+                        } else {
+                            // Generate any success result
+                            TransactionResult::success(
+                                &available_tx.tx.tx,
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
+                            )
+                            .convert_to_event()
+                        };
+                        Ok(Some(result))
+                    },
+                )
+                .unwrap();
+            assert_eq!(
+                count_txs, 2,
+                "Mempool iteration should not proceed past the skipped transaction"
+            );
+        },
+    );
+}
+
+#[test]
+/// This test verifies that when a transaction is skipped, other transactions
+/// from the same address with higher nonces are not included in a block.
+fn test_iterate_candidates_problematic_transaction() {
+    let mut chainstate = instantiate_chainstate_with_balances(
+        false,
+        0x80000000,
+        "test_iterate_candidates_problematic_transaction",
+        vec![],
+    );
+    let chainstate_path = chainstate_path("test_iterate_candidates_problematic_transaction");
+    let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+    let b_1 = make_block(
+        &mut chainstate,
+        ConsensusHash([0x1; 20]),
+        &(
+            FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
+            FIRST_STACKS_BLOCK_HASH.clone(),
+        ),
+        1,
+        1,
+    );
+    let b_2 = make_block(&mut chainstate, ConsensusHash([0x2; 20]), &b_1, 2, 2);
+
+    let mut mempool_settings = MemPoolWalkSettings::default();
+    mempool_settings.min_tx_fee = 10;
+    let mut tx_events = Vec::new();
+
+    let mut txs = codec_all_transactions(
+        &TransactionVersion::Testnet,
+        0x80000000,
+        &TransactionAnchorMode::Any,
+        &TransactionPostConditionMode::Allow,
+    );
+
+    // Load 3 transactions into the mempool
+    for nonce in 0..3 {
+        let mut tx = txs.pop().unwrap();
+        let mut mempool_tx = mempool.tx_begin().unwrap();
+
+        let origin_address = tx.origin_address();
+        let origin_nonce = tx.get_origin_nonce();
+        let sponsor_address = tx.sponsor_address().unwrap_or(origin_address);
+        let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+
+        tx.set_tx_fee(100);
+        let txid = tx.txid();
+        let tx_bytes = tx.serialize_to_vec();
+        let tx_fee = tx.get_tx_fee();
+        let height = 100;
+
+        MemPoolDB::try_add_tx(
+            &mut mempool_tx,
+            &mut chainstate,
+            &b_1.0,
+            &b_1.1,
+            txid,
+            tx_bytes,
+            tx_fee,
+            height,
+            &origin_address,
+            nonce,
+            &sponsor_address,
+            nonce,
+            None,
+        )
+        .unwrap();
+
+        mempool_tx.commit().unwrap();
+    }
+
+    chainstate.with_read_only_clarity_tx(
+        &TEST_BURN_STATE_DB,
+        &StacksBlockHeader::make_index_block_hash(&b_2.0, &b_2.1),
+        |clarity_conn| {
+            let mut count_txs = 0;
+            mempool
+                .iterate_candidates::<_, ChainstateError, _>(
+                    clarity_conn,
+                    &mut tx_events,
+                    2,
+                    mempool_settings.clone(),
+                    |_, available_tx, _| {
+                        count_txs += 1;
+                        // For the second transaction, return a `Skipped` result
+                        let result = if count_txs == 2 {
+                            TransactionResult::problematic(
+                                &available_tx.tx.tx,
+                                crate::chainstate::stacks::Error::StacksTransactionSkipped(
+                                    "problematic for testing".to_string(),
+                                ),
+                            )
+                            .convert_to_event()
+                        } else {
+                            // Generate any success result
+                            TransactionResult::success(
+                                &available_tx.tx.tx,
+                                available_tx.tx.metadata.tx_fee,
+                                StacksTransactionReceipt::from_stx_transfer(
+                                    available_tx.tx.tx.clone(),
+                                    vec![],
+                                    Value::okay(Value::Bool(true)).unwrap(),
+                                    ExecutionCost::zero(),
+                                ),
+                            )
+                            .convert_to_event()
+                        };
+                        Ok(Some(result))
+                    },
+                )
+                .unwrap();
+            assert_eq!(
+                count_txs, 2,
+                "Mempool iteration should not proceed past the skipped transaction"
+            );
+        },
+    );
+}
+
+#[test]
 fn mempool_do_not_replace_tx() {
     let mut chainstate = instantiate_chainstate_with_balances(
         false,

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -336,7 +336,7 @@ fn mempool_walk_over_fork() {
     );
 
     mempool
-        .reset_last_known_nonces()
+        .reset_nonce_cache()
         .expect("Should be able to reset nonces");
 
     chainstate.with_read_only_clarity_tx(
@@ -370,7 +370,7 @@ fn mempool_walk_over_fork() {
     );
 
     mempool
-        .reset_last_known_nonces()
+        .reset_nonce_cache()
         .expect("Should be able to reset nonces");
 
     // The mempool iterator no longer does any consideration of what block accepted
@@ -406,7 +406,7 @@ fn mempool_walk_over_fork() {
     );
 
     mempool
-        .reset_last_known_nonces()
+        .reset_nonce_cache()
         .expect("Should be able to reset nonces");
 
     chainstate.with_read_only_clarity_tx(
@@ -440,7 +440,7 @@ fn mempool_walk_over_fork() {
     );
 
     mempool
-        .reset_last_known_nonces()
+        .reset_nonce_cache()
         .expect("Should be able to reset nonces");
 
     // let's test replace-across-fork while we're here.

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -595,6 +595,12 @@ impl Config {
                 probability_pick_no_estimate_tx: miner
                     .probability_pick_no_estimate_tx
                     .unwrap_or(miner_default_config.probability_pick_no_estimate_tx),
+                nonce_cache_size: miner
+                    .nonce_cache_size
+                    .unwrap_or(miner_default_config.nonce_cache_size),
+                candidate_retry_cache_size: miner
+                    .candidate_retry_cache_size
+                    .unwrap_or(miner_default_config.candidate_retry_cache_size),
             },
             None => miner_default_config,
         };
@@ -970,6 +976,8 @@ impl Config {
                     self.miner.subsequent_attempt_time_ms
                 },
                 consider_no_estimate_tx_prob: self.miner.probability_pick_no_estimate_tx,
+                nonce_cache_size: self.miner.nonce_cache_size,
+                candidate_retry_cache_size: self.miner.candidate_retry_cache_size,
             },
         }
     }
@@ -1514,6 +1522,8 @@ pub struct MinerConfig {
     pub subsequent_attempt_time_ms: u64,
     pub microblock_attempt_time_ms: u64,
     pub probability_pick_no_estimate_tx: u8,
+    pub nonce_cache_size: u64,
+    pub candidate_retry_cache_size: u64,
 }
 
 impl MinerConfig {
@@ -1524,6 +1534,8 @@ impl MinerConfig {
             subsequent_attempt_time_ms: 30_000,
             microblock_attempt_time_ms: 30_000,
             probability_pick_no_estimate_tx: 5,
+            nonce_cache_size: 10_000,
+            candidate_retry_cache_size: 10_000,
         }
     }
 }
@@ -1628,6 +1640,8 @@ pub struct MinerConfigFile {
     pub subsequent_attempt_time_ms: Option<u64>,
     pub microblock_attempt_time_ms: Option<u64>,
     pub probability_pick_no_estimate_tx: Option<u8>,
+    pub nonce_cache_size: Option<u64>,
+    pub candidate_retry_cache_size: Option<u64>,
 }
 
 #[derive(Clone, Deserialize, Default, Debug)]


### PR DESCRIPTION
This is the cleaned up version of `simple-iterator` discussed in #3326 and #3313.


To-do before checking in:
* verify that a snapshot chainstate creates a DB with the right query plan
  * can do as part of bringing up mock miner from snapshot.. then can check the query plan