### PR TITLE
Fix/restore and gate pox sunset

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -78,6 +78,7 @@ jobs:
           - tests::epoch_21::transition_fixes_bitcoin_rigidity
           - tests::epoch_21::transition_adds_pay_to_contract
           - tests::epoch_21::transition_adds_get_pox_addr_recipients
+          - tests::epoch_21::transition_removes_pox_sunset
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ net-test/mnt/archive/*
 *.profraw
 *.profdata
 lcov.info
+
+# patch
+*.orig
+*.rej

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -57,12 +57,12 @@ use crate::chainstate::burn::{BlockSnapshot, Opcodes};
 use crate::chainstate::coordinator::comm::CoordinatorChannels;
 use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::StacksPublicKey;
-use crate::core::StacksEpoch;
 use crate::core::MINING_COMMITMENT_WINDOW;
 use crate::core::NETWORK_ID_MAINNET;
 use crate::core::NETWORK_ID_TESTNET;
 use crate::core::PEER_VERSION_MAINNET;
 use crate::core::PEER_VERSION_TESTNET;
+use crate::core::{StacksEpoch, StacksEpochId};
 use crate::deps;
 use crate::monitoring::update_burnchain_height;
 use crate::types::chainstate::StacksAddress;
@@ -168,7 +168,19 @@ impl BurnchainStateTransition {
         let mut windowed_block_commits = vec![block_commits];
         let mut windowed_missed_commits = vec![];
 
-        if !burnchain.is_in_prepare_phase(parent_snapshot.block_height + 1) {
+        // what epoch are we in?
+        let epoch_id = SortitionDB::get_stacks_epoch(sort_tx, parent_snapshot.block_height + 1)?
+            .expect(&format!(
+                "FATAL: no epoch defined at burn height {}",
+                parent_snapshot.block_height + 1
+            ))
+            .epoch_id;
+
+        if !burnchain.is_in_prepare_phase(parent_snapshot.block_height + 1)
+            && !burnchain
+                .pox_constants
+                .is_after_pox_sunset_end(parent_snapshot.block_height + 1, epoch_id)
+        {
             // PoX reward-phase is active!
             // build a map of intended sortition -> missed commit for the missed commits
             //   discovered in this block.
@@ -211,7 +223,7 @@ impl BurnchainStateTransition {
         } else {
             // PoX reward-phase is not active
             debug!(
-                "Block {} is in a prepare phase, so no windowing will take place",
+                "Block {} is in a prepare phase or post-PoX sunset, so no windowing will take place",
                 parent_snapshot.block_height + 1
             );
 
@@ -223,14 +235,22 @@ impl BurnchainStateTransition {
         windowed_block_commits.reverse();
         windowed_missed_commits.reverse();
 
-        // figure out which sortitions must be PoB due to them falling in a prepare phase.
+        // figure out if the PoX sunset finished during the window,
+        // and/or which sortitions must be PoB due to them falling in a prepare phase.
         let window_end_height = parent_snapshot.block_height + 1;
         let window_start_height = window_end_height + 1 - (windowed_block_commits.len() as u64);
         let mut burn_blocks = vec![false; windowed_block_commits.len()];
 
-        // set burn_blocks flags to accomodate prepare phases
+        // set burn_blocks flags to accomodate prepare phases and PoX sunset
         for (i, b) in burn_blocks.iter_mut().enumerate() {
-            if burnchain.is_in_prepare_phase(window_start_height + (i as u64)) {
+            if PoxConstants::has_pox_sunset(epoch_id)
+                && burnchain
+                    .pox_constants
+                    .is_after_pox_sunset_end(window_start_height + (i as u64), epoch_id)
+            {
+                // past PoX sunset, so must burn
+                *b = true;
+            } else if burnchain.is_in_prepare_phase(window_start_height + (i as u64)) {
                 // must burn
                 *b = true;
             } else {
@@ -454,8 +474,61 @@ impl Burnchain {
         })
     }
 
+    /// BROKEN; DO NOT USE IN NEW CODE
     pub fn is_mainnet(&self) -> bool {
         self.network_id == NETWORK_ID_MAINNET
+    }
+
+    /// the expected sunset burn is:
+    ///   total_commit * (progress through sunset phase) / (sunset phase duration)
+    pub fn expected_sunset_burn(
+        &self,
+        burn_height: u64,
+        total_commit: u64,
+        epoch_id: StacksEpochId,
+    ) -> u64 {
+        if !PoxConstants::has_pox_sunset(epoch_id) {
+            // sunset is disabled
+            return 0;
+        }
+        if !self
+            .pox_constants
+            .is_after_pox_sunset_start(burn_height, epoch_id)
+        {
+            // too soon to do this
+            return 0;
+        }
+        if self
+            .pox_constants
+            .is_after_pox_sunset_end(burn_height, epoch_id)
+        {
+            // no need to do an extra burn; PoX is already disabled
+            return 0;
+        }
+
+        // no sunset burn needed in prepare phase -- it's already getting burnt
+        if self.is_in_prepare_phase(burn_height) {
+            return 0;
+        }
+
+        let reward_cycle_height = self.reward_cycle_to_block_height(
+            self.block_height_to_reward_cycle(burn_height)
+                .expect("BUG: Sunset start is less than first_block_height"),
+        );
+
+        if reward_cycle_height <= self.pox_constants.sunset_start {
+            return 0;
+        }
+
+        let sunset_duration =
+            (self.pox_constants.sunset_end - self.pox_constants.sunset_start) as u128;
+        let sunset_progress = (reward_cycle_height - self.pox_constants.sunset_start) as u128;
+
+        // use u128 to avoid any possibilities of overflowing in the calculation here.
+        let expected_u128 = (total_commit as u128) * (sunset_progress) / sunset_duration;
+        u64::try_from(expected_u128)
+            // should never be possible, because sunset_burn is <= total_commit, which is a u64
+            .expect("Overflowed u64 in calculating expected sunset_burn")
     }
 
     pub fn is_reward_cycle_start(&self, burn_height: u64) -> bool {
@@ -688,6 +761,7 @@ impl Burnchain {
         burnchain: &Burnchain,
         burnchain_db: &BurnchainDB,
         block_header: &BurnchainBlockHeader,
+        epoch_id: StacksEpochId,
         burn_tx: &BurnchainTransaction,
         pre_stx_op_map: &HashMap<Txid, PreStxOp>,
     ) -> Option<BlockstackOperationType> {
@@ -707,7 +781,7 @@ impl Burnchain {
                 }
             }
             x if x == Opcodes::LeaderBlockCommit as u8 => {
-                match LeaderBlockCommitOp::from_tx(burnchain, block_header, burn_tx) {
+                match LeaderBlockCommitOp::from_tx(burnchain, block_header, epoch_id, burn_tx) {
                     Ok(op) => Some(BlockstackOperationType::LeaderBlockCommit(op)),
                     Err(e) => {
                         warn!(
@@ -734,18 +808,25 @@ impl Burnchain {
                     }
                 }
             }
-            x if x == Opcodes::PreStx as u8 => match PreStxOp::from_tx(block_header, burn_tx) {
-                Ok(op) => Some(BlockstackOperationType::PreStx(op)),
-                Err(e) => {
-                    warn!(
-                        "Failed to parse pre stack stx tx";
-                        "txid" => %burn_tx.txid(),
-                        "data" => %to_hex(&burn_tx.data()),
-                        "error" => ?e,
-                    );
-                    None
+            x if x == Opcodes::PreStx as u8 => {
+                match PreStxOp::from_tx(
+                    block_header,
+                    epoch_id,
+                    burn_tx,
+                    burnchain.pox_constants.sunset_end,
+                ) {
+                    Ok(op) => Some(BlockstackOperationType::PreStx(op)),
+                    Err(e) => {
+                        warn!(
+                            "Failed to parse pre stack stx tx";
+                            "txid" => %burn_tx.txid(),
+                            "data" => %to_hex(&burn_tx.data()),
+                            "error" => ?e,
+                        );
+                        None
+                    }
                 }
-            },
+            }
             x if x == Opcodes::TransferStx as u8 => {
                 let pre_stx_txid = TransferStxOp::get_sender_txid(burn_tx).ok()?;
                 let pre_stx_tx = match pre_stx_op_map.get(&pre_stx_txid) {
@@ -783,7 +864,13 @@ impl Burnchain {
                 };
                 if let Some(BlockstackOperationType::PreStx(pre_stack_stx)) = pre_stx_tx {
                     let sender = &pre_stack_stx.output;
-                    match StackStxOp::from_tx(block_header, burn_tx, sender) {
+                    match StackStxOp::from_tx(
+                        block_header,
+                        epoch_id,
+                        burn_tx,
+                        sender,
+                        burnchain.pox_constants.sunset_end,
+                    ) {
                         Ok(op) => Some(BlockstackOperationType::StackStx(op)),
                         Err(e) => {
                             warn!(
@@ -859,6 +946,7 @@ impl Burnchain {
         burnchain: &Burnchain,
         burnchain_db: &mut BurnchainDB,
         block: &BurnchainBlock,
+        epoch_id: StacksEpochId,
     ) -> Result<BurnchainBlockHeader, burnchain_error> {
         debug!(
             "Process block {} {}",
@@ -866,7 +954,8 @@ impl Burnchain {
             &block.block_hash()
         );
 
-        let _blockstack_txs = burnchain_db.store_new_burnchain_block(burnchain, &block)?;
+        let _blockstack_txs =
+            burnchain_db.store_new_burnchain_block(burnchain, &block, epoch_id)?;
 
         let header = block.header();
 
@@ -887,8 +976,15 @@ impl Burnchain {
             &block.block_hash()
         );
 
+        let cur_epoch =
+            SortitionDB::get_stacks_epoch(db.conn(), block.block_height())?.expect(&format!(
+                "FATAL: no epoch for burn block height {}",
+                block.block_height()
+            ));
+
         let header = block.header();
-        let blockstack_txs = burnchain_db.store_new_burnchain_block(burnchain, &block)?;
+        let blockstack_txs =
+            burnchain_db.store_new_burnchain_block(burnchain, &block, cur_epoch.epoch_id)?;
 
         let sortition_tip = SortitionDB::get_canonical_sortition_tip(db.conn())?;
 
@@ -1325,6 +1421,11 @@ impl Burnchain {
 
         let myself = self.clone();
 
+        let epochs = {
+            let (sortdb, _) = self.open_db(false)?;
+            SortitionDB::get_stacks_epochs(sortdb.conn())?
+        };
+
         // TODO: don't re-process blocks.  See if the block hash is already present in the burn db,
         // and if so, do nothing.
         let download_thread: thread::JoinHandle<Result<(), burnchain_error>> =
@@ -1406,6 +1507,8 @@ impl Burnchain {
                         }
 
                         if is_mainnet {
+                            // NOTE: This code block is unreachable due to a bug in
+                            // self.is_mainnet() 
                             if last_processed.block_height == STACKS_2_0_LAST_BLOCK_TO_PROCESS {
                                 info!("Reached Stacks 2.0 last block to processed, ignoring subsequent burn blocks";
                                       "block_height" => last_processed.block_height);
@@ -1418,9 +1521,14 @@ impl Burnchain {
                             }
                         }
 
+                        let epoch_index = StacksEpoch::find_epoch(&epochs, block_height)
+                            .expect(&format!("FATAL: no epoch defined for height {}", block_height));
+
+                        let epoch_id = epochs[epoch_index].epoch_id;
+
                         let insert_start = get_epoch_time_ms();
                         last_processed =
-                            Burnchain::process_block(&myself, &mut burnchain_db, &burnchain_block)?;
+                            Burnchain::process_block(&myself, &mut burnchain_db, &burnchain_block, epoch_id)?;
                         if !coord_comm.announce_new_burn_block() {
                             return Err(burnchain_error::CoordinatorClosed);
                         }
@@ -1845,6 +1953,7 @@ pub mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
@@ -1885,6 +1994,7 @@ pub mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
@@ -1925,6 +2035,7 @@ pub mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             commit_outs: vec![],
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
@@ -2487,6 +2598,7 @@ pub mod tests {
             // insert block commit paired to previous round's leader key, as well as a user burn
             if i > 0 {
                 let next_block_commit = LeaderBlockCommitOp {
+                    sunset_burn: 0,
                     commit_outs: vec![],
                     block_header_hash: BlockHeaderHash::from_bytes(&vec![
                         i, i, i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/burnchains/db.rs
+++ b/src/burnchains/db.rs
@@ -34,6 +34,8 @@ use crate::util_lib::db::{
 use crate::chainstate::stacks::index::ClarityMarfTrieId;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 
+use crate::core::StacksEpochId;
+
 pub struct BurnchainDB {
     conn: Connection,
 }
@@ -320,6 +322,7 @@ impl BurnchainDB {
         burnchain: &Burnchain,
         block: &BurnchainBlock,
         block_header: &BurnchainBlockHeader,
+        epoch_id: StacksEpochId,
     ) -> Vec<BlockstackOperationType> {
         debug!(
             "Extract Blockstack transactions from block {} {}",
@@ -331,8 +334,14 @@ impl BurnchainDB {
         let mut pre_stx_ops = HashMap::new();
 
         for tx in block.txs().iter() {
-            let result =
-                Burnchain::classify_transaction(burnchain, self, block_header, &tx, &pre_stx_ops);
+            let result = Burnchain::classify_transaction(
+                burnchain,
+                self,
+                block_header,
+                epoch_id,
+                &tx,
+                &pre_stx_ops,
+            );
             if let Some(classified_tx) = result {
                 if let BlockstackOperationType::PreStx(pre_stx_op) = classified_tx {
                     pre_stx_ops.insert(pre_stx_op.txid.clone(), pre_stx_op);
@@ -357,11 +366,13 @@ impl BurnchainDB {
         &mut self,
         burnchain: &Burnchain,
         block: &BurnchainBlock,
+        epoch_id: StacksEpochId,
     ) -> Result<Vec<BlockstackOperationType>, BurnchainError> {
         let header = block.header();
         debug!("Storing new burnchain block";
               "burn_header_hash" => %header.block_hash.to_string());
-        let mut blockstack_ops = self.get_blockstack_transactions(burnchain, block, &header);
+        let mut blockstack_ops =
+            self.get_blockstack_transactions(burnchain, block, &header, epoch_id);
         apply_blockstack_txs_safety_checks(header.block_height, &mut blockstack_ops);
 
         let db_tx = self.tx_begin()?;
@@ -432,6 +443,8 @@ mod tests {
 
         let mut burnchain = Burnchain::regtest(":memory:");
         burnchain.pox_constants = PoxConstants::test_default();
+        burnchain.pox_constants.sunset_start = 999;
+        burnchain.pox_constants.sunset_end = 1000;
 
         let first_block_header = burnchain_db.get_canonical_chain_tip().unwrap();
         assert_eq!(&first_block_header.block_hash, &first_bhh);
@@ -452,7 +465,7 @@ mod tests {
             485,
         ));
         let ops = burnchain_db
-            .store_new_burnchain_block(&burnchain, &canonical_block)
+            .store_new_burnchain_block(&burnchain, &canonical_block, StacksEpochId::Epoch21)
             .unwrap();
         assert_eq!(ops.len(), 0);
 
@@ -490,7 +503,7 @@ mod tests {
         ));
 
         let ops = burnchain_db
-            .store_new_burnchain_block(&burnchain, &non_canonical_block)
+            .store_new_burnchain_block(&burnchain, &non_canonical_block, StacksEpochId::Epoch21)
             .unwrap();
         assert_eq!(ops.len(), expected_ops.len());
         for op in ops.iter() {
@@ -542,6 +555,8 @@ mod tests {
 
         let mut burnchain = Burnchain::regtest(":memory:");
         burnchain.pox_constants = PoxConstants::test_default();
+        burnchain.pox_constants.sunset_start = 999;
+        burnchain.pox_constants.sunset_end = 1000;
 
         let first_block_header = burnchain_db.get_canonical_chain_tip().unwrap();
         assert_eq!(&first_block_header.block_hash, &first_bhh);
@@ -562,7 +577,7 @@ mod tests {
             485,
         ));
         let ops = burnchain_db
-            .store_new_burnchain_block(&burnchain, &canonical_block)
+            .store_new_burnchain_block(&burnchain, &canonical_block, StacksEpochId::Epoch21)
             .unwrap();
         assert_eq!(ops.len(), 0);
 
@@ -713,7 +728,7 @@ mod tests {
         ));
 
         let processed_ops_0 = burnchain_db
-            .store_new_burnchain_block(&burnchain, &block_0)
+            .store_new_burnchain_block(&burnchain, &block_0, StacksEpochId::Epoch21)
             .unwrap();
 
         assert_eq!(
@@ -723,7 +738,7 @@ mod tests {
         );
 
         let processed_ops_1 = burnchain_db
-            .store_new_burnchain_block(&burnchain, &block_1)
+            .store_new_burnchain_block(&burnchain, &block_1, StacksEpochId::Epoch21)
             .unwrap();
 
         assert_eq!(

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -420,7 +420,7 @@ impl PoxConstants {
         if !Self::has_pox_sunset(epoch_id) {
             false
         } else {
-            burn_block_height > self.sunset_end
+            burn_block_height >= self.sunset_end
         }
     }
 

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -302,6 +302,10 @@ pub struct PoxConstants {
     /// percentage of liquid STX that must participate for PoX
     ///  to occur
     pub pox_participation_threshold_pct: u64,
+    /// last+1 block height of sunset phase
+    pub sunset_end: u64,
+    /// first block height of sunset phase
+    pub sunset_start: u64,
     /// The auto unlock height for PoX v1 lockups before transition to PoX v2. This
     /// also defines the burn height at which PoX reward sets are calculated using
     /// PoX v2 rather than v1
@@ -316,10 +320,13 @@ impl PoxConstants {
         anchor_threshold: u32,
         pox_rejection_fraction: u64,
         pox_participation_threshold_pct: u64,
+        sunset_start: u64,
+        sunset_end: u64,
         v1_unlock_height: u32,
     ) -> PoxConstants {
         assert!(anchor_threshold > (prepare_length / 2));
         assert!(prepare_length < reward_cycle_length);
+        assert!(sunset_start <= sunset_end);
 
         PoxConstants {
             reward_cycle_length,
@@ -327,6 +334,8 @@ impl PoxConstants {
             anchor_threshold,
             pox_rejection_fraction,
             pox_participation_threshold_pct,
+            sunset_start,
+            sunset_end,
             v1_unlock_height,
             _shadow: PhantomData,
         }
@@ -334,7 +343,7 @@ impl PoxConstants {
     #[cfg(test)]
     pub fn test_default() -> PoxConstants {
         // 20 reward slots; 10 prepare-phase slots
-        PoxConstants::new(10, 5, 3, 25, 5, u32::max_value())
+        PoxConstants::new(10, 5, 3, 25, 5, 5000, 10000, u32::max_value())
     }
 
     /// Returns the PoX contract that is "active" at the given burn block height
@@ -367,6 +376,8 @@ impl PoxConstants {
             80,
             25,
             5,
+            BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,
+            BITCOIN_MAINNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_END,
             POX_V1_MAINNET_EARLY_UNLOCK_HEIGHT,
         )
     }
@@ -378,12 +389,54 @@ impl PoxConstants {
             40,
             12,
             2,
+            BITCOIN_TESTNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,
+            BITCOIN_TESTNET_FIRST_BLOCK_HEIGHT + POX_SUNSET_END,
             POX_V1_TESTNET_EARLY_UNLOCK_HEIGHT,
         ) // total liquid supply is 40000000000000000 µSTX
     }
 
     pub fn regtest_default() -> PoxConstants {
-        PoxConstants::new(5, 1, 1, 3333333333333333, 1, 1_000_000)
+        PoxConstants::new(
+            5,
+            1,
+            1,
+            3333333333333333,
+            1,
+            BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT + POX_SUNSET_START,
+            BITCOIN_REGTEST_FIRST_BLOCK_HEIGHT + POX_SUNSET_END,
+            1_000_000,
+        )
+    }
+
+    /// Return true if PoX should sunset at all
+    /// return false if not.
+    pub fn has_pox_sunset(epoch_id: StacksEpochId) -> bool {
+        epoch_id < StacksEpochId::Epoch21
+    }
+
+    /// Returns true if PoX has been fully disabled by the PoX sunset.
+    /// Behavior is epoch-specific
+    pub fn is_after_pox_sunset_end(&self, burn_block_height: u64, epoch_id: StacksEpochId) -> bool {
+        if !Self::has_pox_sunset(epoch_id) {
+            false
+        } else {
+            burn_block_height > self.sunset_end
+        }
+    }
+
+    /// Returns true if the burn height falls into the PoX sunset period.
+    /// Returns false if not, or if the sunset isn't active in this epoch
+    /// (Note that this is true if burn_block_height is beyond the sunset height)
+    pub fn is_after_pox_sunset_start(
+        &self,
+        burn_block_height: u64,
+        epoch_id: StacksEpochId,
+    ) -> bool {
+        if !Self::has_pox_sunset(epoch_id) {
+            false
+        } else {
+            self.sunset_start <= burn_block_height
+        }
     }
 }
 

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -418,6 +418,7 @@ mod tests {
         };
 
         let block_commit = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash([0x22; 32]),
             new_seed: VRFSeed::from_hex(
                 "3333333333333333333333333333333333333333333333333333333333333333",

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -269,7 +269,7 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
 
         let burn_fee = burn_fee_str
             .parse::<u64>()
-            .expect("DB Corruption: Sunset burn is not parseable as u64");
+            .expect("DB Corruption: burn fee is not parseable as u64");
 
         let sunset_burn = sunset_burn_str
             .parse::<u64>()

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -252,6 +252,7 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
         let burn_fee_str: String = row.get_unwrap("burn_fee");
         let input_json: String = row.get_unwrap("input");
         let apparent_sender_json: String = row.get_unwrap("apparent_sender");
+        let sunset_burn_str: String = row.get_unwrap("sunset_burn");
 
         let commit_outs = serde_json::from_value(row.get_unwrap("commit_outs"))
             .expect("Unparseable value stored to database");
@@ -268,7 +269,11 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
 
         let burn_fee = burn_fee_str
             .parse::<u64>()
-            .expect("DB Corruption: burn is not parseable as u64");
+            .expect("DB Corruption: Sunset burn is not parseable as u64");
+
+        let sunset_burn = sunset_burn_str
+            .parse::<u64>()
+            .expect("DB Corruption: Sunset burn is not parseable as u64");
 
         let burn_parent_modulus: u8 = row.get_unwrap("burn_parent_modulus");
 
@@ -286,6 +291,7 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
             input,
             apparent_sender,
             commit_outs,
+            sunset_burn,
             txid,
             vtxindex,
             block_height,
@@ -523,7 +529,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         memo TEXT,
         commit_outs TEXT,
         burn_fee TEXT NOT NULL,     -- use text to encode really big numbers
-        sunset_burn TEXT NOT NULL,     -- use text to encode really big numbers (OBSOLETE; IGNORED)
+        sunset_burn TEXT NOT NULL,     -- use text to encode really big numbers
         input TEXT NOT NULL,
         apparent_sender TEXT NOT NULL,
         burn_parent_modulus INTEGER NOT NULL,
@@ -1540,6 +1546,9 @@ impl<'a> SortitionHandleTx<'a> {
                         // This block was mined on this fork, but it's acceptance doesn't overtake
                         // the current stacks chain tip.  Remember it so that we can process its children,
                         // which might do so later.
+                        //
+                        // TODO: flip a coin here to decide the tie (or use the burn block hash or
+                        // whatever)
                         debug!("Accepted Stacks block {}/{} builds on a non-canonical Stacks tip in this burnchain fork ({})", consensus_hash, stacks_block_hash, &burn_tip.burn_header_hash);
                     }
                     SortitionDB::insert_accepted_stacks_block_pointer(
@@ -3052,6 +3061,12 @@ impl SortitionDB {
                 BurnchainError::MissingParentBlock
             })?;
 
+        let cur_epoch = SortitionDB::get_stacks_epoch(self.conn(), burn_header.block_height)?
+            .expect(&format!(
+                "FATAL: no epoch defined for burn height {}",
+                burn_header.block_height
+            ));
+
         let mut sortition_db_handle = SortitionHandleTx::begin(self, &parent_sort_id)?;
         let parent_snapshot = sortition_db_handle
             .get_block_snapshot(&burn_header.parent_block_hash, &parent_sort_id)?
@@ -3066,12 +3081,24 @@ impl SortitionDB {
             .sortition_hash
             .mix_burn_header(&parent_snapshot.burn_header_hash);
 
-        let reward_set_info = sortition_db_handle.pick_recipients(
-            burnchain,
-            burn_header.block_height,
-            &reward_set_vrf_hash,
-            next_pox_info.as_ref(),
-        )?;
+        let reward_set_info = if cur_epoch.epoch_id < StacksEpochId::Epoch21
+            && burn_header.block_height >= burnchain.pox_constants.sunset_end
+        {
+            test_debug!(
+                "No recipients for burn height {}: epoch = {}, sunset_end = {}",
+                burnchain.pox_constants.sunset_end,
+                cur_epoch.epoch_id,
+                burn_header.block_height
+            );
+            None
+        } else {
+            sortition_db_handle.pick_recipients(
+                burnchain,
+                burn_header.block_height,
+                &reward_set_vrf_hash,
+                next_pox_info.as_ref(),
+            )?
+        };
 
         // Get any initial mining bonus which would be due to the winner of this block.
         let bonus_remaining =
@@ -3128,15 +3155,28 @@ impl SortitionDB {
             .sortition_hash
             .mix_burn_header(&parent_snapshot.burn_header_hash);
 
+        let cur_epoch =
+            SortitionDB::get_stacks_epoch(self.conn(), parent_snapshot.block_height + 1)?.expect(
+                &format!(
+                    "FATAL: no epoch defined for burn height {}",
+                    parent_snapshot.block_height + 1
+                ),
+            );
+
         let mut sortition_db_handle =
             SortitionHandleTx::begin(self, &parent_snapshot.sortition_id)?;
-
-        sortition_db_handle.pick_recipients(
-            burnchain,
-            parent_snapshot.block_height + 1,
-            &reward_set_vrf_hash,
-            next_pox_info,
-        )
+        if cur_epoch.epoch_id < StacksEpochId::Epoch21
+            && parent_snapshot.block_height + 1 >= burnchain.pox_constants.sunset_end
+        {
+            Ok(None)
+        } else {
+            sortition_db_handle.pick_recipients(
+                burnchain,
+                parent_snapshot.block_height + 1,
+                &reward_set_vrf_hash,
+                next_pox_info,
+            )
+        }
     }
 
     pub fn is_stacks_block_in_sortition_set(
@@ -4190,7 +4230,7 @@ impl<'a> SortitionHandleTx<'a> {
             &tx_input_str,
             sort_id,
             &serde_json::to_value(&block_commit.commit_outs).unwrap(),
-            &0i64,
+            &block_commit.sunset_burn.to_string(),
             &apparent_sender_str,
             &block_commit.burn_parent_modulus,
         ];
@@ -5040,6 +5080,7 @@ pub mod tests {
         };
 
         let block_commit = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -5861,6 +5902,7 @@ pub mod tests {
         };
 
         let block_commit = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -7988,6 +8030,7 @@ pub mod tests {
         };
 
         let genesis_block_commit = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222221")
                     .unwrap(),
@@ -8030,6 +8073,7 @@ pub mod tests {
 
         // descends from genesis
         let block_commit_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -8071,6 +8115,7 @@ pub mod tests {
 
         // descends from block_commit_1
         let block_commit_1_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
                     .unwrap(),
@@ -8112,6 +8157,7 @@ pub mod tests {
 
         // descends from genesis_block_commit
         let block_commit_2 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
                     .unwrap(),

--- a/src/chainstate/burn/distribution.rs
+++ b/src/chainstate/burn/distribution.rs
@@ -126,8 +126,8 @@ impl BurnSamplePoint {
     ///
     /// All operations need to be supplied in an ordered Vec of Vecs containing
     ///   the ops at each block height in a mining commit window.  Normally, this window
-    ///   is the constant `MINING_COMMITMENT_WINDOW`, except during prepare-phases.
-    ///   In this particular case, the window is only one block.  The code does not
+    ///   is the constant `MINING_COMMITMENT_WINDOW`, except during prepare-phases and post-PoX
+    ///   sunset.  In either of these two cases, the window is only one block.  The code does not
     ///   consider which window is active; it merely deduces it by inspecting the length of the
     ///   given `block_commits` argument.
     ///
@@ -150,7 +150,7 @@ impl BurnSamplePoint {
     ///     `missed_commits.len() = block_commits.len() - 1`
     /// * `burn_blocks`: this is a vector of booleans that indicate whether or not a block-commit
     ///     occurred during a PoB-only sortition or a possibly-PoX sortition.  The former occurs
-    ///     during a prepare phase, and must have only one (burn) output.
+    ///     during either a prepare phase or after PoX sunset, and must have only one (burn) output.
     ///     The latter occurs everywhere else, and must have `OUTPUTS_PER_COMMIT` outputs after the
     ///     `OP_RETURN` payload.  The length of this vector must be equal to the length of the
     ///     `block_commits` vector.  `burn_blocks[i]` is `true` if the `ith` block-commit must be PoB.
@@ -519,6 +519,7 @@ mod tests {
             input: (input_txid, 3),
             apparent_sender: BurnchainSigner::new_p2pkh(&StacksPublicKey::new()),
             commit_outs: vec![],
+            sunset_burn: 0,
             txid,
             vtxindex: 0,
             block_height: block_ht,
@@ -529,6 +530,111 @@ mod tests {
             },
             burn_header_hash: BurnchainHeaderHash([0; 32]),
         }
+    }
+
+    #[test]
+    fn make_mean_min_median_sunset_in_window() {
+        //    miner 1:  3 4 5 4 5 4
+        //       ub  :  1 0 0 0 0 0
+        //                    | sunset end
+        //    miner 2:  1 3 3 3 3 3
+        //       ub  :  1 0 0 0 0 0
+        //              0 1 0 0 0 0
+        //                   ..
+
+        // miner 1 => min = 1, median = 1, last_burn = 4
+        // miner 2 => min = 1, median = 1, last_burn = 3
+
+        let mut commits = vec![
+            vec![
+                make_block_commit(3, 1, 1, 1, None, 1),
+                make_block_commit(1, 2, 2, 2, None, 1),
+            ],
+            vec![
+                make_block_commit(4, 3, 3, 3, Some(1), 2),
+                make_block_commit(3, 4, 4, 4, Some(2), 2),
+            ],
+            vec![
+                make_block_commit(5, 5, 5, 5, Some(3), 3),
+                make_block_commit(3, 6, 6, 6, Some(4), 3),
+            ],
+            vec![
+                make_block_commit(4, 7, 7, 7, Some(5), 4),
+                make_block_commit(3, 8, 8, 8, Some(6), 4),
+            ],
+            vec![
+                make_block_commit(5, 9, 9, 9, Some(7), 5),
+                make_block_commit(3, 10, 10, 10, Some(8), 5),
+            ],
+            vec![
+                make_block_commit(4, 11, 11, 11, Some(9), 6),
+                make_block_commit(3, 12, 12, 12, Some(10), 6),
+            ],
+        ];
+        let user_burns = vec![
+            vec![make_user_burn(1, 1, 1, 1, 1), make_user_burn(1, 2, 2, 2, 1)],
+            vec![make_user_burn(1, 4, 4, 4, 2)],
+            vec![make_user_burn(1, 6, 6, 6, 3)],
+            vec![make_user_burn(1, 8, 8, 8, 4)],
+            vec![make_user_burn(1, 10, 10, 10, 5)],
+            vec![make_user_burn(1, 12, 12, 12, 6)],
+        ];
+
+        let mut result = BurnSamplePoint::make_min_median_distribution(
+            commits.clone(),
+            vec![vec![]; (MINING_COMMITMENT_WINDOW - 1) as usize],
+            vec![false, false, false, true, true, true],
+        );
+
+        assert_eq!(result.len(), 2, "Should be two miners");
+
+        result.sort_by_key(|sample| sample.candidate.txid);
+
+        // block-commits are currently malformed -- the post-sunset commits spend the wrong UTXO.
+        assert_eq!(result[0].burns, 1);
+        assert_eq!(result[1].burns, 1);
+
+        // make sure that we're associating with the last commit in the window.
+        assert_eq!(result[0].candidate.txid, commits[5][0].txid);
+        assert_eq!(result[1].candidate.txid, commits[5][1].txid);
+
+        assert_eq!(result[0].user_burns.len(), 0);
+        assert_eq!(result[1].user_burns.len(), 0);
+
+        // now correct the back pointers so that they point
+        //   at the correct UTXO position *post-sunset*
+        for (ix, window_slice) in commits.iter_mut().enumerate() {
+            if ix >= 4 {
+                for commit in window_slice.iter_mut() {
+                    commit.input.1 = 2;
+                }
+            }
+        }
+
+        //    miner 1:  3 4 5 4 5 4
+        //    miner 2:  1 3 3 3 3 3
+        // miner 1 => min = 3, median = 4, last_burn = 4
+        // miner 2 => min = 1, median = 3, last_burn = 3
+
+        let mut result = BurnSamplePoint::make_min_median_distribution(
+            commits.clone(),
+            vec![vec![]; (MINING_COMMITMENT_WINDOW - 1) as usize],
+            vec![false, false, false, true, true, true],
+        );
+
+        assert_eq!(result.len(), 2, "Should be two miners");
+
+        result.sort_by_key(|sample| sample.candidate.txid);
+
+        assert_eq!(result[0].burns, 4);
+        assert_eq!(result[1].burns, 3);
+
+        // make sure that we're associating with the last commit in the window.
+        assert_eq!(result[0].candidate.txid, commits[5][0].txid);
+        assert_eq!(result[1].candidate.txid, commits[5][1].txid);
+
+        assert_eq!(result[0].user_burns.len(), 0);
+        assert_eq!(result[1].user_burns.len(), 0);
     }
 
     #[test]
@@ -1018,6 +1124,7 @@ mod tests {
         };
 
         let block_commit_1 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
                     .unwrap(),
@@ -1062,6 +1169,7 @@ mod tests {
         };
 
         let block_commit_2 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222223")
                     .unwrap(),
@@ -1106,6 +1214,7 @@ mod tests {
         };
 
         let block_commit_3 = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: BlockHeaderHash::from_bytes(
                 &hex_bytes("2222222222222222222222222222222222222222222222222222222222222224")
                     .unwrap(),

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -579,9 +579,10 @@ impl LeaderBlockCommitOp {
 
                         if check_recipients.len() == 1 {
                             // If the number of recipients in the set was odd, we need to pad
-                            // with a burn address
-                            check_recipients
-                                .push(PoxAddress::standard_burn_address(burnchain.is_mainnet()))
+                            // with a burn address.
+                            // NOTE: this used the old burnchain.is_mainnet() code, which always
+                            // returns false
+                            check_recipients.push(PoxAddress::standard_burn_address(false))
                         }
 
                         if self.commit_outs.len() != check_recipients.len() {

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -233,6 +233,8 @@ pub struct LeaderBlockCommitOp {
 
     /// PoX/Burn outputs
     pub commit_outs: Vec<PoxAddress>,
+    // PoX sunset burn
+    pub sunset_burn: u64,
 
     // common to all transactions
     pub txid: Txid,                            // transaction ID

--- a/src/chainstate/burn/operations/stack_stx.rs
+++ b/src/chainstate/burn/operations/stack_stx.rs
@@ -19,6 +19,7 @@ use std::io::{Read, Write};
 use crate::burnchains::Address;
 use crate::burnchains::Burnchain;
 use crate::burnchains::BurnchainBlockHeader;
+use crate::burnchains::PoxConstants;
 use crate::burnchains::Txid;
 use crate::burnchains::{BurnchainRecipient, BurnchainSigner};
 use crate::burnchains::{BurnchainTransaction, PublicKey};
@@ -33,6 +34,7 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::index::storage::TrieFileStorage;
 use crate::chainstate::stacks::{StacksPrivateKey, StacksPublicKey};
 use crate::codec::{write_next, Error as codec_error, StacksMessageCodec};
+use crate::core::StacksEpochId;
 use crate::core::POX_MAX_NUM_CYCLES;
 use crate::net::Error as net_error;
 use crate::types::chainstate::TrieHash;
@@ -67,16 +69,27 @@ impl PreStxOp {
 
     pub fn from_tx(
         block_header: &BurnchainBlockHeader,
+        epoch_id: StacksEpochId,
         tx: &BurnchainTransaction,
+        pox_sunset_ht: u64,
     ) -> Result<PreStxOp, op_error> {
-        PreStxOp::parse_from_tx(block_header.block_height, &block_header.block_hash, tx)
+        PreStxOp::parse_from_tx(
+            block_header.block_height,
+            &block_header.block_hash,
+            epoch_id,
+            tx,
+            pox_sunset_ht,
+        )
     }
 
     /// parse a PreStxOp
+    /// `pox_sunset_ht` is the height at which PoX *disables*
     pub fn parse_from_tx(
         block_height: u64,
         block_hash: &BurnchainHeaderHash,
+        epoch_id: StacksEpochId,
         tx: &BurnchainTransaction,
+        pox_sunset_ht: u64,
     ) -> Result<PreStxOp, op_error> {
         // can't be too careful...
         let inputs = tx.get_signers();
@@ -113,6 +126,15 @@ impl PreStxOp {
                 warn!("Invalid tx: output must be representable as a StacksAddress");
                 op_error::InvalidInput
             })?;
+
+        // check if we've reached PoX disable
+        if PoxConstants::has_pox_sunset(epoch_id) && block_height >= pox_sunset_ht {
+            debug!(
+                "PreStxOp broadcasted after sunset. Ignoring. txid={}",
+                tx.txid()
+            );
+            return Err(op_error::InvalidInput);
+        }
 
         Ok(PreStxOp {
             output: output,
@@ -197,23 +219,30 @@ impl StackStxOp {
 
     pub fn from_tx(
         block_header: &BurnchainBlockHeader,
+        epoch_id: StacksEpochId,
         tx: &BurnchainTransaction,
         sender: &StacksAddress,
+        pox_sunset_ht: u64,
     ) -> Result<StackStxOp, op_error> {
         StackStxOp::parse_from_tx(
             block_header.block_height,
             &block_header.block_hash,
+            epoch_id,
             tx,
             sender,
+            pox_sunset_ht,
         )
     }
 
     /// parse a StackStxOp
+    /// `pox_sunset_ht` is the height at which PoX *disables*
     pub fn parse_from_tx(
         block_height: u64,
         block_hash: &BurnchainHeaderHash,
+        epoch_id: StacksEpochId,
         tx: &BurnchainTransaction,
         sender: &StacksAddress,
+        pox_sunset_ht: u64,
     ) -> Result<StackStxOp, op_error> {
         // can't be too careful...
         let outputs = tx.get_recipients();
@@ -249,6 +278,15 @@ impl StackStxOp {
         // coerce a hash mode for this address if need be, since we'll need it when we feed this
         // address into the .pox contract
         let reward_addr = outputs[0].address.clone().coerce_hash_mode();
+
+        // check if we've reached PoX disable
+        if PoxConstants::has_pox_sunset(epoch_id) && block_height >= pox_sunset_ht {
+            debug!(
+                "StackStxOp broadcasted after sunset. Ignoring. txid={}",
+                tx.txid()
+            );
+            return Err(op_error::InvalidInput);
+        }
 
         Ok(StackStxOp {
             sender: sender.clone(),
@@ -328,6 +366,7 @@ mod tests {
     use crate::chainstate::stacks::address::PoxAddress;
     use crate::chainstate::stacks::address::StacksAddressExtensions;
     use crate::chainstate::stacks::StacksPublicKey;
+    use crate::core::StacksEpochId;
     use stacks_common::address::AddressHashMode;
     use stacks_common::deps_common::bitcoin::blockdata::transaction::Transaction;
     use stacks_common::deps_common::bitcoin::network::serialize::{deserialize, serialize_hex};
@@ -406,7 +445,87 @@ mod tests {
         let op = PreStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
+            StacksEpochId::Epoch2_05,
             &BurnchainTransaction::Bitcoin(tx.clone()),
+            16843023,
+        )
+        .unwrap();
+
+        assert_eq!(
+            &op.output,
+            &StacksAddress::from_bitcoin_address(&tx.outputs[0].address)
+        );
+    }
+
+    #[test]
+    fn test_parse_pre_stack_stx_sunset() {
+        let tx = BitcoinTransaction {
+            txid: Txid([0; 32]),
+            vtxindex: 0,
+            opcode: Opcodes::PreStx as u8,
+            data: vec![1; 80],
+            data_amt: 0,
+            inputs: vec![BitcoinTxInput {
+                keys: vec![],
+                num_required: 0,
+                in_type: BitcoinInputType::Standard,
+                tx_ref: (Txid([0; 32]), 0),
+            }],
+            outputs: vec![
+                BitcoinTxOutput {
+                    units: 10,
+                    address: BitcoinAddress {
+                        addrtype: BitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([1; 20]),
+                    },
+                },
+                BitcoinTxOutput {
+                    units: 10,
+                    address: BitcoinAddress {
+                        addrtype: BitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([2; 20]),
+                    },
+                },
+                BitcoinTxOutput {
+                    units: 30,
+                    address: BitcoinAddress {
+                        addrtype: BitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([0; 20]),
+                    },
+                },
+            ],
+        };
+
+        let sender = StacksAddress {
+            version: 0,
+            bytes: Hash160([0; 20]),
+        };
+
+        // pre-2.1 this fails
+        let op_err = PreStxOp::parse_from_tx(
+            16843022,
+            &BurnchainHeaderHash([0; 32]),
+            StacksEpochId::Epoch2_05,
+            &BurnchainTransaction::Bitcoin(tx.clone()),
+            16843022,
+        )
+        .unwrap_err();
+
+        if let op_error::InvalidInput = op_err {
+        } else {
+            panic!("Parsed post-sunset prestx");
+        }
+
+        // post-2.1 this succeeds
+        let op = PreStxOp::parse_from_tx(
+            16843022,
+            &BurnchainHeaderHash([0; 32]),
+            StacksEpochId::Epoch21,
+            &BurnchainTransaction::Bitcoin(tx.clone()),
+            16843022,
         )
         .unwrap();
 
@@ -465,8 +584,96 @@ mod tests {
         let op = StackStxOp::parse_from_tx(
             16843022,
             &BurnchainHeaderHash([0; 32]),
+            StacksEpochId::Epoch2_05,
             &BurnchainTransaction::Bitcoin(tx.clone()),
             &sender,
+            16843023,
+        )
+        .unwrap();
+
+        assert_eq!(&op.sender, &sender);
+        assert_eq!(
+            &op.reward_addr,
+            &PoxAddress::Standard(
+                StacksAddress::from_bitcoin_address(&tx.outputs[0].address),
+                Some(AddressHashMode::SerializeP2PKH)
+            )
+        );
+        assert_eq!(op.stacked_ustx, u128::from_be_bytes([1; 16]));
+        assert_eq!(op.num_cycles, 1);
+    }
+
+    #[test]
+    fn test_parse_stack_stx_sunset() {
+        let tx = BitcoinTransaction {
+            txid: Txid([0; 32]),
+            vtxindex: 0,
+            opcode: Opcodes::StackStx as u8,
+            data: vec![1; 80],
+            data_amt: 0,
+            inputs: vec![BitcoinTxInput {
+                keys: vec![],
+                num_required: 0,
+                in_type: BitcoinInputType::Standard,
+                tx_ref: (Txid([0; 32]), 0),
+            }],
+            outputs: vec![
+                BitcoinTxOutput {
+                    units: 10,
+                    address: BitcoinAddress {
+                        addrtype: BitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([1; 20]),
+                    },
+                },
+                BitcoinTxOutput {
+                    units: 10,
+                    address: BitcoinAddress {
+                        addrtype: BitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([2; 20]),
+                    },
+                },
+                BitcoinTxOutput {
+                    units: 30,
+                    address: BitcoinAddress {
+                        addrtype: BitcoinAddressType::PublicKeyHash,
+                        network_id: BitcoinNetworkType::Mainnet,
+                        bytes: Hash160([0; 20]),
+                    },
+                },
+            ],
+        };
+
+        let sender = StacksAddress {
+            version: 0,
+            bytes: Hash160([0; 20]),
+        };
+
+        // pre-2.1: this fails
+        let op_err = StackStxOp::parse_from_tx(
+            16843022,
+            &BurnchainHeaderHash([0; 32]),
+            StacksEpochId::Epoch2_05,
+            &BurnchainTransaction::Bitcoin(tx.clone()),
+            &sender,
+            16843022,
+        )
+        .unwrap_err();
+
+        if let op_error::InvalidInput = op_err {
+        } else {
+            panic!("Parsed post-sunset epoch 2.05");
+        }
+
+        // post-2.1: this succeeds
+        let op = StackStxOp::parse_from_tx(
+            16843022,
+            &BurnchainHeaderHash([0; 32]),
+            StacksEpochId::Epoch21,
+            &BurnchainTransaction::Bitcoin(tx.clone()),
+            &sender,
+            16843022,
         )
         .unwrap();
 

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1295,6 +1295,7 @@ mod test {
         };
 
         let mut block_commit = LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash: header.block_hash(),
             new_seed: VRFSeed::from_proof(&header.proof),
             parent_block_ptr: 0,

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -535,8 +535,8 @@ impl StacksChainState {
         };
         let threshold = threshold_precise + ceil_amount;
         info!(
-            "PoX participation threshold is {}, from {} + {} ({})",
-            threshold, threshold_precise, ceil_amount, scale_by,
+            "PoX participation threshold is {}, from {} + {} ({}), participation is {}",
+            threshold, threshold_precise, ceil_amount, scale_by, participation
         );
         (threshold, participation)
     }
@@ -853,7 +853,7 @@ pub mod test {
 
     #[test]
     fn get_reward_threshold_units() {
-        let test_pox_constants = PoxConstants::new(501, 1, 1, 1, 5, u32::max_value());
+        let test_pox_constants = PoxConstants::new(501, 1, 1, 1, 5, 5000, 10000, u32::max_value());
         // when the liquid amount = the threshold step,
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -180,8 +180,7 @@ pub fn check_stacking_state_invariants(
         .clone()
         .expect_u128();
     let pox_addr = stacking_state_entry.get("pox-addr").unwrap();
-    let pox_addr =
-        PoxAddress::try_from_pox_tuple(peer.config.burnchain.is_mainnet(), pox_addr).unwrap();
+    let pox_addr = PoxAddress::try_from_pox_tuple(false, pox_addr).unwrap();
 
     let reward_indexes: Vec<u128> = stacking_state_entry
         .get_owned("reward-set-indexes")
@@ -247,9 +246,7 @@ pub fn check_stacking_state_invariants(
             );
 
             let entry_pox_addr = entry_value.get_owned("pox-addr").unwrap();
-            let entry_pox_addr =
-                PoxAddress::try_from_pox_tuple(peer.config.burnchain.is_mainnet(), &entry_pox_addr)
-                    .unwrap();
+            let entry_pox_addr = PoxAddress::try_from_pox_tuple(false, &entry_pox_addr).unwrap();
 
             assert_eq!(
                 &entry_pox_addr, &pox_addr,

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -1633,7 +1633,7 @@ fn test_lock_period_invariant_extend_transition() {
 
     let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
         &burnchain,
-        "test_pox_extend_transition_pox_2",
+        "test_invariant_exten_transition",
         6002,
         Some(epochs.clone()),
         Some(&observer),

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -760,6 +760,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 // C'est la vie.
 
                 // initialize with a synthetic transaction
+                debug!("Instantiate .costs-2 contract");
                 let receipt = StacksChainState::process_transaction_payload(
                     tx_conn,
                     &costs_2_contract_tx,
@@ -782,6 +783,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
             // NOTE: we don't set self.epoch to Epoch2_05 here, even though we probably
             // should, because doing so risks a chain split.
 
+            debug!("Epoch 2.05 initialized");
             (old_cost_tracker, Ok(initialization_receipt))
         })
     }
@@ -877,6 +879,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 tx_conn.epoch = StacksEpochId::Epoch21;
 
                 // initialize with a synthetic transaction
+                debug!("Instantiate {} contract", &pox_2_contract_id);
                 let receipt = StacksChainState::process_transaction_payload(
                     tx_conn,
                     &pox_2_contract_tx,
@@ -917,6 +920,7 @@ impl<'a, 'b> ClarityBlockConnection<'a, 'b> {
                 );
             }
 
+            debug!("Epoch 2.1 initialized");
             (old_cost_tracker, Ok(initialization_receipt))
         })
     }

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3091,7 +3091,16 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u32::max_value());
+        burnchain.pox_constants = PoxConstants::new(
+            5,
+            3,
+            3,
+            25,
+            5,
+            u64::max_value(),
+            u64::max_value(),
+            u32::max_value(),
+        );
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -3109,7 +3118,16 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u32::max_value());
+        burnchain.pox_constants = PoxConstants::new(
+            5,
+            3,
+            3,
+            25,
+            5,
+            u64::max_value(),
+            u64::max_value(),
+            u32::max_value(),
+        );
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2431,7 +2431,16 @@ pub mod test {
                 .unwrap(),
             );
 
-            burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u32::max_value());
+            burnchain.pox_constants = PoxConstants::new(
+                5,
+                3,
+                3,
+                25,
+                5,
+                u64::max_value(),
+                u64::max_value(),
+                u32::max_value(),
+            );
 
             let mut spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -269,18 +269,17 @@ impl RPCPoxInfoData {
     ) -> Result<RPCPoxInfoData, net_error> {
         let mainnet = chainstate.mainnet;
         let chain_id = chainstate.chain_id;
-
-        let current_burn_height = chainstate
-            .with_read_only_clarity_tx(&sortdb.index_conn(), tip, |clarity_tx| {
-                clarity_tx.with_clarity_db_readonly(|clarity_db| {
-                    clarity_db.get_current_burnchain_block_height() as u64
-                })
-            })
-            .ok_or(net_error::NotFoundError)?;
+        let current_burn_height =
+            SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())?.block_height;
 
         let pox_contract_name = burnchain
             .pox_constants
             .active_pox_contract(current_burn_height);
+
+        debug!(
+            "Active PoX contract is '{}' (current_burn_height = {}, v1_unlock_height = {}",
+            &pox_contract_name, current_burn_height, burnchain.pox_constants.v1_unlock_height
+        );
 
         let contract_identifier = boot_code_id(pox_contract_name, mainnet);
         let function = "get-pox-info";
@@ -306,7 +305,7 @@ impl RPCPoxInfoData {
                 clarity_tx.with_readonly_clarity_env(
                     mainnet,
                     chain_id,
-                    ClarityVersion::Clarity1,
+                    ClarityVersion::Clarity2,
                     sender,
                     None,
                     cost_track,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -96,6 +96,7 @@ impl OngoingBlockCommit {
 
 #[derive(Clone)]
 struct LeaderBlockCommitFees {
+    sunset_fee: u64,
     fee_rate: u64,
     sortition_fee: u64,
     outputs_len: u64,
@@ -123,6 +124,12 @@ impl LeaderBlockCommitFees {
         payload: &LeaderBlockCommitOp,
         config: &Config,
     ) -> LeaderBlockCommitFees {
+        let sunset_fee = if payload.sunset_burn > 0 {
+            cmp::max(payload.sunset_burn, DUST_UTXO_LIMIT)
+        } else {
+            0
+        };
+
         let number_of_transfers = payload.commit_outs.len() as u64;
         let value_per_transfer = payload.burn_fee / number_of_transfers;
         let sortition_fee = value_per_transfer * number_of_transfers;
@@ -131,6 +138,7 @@ impl LeaderBlockCommitFees {
         let default_tx_size = config.burnchain.block_commit_tx_estimated_size;
 
         LeaderBlockCommitFees {
+            sunset_fee,
             fee_rate,
             sortition_fee,
             outputs_len: number_of_transfers,
@@ -154,11 +162,14 @@ impl LeaderBlockCommitFees {
     }
 
     pub fn estimated_amount_required(&self) -> u64 {
-        self.estimated_miner_fee() + self.rbf_fee() + self.sortition_fee
+        self.estimated_miner_fee() + self.rbf_fee() + self.sunset_fee + self.sortition_fee
     }
 
     pub fn total_spent(&self) -> u64 {
-        self.fee_rate * self.final_size + self.spent_in_attempts + self.sortition_fee
+        self.fee_rate * self.final_size
+            + self.spent_in_attempts
+            + self.sunset_fee
+            + self.sortition_fee
     }
 
     pub fn amount_per_output(&self) -> u64 {
@@ -166,7 +177,7 @@ impl LeaderBlockCommitFees {
     }
 
     pub fn total_spent_in_outputs(&self) -> u64 {
-        self.sortition_fee
+        self.sunset_fee + self.sortition_fee
     }
 
     pub fn min_tx_size(&self) -> u64 {
@@ -955,7 +966,7 @@ impl BitcoinRegtestController {
         };
 
         let consensus_output = TxOut {
-            value: 0,
+            value: estimated_fees.sunset_fee,
             script_pubkey: Builder::new()
                 .push_opcode(opcodes::All::OP_RETURN)
                 .push_slice(&op_bytes)

--- a/testnet/stacks-node/src/burnchains/mocknet_controller.rs
+++ b/testnet/stacks-node/src/burnchains/mocknet_controller.rs
@@ -184,6 +184,7 @@ impl BurnchainController for MocknetController {
                 }
                 BlockstackOperationType::LeaderBlockCommit(payload) => {
                     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                        sunset_burn: 0,
                         block_header_hash: payload.block_header_hash,
                         new_seed: payload.new_seed,
                         parent_block_ptr: payload.parent_block_ptr,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use std::{thread, thread::JoinHandle};
 
 use stacks::burnchains::BurnchainSigner;
+use stacks::burnchains::PoxConstants;
 use stacks::burnchains::{Burnchain, BurnchainParameters, Txid};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::{
@@ -414,6 +415,7 @@ fn inner_generate_block_commit_op(
     parent_winning_vtx: u16,
     vrf_seed: VRFSeed,
     commit_outs: Vec<PoxAddress>,
+    sunset_burn: u64,
     current_burn_height: u64,
 ) -> BlockstackOperationType {
     let (parent_block_ptr, parent_vtxindex) = (parent_burnchain_height, parent_winning_vtx);
@@ -421,6 +423,7 @@ fn inner_generate_block_commit_op(
     let burn_parent_modulus = (current_burn_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
 
     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+        sunset_burn,
         block_header_hash,
         burn_fee,
         input: (Txid([0; 32]), 0),
@@ -2167,9 +2170,26 @@ impl StacksNode {
             }
         };
 
-        let commit_outs = if !burnchain.is_in_prepare_phase(burn_block.block_height + 1) {
+        let epoch_id = SortitionDB::get_stacks_epoch(burn_db.conn(), burn_block.block_height + 1)
+            .expect("FATAL: unable to read sortition DB")
+            .expect("FATAL: no epoch defined for current block height")
+            .epoch_id;
+
+        let sunset_burn =
+            burnchain.expected_sunset_burn(burn_block.block_height + 1, burn_fee_cap, epoch_id);
+        let rest_commit = burn_fee_cap - sunset_burn;
+
+        let commit_outs = if !burnchain.is_in_prepare_phase(burn_block.block_height + 1)
+            && (!PoxConstants::has_pox_sunset(epoch_id)
+                || !burnchain
+                    .pox_constants
+                    .is_after_pox_sunset_end(burn_block.block_height + 1, epoch_id))
+        {
+            // not in prepare phase, and if we have a sunset, it's not yet completed
             RewardSetInfo::into_commit_outs(recipients, config.is_mainnet())
         } else {
+            // in prepare phase, or either there's no sunset at all in this epoch, or if there is,
+            // it has completed.
             vec![PoxAddress::standard_burn_address(config.is_mainnet())]
         };
 
@@ -2177,7 +2197,7 @@ impl StacksNode {
         let op = inner_generate_block_commit_op(
             keychain.get_burnchain_signer(),
             anchored_block.block_hash(),
-            burn_fee_cap,
+            rest_commit,
             &registered_key,
             parent_block_burn_height
                 .try_into()
@@ -2185,8 +2205,11 @@ impl StacksNode {
             parent_winning_vtxindex,
             VRFSeed::from_proof(&vrf_proof),
             commit_outs,
+            sunset_burn,
             burn_block.block_height,
         );
+
+        debug!("Leader block commit: {:?}", &op);
 
         let cur_burn_chain_tip = SortitionDB::get_canonical_burn_chain_tip(burn_db.conn())
             .expect("FATAL: failed to query sortition DB for canonical burn chain tip");

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -1010,16 +1010,20 @@ impl Node {
         self.config
             .update_pox_constants(&mut burnchain.pox_constants);
 
-        let commit_outs =
-            if !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1) {
-                RewardSetInfo::into_commit_outs(None, self.config.is_mainnet())
-            } else {
-                vec![PoxAddress::standard_burn_address(self.config.is_mainnet())]
-            };
+        let commit_outs = if burnchain_tip.block_snapshot.block_height + 1
+            < burnchain.pox_constants.sunset_end
+            && !burnchain.is_in_prepare_phase(burnchain_tip.block_snapshot.block_height + 1)
+        {
+            RewardSetInfo::into_commit_outs(None, self.config.is_mainnet())
+        } else {
+            vec![PoxAddress::standard_burn_address(self.config.is_mainnet())]
+        };
+
         let burn_parent_modulus =
             (burnchain_tip.block_snapshot.block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
 
         BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+            sunset_burn: 0,
             block_header_hash,
             burn_fee,
             input: (Txid([0; 32]), 0),

--- a/testnet/stacks-node/src/tests/epoch_205.rs
+++ b/testnet/stacks-node/src/tests/epoch_205.rs
@@ -589,8 +589,16 @@ fn transition_empty_blocks() {
 
         if tip_info.burn_block_height + 1 >= epoch_2_05 {
             let burn_fee_cap = 100000000; // 1 BTC
+            let sunset_burn = burnchain.expected_sunset_burn(
+                tip_info.burn_block_height + 1,
+                burn_fee_cap,
+                StacksEpochId::Epoch2_05,
+            );
+            let rest_commit = burn_fee_cap - sunset_burn;
 
-            let commit_outs = if !burnchain.is_in_prepare_phase(tip_info.burn_block_height + 1) {
+            let commit_outs = if tip_info.burn_block_height + 1 < burnchain.pox_constants.sunset_end
+                && !burnchain.is_in_prepare_phase(tip_info.burn_block_height + 1)
+            {
                 vec![
                     PoxAddress::standard_burn_address(conf.is_mainnet()),
                     PoxAddress::standard_burn_address(conf.is_mainnet()),
@@ -603,8 +611,9 @@ fn transition_empty_blocks() {
             let burn_parent_modulus =
                 (tip_info.burn_block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
             let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                sunset_burn,
                 block_header_hash: BlockHeaderHash([0xff; 32]),
-                burn_fee: burn_fee_cap,
+                burn_fee: rest_commit,
                 input: (Txid([0; 32]), 0),
                 apparent_sender: keychain.get_burnchain_signer(),
                 key_block_ptr,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -53,7 +53,6 @@ use stacks::core::BURNCHAIN_TX_SEARCH_WINDOW;
 
 use crate::burnchains::bitcoin_regtest_controller::UTXO;
 use crate::operations::BurnchainOpSigner;
-use crate::tests::neon_integrations::get_balance;
 use crate::Keychain;
 
 fn advance_to_2_1(
@@ -101,6 +100,8 @@ fn advance_to_2_1(
         4 * prepare_phase_len / 5,
         5,
         15,
+        u64::max_value() - 2,
+        u64::max_value() - 1,
         u32::max_value(),
     ));
     burnchain_config.pox_constants = pox_constants.clone();
@@ -609,6 +610,8 @@ fn transition_fixes_bitcoin_rigidity() {
         4 * prepare_phase_len / 5,
         5,
         15,
+        (16 * reward_cycle_len - 1).into(),
+        (17 * reward_cycle_len).into(),
         u32::max_value(),
     );
     burnchain_config.pox_constants = pox_constants.clone();
@@ -1014,6 +1017,8 @@ fn transition_adds_get_pox_addr_recipients() {
         4 * prepare_phase_len / 5,
         1,
         1,
+        u64::max_value() - 2,
+        u64::max_value() - 1,
         v1_unlock_height,
     );
 
@@ -1244,4 +1249,302 @@ fn transition_adds_get_pox_addr_recipients() {
 
     eprintln!("found pox addrs: {:?}", &found_pox_addrs);
     assert_eq!(found_pox_addrs.len(), 4);
+}
+
+/// Verify that a sunset-in-progress will be halted by the epoch 2.1 transition
+#[test]
+#[ignore]
+fn transition_removes_pox_sunset() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let spender_sk = StacksPrivateKey::new();
+    let spender_addr: PrincipalData = to_addr(&spender_sk).into();
+    let first_bal = 6_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
+
+    let pox_pubkey = Secp256k1PublicKey::from_hex(
+        "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
+    )
+    .unwrap();
+    let pox_pubkey_hash = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    test_observer::spawn();
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    conf.initial_balances.push(InitialBalance {
+        address: spender_addr.clone(),
+        amount: first_bal,
+    });
+
+    // reward cycle length = 15, so 10 reward cycle slots + 5 prepare-phase burns
+    let first_sortition_height = 201;
+    let reward_cycle_len = 15;
+    let prepare_phase_len = 5;
+    let sunset_start_rc = 16;
+    let sunset_end_rc = 20;
+    let epoch_21_rc = 18;
+
+    let epoch_21 = epoch_21_rc * reward_cycle_len + 1;
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = 1;
+    epochs[2].start_height = 1;
+    epochs[2].end_height = epoch_21;
+    epochs[3].start_height = epoch_21;
+
+    conf.burnchain.epochs = Some(epochs);
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let pox_constants = PoxConstants::new(
+        reward_cycle_len as u32,
+        prepare_phase_len,
+        4 * prepare_phase_len / 5,
+        5,
+        15,
+        (sunset_start_rc * reward_cycle_len - 1).into(),
+        (sunset_end_rc * reward_cycle_len).into(),
+        (epoch_21 as u32) + 1,
+    );
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(first_sortition_height);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+    let channel = run_loop.get_coordinator_channel().unwrap();
+    let thread_burnchain = burnchain_config.clone();
+
+    thread::spawn(move || run_loop.start(Some(thread_burnchain), 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let sort_height = channel.get_sortitions_processed();
+
+    // let's query the miner's account nonce:
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.balance, 0);
+    assert_eq!(account.nonce, 1);
+
+    // and our potential spenders:
+    let account = get_account(&http_origin, &spender_addr);
+    assert_eq!(account.balance, first_bal as u128);
+    assert_eq!(account.nonce, 0);
+
+    let pox_info = get_pox_info(&http_origin);
+
+    assert_eq!(
+        &pox_info.contract_id,
+        &format!("ST000000000000000000002AMW42H.pox")
+    );
+    assert_eq!(pox_info.current_cycle.is_pox_active, false);
+    assert_eq!(pox_info.next_cycle.stacked_ustx, 0);
+
+    let tx = make_contract_call(
+        &spender_sk,
+        0,
+        260,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox",
+        "stack-stx",
+        &[
+            Value::UInt(first_bal as u128 - 260 * 3),
+            execute(
+                &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash),
+                ClarityVersion::Clarity1,
+            )
+            .unwrap()
+            .unwrap(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(12),
+        ],
+    );
+
+    // okay, let's push that stacking transaction!
+    submit_tx(&http_origin, &tx);
+
+    let mut sort_height = channel.get_sortitions_processed();
+    eprintln!("Sort height pox-1: {}", sort_height);
+
+    // advance to next reward cycle
+    for _i in 0..(reward_cycle_len * 2 + 2) {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height pox-1: {} <= {}", sort_height, epoch_21);
+    }
+
+    // pox must activate
+    let pox_info = get_pox_info(&http_origin);
+    eprintln!("pox_info in pox-1 = {:?}", &pox_info);
+    assert_eq!(pox_info.current_cycle.is_pox_active, true);
+    assert_eq!(
+        &pox_info.contract_id,
+        &format!("ST000000000000000000002AMW42H.pox")
+    );
+
+    // advance to 2.1
+    while sort_height <= epoch_21 + 1 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height pox-1: {} <= {}", sort_height, epoch_21);
+    }
+
+    let pox_info = get_pox_info(&http_origin);
+
+    // pox is still "active" despite unlock, because there's enough participation, and also even
+    // though the v1 blocok height has passed, the pox-2 contract won't be managing reward sets
+    // until the next reward cycle
+    eprintln!("pox_info in pox-2 = {:?}", &pox_info);
+    assert_eq!(pox_info.current_cycle.is_pox_active, true);
+    assert_eq!(
+        &pox_info.contract_id,
+        &format!("ST000000000000000000002AMW42H.pox")
+    );
+
+    // re-stack
+    let tx = make_contract_call(
+        &spender_sk,
+        1,
+        260 * 2,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox-2",
+        "stack-stx",
+        &[
+            Value::UInt(first_bal as u128 - 260 * 3),
+            execute(
+                &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash),
+                ClarityVersion::Clarity2,
+            )
+            .unwrap()
+            .unwrap(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(12),
+        ],
+    );
+
+    // okay, let's push that stacking transaction!
+    submit_tx(&http_origin, &tx);
+
+    eprintln!("Try and confirm pox-2 stack-stx");
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    sort_height = channel.get_sortitions_processed();
+    eprintln!(
+        "Sort height pox-1 to pox-2 with stack-stx to pox-2: {}",
+        sort_height
+    );
+
+    let pox_info = get_pox_info(&http_origin);
+    assert_eq!(pox_info.current_cycle.is_pox_active, true);
+
+    // get pox back online
+    while sort_height <= epoch_21 + reward_cycle_len {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height pox-2: {}", sort_height);
+    }
+
+    let pox_info = get_pox_info(&http_origin);
+    eprintln!("pox_info = {:?}", &pox_info);
+    assert_eq!(pox_info.current_cycle.is_pox_active, true);
+
+    // first full reward cycle with pox-2
+    assert_eq!(
+        &pox_info.contract_id,
+        &format!("ST000000000000000000002AMW42H.pox-2")
+    );
+
+    let burn_blocks = test_observer::get_burn_blocks();
+    let mut pox_out_opt = None;
+    for (i, block) in burn_blocks.into_iter().enumerate() {
+        let recipients: Vec<(String, u64)> = block
+            .get("reward_recipients")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| {
+                let recipient: String = value
+                    .get("recipient")
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+                let amount = value.get("amt").unwrap().as_u64().unwrap();
+                (recipient, amount)
+            })
+            .collect();
+
+        if (i as u64) < (sunset_start_rc * reward_cycle_len) {
+            // before sunset
+            if recipients.len() >= 1 {
+                for (_, amt) in recipients.into_iter() {
+                    pox_out_opt = if let Some(pox_out) = pox_out_opt.clone() {
+                        Some(std::cmp::max(amt, pox_out))
+                    } else {
+                        Some(amt)
+                    };
+                }
+            }
+        } else if (i as u64) >= (sunset_start_rc * reward_cycle_len) && (i as u64) + 1 < epoch_21 {
+            // some sunset burn happened
+            let pox_out = pox_out_opt.clone().unwrap();
+            if recipients.len() >= 1 {
+                for (_, amt) in recipients.into_iter() {
+                    assert!(amt < pox_out);
+                }
+            }
+        } else if (i as u64) + 1 >= epoch_21 {
+            // no sunset burn happened
+            let pox_out = pox_out_opt.clone().unwrap();
+            if recipients.len() >= 1 {
+                for (_, amt) in recipients.into_iter() {
+                    // NOTE: odd number of reward cycles
+                    if !burnchain_config.is_in_prepare_phase((i + 2) as u64) {
+                        assert_eq!(amt, pox_out);
+                    }
+                }
+            }
+        }
+    }
+
+    test_observer::clear();
+    channel.stop_chains_coordinator();
 }

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -1429,7 +1429,7 @@ fn transition_removes_pox_sunset() {
     let pox_info = get_pox_info(&http_origin);
 
     // pox is still "active" despite unlock, because there's enough participation, and also even
-    // though the v1 blocok height has passed, the pox-2 contract won't be managing reward sets
+    // though the v1 block height has passed, the pox-2 contract won't be managing reward sets
     // until the next reward cycle
     eprintln!("pox_info in pox-2 = {:?}", &pox_info);
     assert_eq!(pox_info.current_cycle.is_pox_active, true);

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -58,9 +58,6 @@ const CALL_READ_CONTRACT: &'static str = "
     (ok (contract-call? .other f2 u5)))
 ";
 
-// TODO(gregorycoppola) Add "burn-block-info" section to this test, once a way to configure the
-// Mocknet default Stacks epoch has been decided. Verify that we get (none) for any block height
-// prior to the first burnchain block height.
 const GET_INFO_CONTRACT: &'static str = "
         (define-map block-data
           { height: uint }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -759,7 +759,7 @@ pub fn get_account<F: std::fmt::Display>(http_origin: &str, account: &F) -> Acco
     }
 }
 
-fn get_pox_info(http_origin: &str) -> RPCPoxInfoData {
+pub fn get_pox_info(http_origin: &str) -> RPCPoxInfoData {
     let client = reqwest::blocking::Client::new();
     let path = format!("{}/v2/pox", http_origin);
     client
@@ -4925,6 +4925,8 @@ fn pox_integration_test() {
         4 * prepare_phase_len / 5,
         5,
         15,
+        (16 * reward_cycle_len - 1).into(),
+        (17 * reward_cycle_len).into(),
         u32::max_value(),
     );
     burnchain_config.pox_constants = pox_constants.clone();
@@ -5016,7 +5018,7 @@ fn pox_integration_test() {
             Value::UInt(stacked_bal),
             execute(
                 &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash),
-                ClarityVersion::Clarity2,
+                ClarityVersion::Clarity1,
             )
             .unwrap()
             .unwrap(),
@@ -5129,7 +5131,7 @@ fn pox_integration_test() {
             Value::UInt(stacked_bal / 2),
             execute(
                 &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_2_pubkey_hash),
-                ClarityVersion::Clarity2,
+                ClarityVersion::Clarity1,
             )
             .unwrap()
             .unwrap(),
@@ -5152,7 +5154,7 @@ fn pox_integration_test() {
             Value::UInt(stacked_bal / 2),
             execute(
                 &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_2_pubkey_hash),
-                ClarityVersion::Clarity2,
+                ClarityVersion::Clarity1,
             )
             .unwrap()
             .unwrap(),
@@ -5217,6 +5219,7 @@ fn pox_integration_test() {
     // let's test the reward information in the observer
     test_observer::clear();
 
+    // before sunset
     // mine until the end of the next reward cycle,
     //   the participation threshold now should be met.
     while sort_height < ((16 * pox_constants.reward_cycle_length) - 1).into() {
@@ -5304,6 +5307,53 @@ fn pox_integration_test() {
 
     eprintln!("Stacks tip is now {}", tip_info.stacks_tip_height);
     assert_eq!(tip_info.stacks_tip_height, 36);
+
+    // now let's mine into the sunset
+    while sort_height < ((17 * pox_constants.reward_cycle_length) - 1).into() {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height: {}", sort_height);
+    }
+
+    // get the canonical chain tip
+    let tip_info = get_chain_info(&conf);
+
+    eprintln!("Stacks tip is now {}", tip_info.stacks_tip_height);
+    assert_eq!(tip_info.stacks_tip_height, 51);
+
+    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
+
+    // should receive more rewards during this cycle...
+    eprintln!("Got UTXOs: {}", utxos.len());
+    assert_eq!(
+        utxos.len(),
+        14,
+        "Should have received more outputs during the sunsetting PoX reward cycle"
+    );
+
+    // and after sunset
+    while sort_height < ((18 * pox_constants.reward_cycle_length) - 1).into() {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        sort_height = channel.get_sortitions_processed();
+        eprintln!("Sort height: {}", sort_height);
+    }
+
+    let utxos = btc_regtest_controller.get_all_utxos(&pox_2_pubkey);
+
+    // should *not* receive more rewards during the after sunset cycle...
+    eprintln!("Got UTXOs: {}", utxos.len());
+    assert_eq!(
+        utxos.len(),
+        14,
+        "Should have received no more outputs after sunset PoX reward cycle"
+    );
+
+    // should have progressed the chain, though!
+    // get the canonical chain tip
+    let tip_info = get_chain_info(&conf);
+
+    eprintln!("Stacks tip is now {}", tip_info.stacks_tip_height);
+    assert_eq!(tip_info.stacks_tip_height, 66);
 
     test_observer::clear();
     channel.stop_chains_coordinator();


### PR DESCRIPTION
This PR addresses #3343 by restoring the PoX sunset burn calculation, and gating its applicability based on the epoch.  The gating is confined to methods in `PoxConstants`; code that needs to verify whether or not a sunset is active uses these methods instead of directly reasoning about the current system epoch and block height (this "confines" the gates to one place).

In doing so, it's _possible_ that this PR also fixes #3281 by allowing calls to read-only functions in `.pox` when `.pox-2` is active.  The VM's special case handler had been too strict about this earlier.