### PR TITLE
docs: add details for corner cases of `pow`

### DIFF
--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -216,7 +216,13 @@ const MOD_API: SimpleFunctionAPI = SimpleFunctionAPI {
 const POW_API: SimpleFunctionAPI = SimpleFunctionAPI {
     name: None,
     signature: "(pow i1 i2)",
-    description: "Returns the result of raising `i1` to the power of `i2`. In the event of an _overflow_, throws a runtime error.",
+    description: "Returns the result of raising `i1` to the power of `i2`. In the event of an _overflow_, throws a runtime error.
+Note: Corner cases are handled with the following rules:
+  * if both `i1` and `i2` are `0`, return `1`
+  * if `i1` is `1`, return `1`
+  * if `i1` is `0`, return `0`
+  * if `i2` is `1`, return `i1`
+  * if `i2` is negative or greater than `u32::MAX`, throw a runtime error",
     example: "(pow 2 3) ;; Returns 8
 (pow 2 2) ;; Returns 4
 (pow 7 1) ;; Returns 7


### PR DESCRIPTION
### Description
Documents the corner cases for `pow`

### Applicable issues
- fixes #3295