### PR TITLE
feat/native-segwit-test

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -6,6 +6,8 @@ ENV BITCOIND_TEST 1
 RUN cargo build && \
     cargo test -- --test-threads 1 --ignored "$test_name"
 
+RUN cat bitcoind_debug.log
+
 RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o /lcov.info
 
 FROM scratch AS export-stage

--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -6,8 +6,6 @@ ENV BITCOIND_TEST 1
 RUN cargo build && \
     cargo test -- --test-threads 1 --ignored "$test_name"
 
-RUN cat bitcoind_debug.log
-
 RUN grcov . --binary-path ../../target/debug/ -s ../.. -t lcov --branch --ignore-not-existing --ignore "/*" -o /lcov.info
 
 FROM scratch AS export-stage

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1818,6 +1818,13 @@ impl BurnchainController for BitcoinRegtestController {
             if self.config.miner.segwit {
                 local_mining_pubkey.set_compressed(true);
             }
+
+            info!("Creating wallet if it does not exist");
+            match self.create_wallet_if_dne() {
+                Err(e) => warn!("Error when creating wallet: {:?}", e),
+                _ => {}
+            }
+
             test_debug!("Import public key '{}'", &local_mining_pubkey.to_hex());
 
             let _result = BitcoinRPCRequest::import_public_key(&self.config, &local_mining_pubkey);
@@ -1839,11 +1846,6 @@ impl BurnchainController for BitcoinRegtestController {
                     error!("Bitcoin RPC failure: error generating block {:?}", e);
                     panic!();
                 }
-            }
-            info!("Creating wallet if it does not exist");
-            match self.create_wallet_if_dne() {
-                Err(e) => warn!("Error when creating wallet: {:?}", e),
-                _ => {}
             }
         }
     }

--- a/testnet/stacks-node/src/keychain.rs
+++ b/testnet/stacks-node/src/keychain.rs
@@ -226,8 +226,5 @@ fn rotate_vrf_keypair_fixed_value_test() {
     let mut keychain = Keychain::default(vec![0; 32]);
     let new_vrf_pubkey = keychain.rotate_vrf_keypair(201);
     // saved from bitcoind_integration_test
-    assert_eq!(
-        "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6",
-        new_vrf_pubkey.to_hex()
-    );
+    assert_eq!("63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6", new_vrf_pubkey.to_hex());
 }

--- a/testnet/stacks-node/src/keychain.rs
+++ b/testnet/stacks-node/src/keychain.rs
@@ -226,5 +226,8 @@ fn rotate_vrf_keypair_fixed_value_test() {
     let mut keychain = Keychain::default(vec![0; 32]);
     let new_vrf_pubkey = keychain.rotate_vrf_keypair(201);
     // saved from bitcoind_integration_test
-    assert_eq!("63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6", new_vrf_pubkey.to_hex());
+    assert_eq!(
+        "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6",
+        new_vrf_pubkey.to_hex()
+    );
 }

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -179,7 +179,7 @@ fn bitcoind_integration(segwit_flag: bool) {
     run_loop
         .callbacks
         .on_burn_chain_initialized(|burnchain_controller| {
-            burnchain_controller.bootstrap_chain(201);
+            burnchain_controller.bootstrap_chain(2001);
         });
 
     // In this serie of tests, the callback is fired post-burnchain-sync, pre-stacks-sync

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -76,8 +76,7 @@ impl BitcoinCoreController {
         command
             .stdout(Stdio::piped())
             .arg("-regtest")
-            .arg("-nodebug")
-            .arg("-nodebuglogfile")
+            .arg("-debuglogfile=bitcoind_debug.log")
             .arg("-rest")
             .arg("-txindex=1")
             .arg("-server=1")

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -133,6 +133,7 @@ fn bitcoind_integration_test() {
     conf.miner.min_tx_fee = 0;
     conf.miner.first_attempt_time_ms = i64::max_value() as u64;
     conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
+    conf.miner.segwit = true;
 
     conf.initial_balances.push(InitialBalance {
         address: to_addr(

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -39,40 +39,7 @@ impl BitcoinCoreController {
     pub fn start_bitcoind(&mut self) -> BitcoinResult<()> {
         std::fs::create_dir_all(&self.config.get_burnchain_path_str()).unwrap();
 
-        let mut command = match env::var("BITCOIND_DOCKER") == Ok("1".into()) {
-            true => {
-                eprintln!("using docker for bitcoind");
-                let mut command = Command::new("docker");
-                command
-                    .arg("run")
-                    .arg("--rm")
-                    .arg(&format!(
-                        "--publish={}:18444",
-                        self.config.burnchain.peer_port
-                    ))
-                    .arg(&format!(
-                        "--publish={}:18443",
-                        self.config.burnchain.rpc_port
-                    ))
-                    .arg("ruimarinho/bitcoin-core:22")
-                    .arg("-rpcallowip=172.17.0.0/16")
-                    .arg("-rpcbind=0.0.0.0");
-                command
-            }
-            false => {
-                let mut command = Command::new("bitcoind");
-                command
-                    .arg("-rpcbind=127.0.0.1")
-                    .arg(&format!("-port={}", self.config.burnchain.peer_port))
-                    .arg(&format!(
-                        "-datadir={}",
-                        self.config.get_burnchain_path_str()
-                    ))
-                    .arg(&format!("-rpcport={}", self.config.burnchain.rpc_port));
-                command
-            }
-        };
-
+        let mut command = Command::new("bitcoind");
         command
             .stdout(Stdio::piped())
             .arg("-regtest")
@@ -81,7 +48,14 @@ impl BitcoinCoreController {
             .arg("-rest")
             .arg("-txindex=1")
             .arg("-server=1")
-            .arg("-listenonion=0");
+            .arg("-listenonion=0")
+            .arg("-rpcbind=127.0.0.1")
+            .arg(&format!("-port={}", self.config.burnchain.peer_port))
+            .arg(&format!(
+                "-datadir={}",
+                self.config.get_burnchain_path_str()
+            ))
+            .arg(&format!("-rpcport={}", self.config.burnchain.rpc_port));
 
         match (
             &self.config.burnchain.username,

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -76,7 +76,8 @@ impl BitcoinCoreController {
         command
             .stdout(Stdio::piped())
             .arg("-regtest")
-            .arg("-debuglogfile=bitcoind_debug.log")
+            .arg("-nodebug")
+            .arg("-nodebuglogfile")
             .arg("-rest")
             .arg("-txindex=1")
             .arg("-server=1")

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -183,145 +183,192 @@ fn bitcoind_integration(segwit_flag: bool) {
         });
 
     // In this serie of tests, the callback is fired post-burnchain-sync, pre-stacks-sync
-    run_loop.callbacks.on_new_burn_chain_state(|round, burnchain_tip, chain_tip| {
-        let block = &burnchain_tip.block_snapshot;
-        let expected_total_burn = BITCOIND_INT_TEST_COMMITS * (round as u64 + 1);
-        assert_eq!(block.total_burn, expected_total_burn);
-        assert_eq!(block.sortition, true);
-        assert_eq!(block.num_sortitions, round as u64 + 1);
-        assert_eq!(block.block_height, round as u64 + 2003);
-        // let leader_key = "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6";
-        let leader_key = "eb5b00d8ba6d3e40334364721014ead390dc995e9d00d17d8fd8ee544afd6e58"; // TODO: validate this value
+    run_loop
+        .callbacks
+        .on_new_burn_chain_state(|round, burnchain_tip, chain_tip| {
+            let block = &burnchain_tip.block_snapshot;
+            let expected_total_burn = BITCOIND_INT_TEST_COMMITS * (round as u64 + 1);
+            assert_eq!(block.total_burn, expected_total_burn);
+            assert_eq!(block.sortition, true);
+            assert_eq!(block.num_sortitions, round as u64 + 1);
+            assert_eq!(block.block_height, round as u64 + 2003);
+            // let leader_key = "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6";
+            let leader_key = "eb5b00d8ba6d3e40334364721014ead390dc995e9d00d17d8fd8ee544afd6e58"; // TODO: validate this value
 
-        match round {
-            0 => {
-                let state_transition = &burnchain_tip.state_transition;
-                assert!(state_transition.accepted_ops.len() == 1);
-                assert!(state_transition.consumed_leader_keys.len() == 1);
+            match round {
+                0 => {
+                    let state_transition = &burnchain_tip.state_transition;
+                    assert!(state_transition.accepted_ops.len() == 1);
+                    assert!(state_transition.consumed_leader_keys.len() == 1);
 
-                for op in &state_transition.accepted_ops {
-                    match op {
-                        LeaderKeyRegister(_op) => {
-                            unreachable!();
-                        },
-                        LeaderBlockCommit(op) => {
-                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
-                            assert!(op.parent_block_ptr == 0);
-                            assert!(op.parent_vtxindex == 0);
-                            assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                    for op in &state_transition.accepted_ops {
+                        match op {
+                            LeaderKeyRegister(_op) => {
+                                unreachable!();
+                            }
+                            LeaderBlockCommit(op) => {
+                                assert_eq!(
+                                    burnchain_tip.state_transition.consumed_leader_keys[0]
+                                        .public_key
+                                        .to_hex(),
+                                    leader_key
+                                );
+                                assert!(op.parent_block_ptr == 0);
+                                assert!(op.parent_vtxindex == 0);
+                                assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                            }
+                            _ => assert!(false),
                         }
-                        _ => assert!(false)
                     }
                 }
-            },
-            1 => {
-                let state_transition = &burnchain_tip.state_transition;
-                assert!(state_transition.accepted_ops.len() == 1);
-                assert!(state_transition.consumed_leader_keys.len() == 1);
+                1 => {
+                    let state_transition = &burnchain_tip.state_transition;
+                    assert!(state_transition.accepted_ops.len() == 1);
+                    assert!(state_transition.consumed_leader_keys.len() == 1);
 
-                for op in &state_transition.accepted_ops {
-                    match op {
-                        LeaderKeyRegister(_op) => {
-                            unreachable!();
-                        },
-                        LeaderBlockCommit(op) => {
-                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
-                            assert_eq!(op.parent_block_ptr, 2003);
-                            assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                    for op in &state_transition.accepted_ops {
+                        match op {
+                            LeaderKeyRegister(_op) => {
+                                unreachable!();
+                            }
+                            LeaderBlockCommit(op) => {
+                                assert_eq!(
+                                    burnchain_tip.state_transition.consumed_leader_keys[0]
+                                        .public_key
+                                        .to_hex(),
+                                    leader_key
+                                );
+                                assert_eq!(op.parent_block_ptr, 2003);
+                                assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                            }
+                            _ => assert!(false),
                         }
-                        _ => assert!(false)
                     }
+
+                    assert!(
+                        burnchain_tip.block_snapshot.parent_burn_header_hash
+                            == chain_tip.metadata.burn_header_hash
+                    );
                 }
+                2 => {
+                    let state_transition = &burnchain_tip.state_transition;
+                    assert!(state_transition.accepted_ops.len() == 1);
+                    assert!(state_transition.consumed_leader_keys.len() == 1);
 
-                assert!(burnchain_tip.block_snapshot.parent_burn_header_hash == chain_tip.metadata.burn_header_hash);
-            },
-            2 => {
-                let state_transition = &burnchain_tip.state_transition;
-                assert!(state_transition.accepted_ops.len() == 1);
-                assert!(state_transition.consumed_leader_keys.len() == 1);
-
-                for op in &state_transition.accepted_ops {
-                    match op {
-                        LeaderKeyRegister(_op) => {
-                            unreachable!();
-                        },
-                        LeaderBlockCommit(op) => {
-                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
-                            assert_eq!(op.parent_block_ptr, 2004);
-                            assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                    for op in &state_transition.accepted_ops {
+                        match op {
+                            LeaderKeyRegister(_op) => {
+                                unreachable!();
+                            }
+                            LeaderBlockCommit(op) => {
+                                assert_eq!(
+                                    burnchain_tip.state_transition.consumed_leader_keys[0]
+                                        .public_key
+                                        .to_hex(),
+                                    leader_key
+                                );
+                                assert_eq!(op.parent_block_ptr, 2004);
+                                assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                            }
+                            _ => assert!(false),
                         }
-                        _ => assert!(false)
                     }
+
+                    assert!(
+                        burnchain_tip.block_snapshot.parent_burn_header_hash
+                            == chain_tip.metadata.burn_header_hash
+                    );
                 }
+                3 => {
+                    let state_transition = &burnchain_tip.state_transition;
+                    assert!(state_transition.accepted_ops.len() == 1);
+                    assert!(state_transition.consumed_leader_keys.len() == 1);
 
-                assert!(burnchain_tip.block_snapshot.parent_burn_header_hash == chain_tip.metadata.burn_header_hash);
-            },
-            3 => {
-                let state_transition = &burnchain_tip.state_transition;
-                assert!(state_transition.accepted_ops.len() == 1);
-                assert!(state_transition.consumed_leader_keys.len() == 1);
-
-                for op in &state_transition.accepted_ops {
-                    match op {
-                        LeaderKeyRegister(_op) => {
-                            unreachable!();
-                        },
-                        LeaderBlockCommit(op) => {
-                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
-                            assert_eq!(op.parent_block_ptr, 2005);
-                            assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                    for op in &state_transition.accepted_ops {
+                        match op {
+                            LeaderKeyRegister(_op) => {
+                                unreachable!();
+                            }
+                            LeaderBlockCommit(op) => {
+                                assert_eq!(
+                                    burnchain_tip.state_transition.consumed_leader_keys[0]
+                                        .public_key
+                                        .to_hex(),
+                                    leader_key
+                                );
+                                assert_eq!(op.parent_block_ptr, 2005);
+                                assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                            }
+                            _ => assert!(false),
                         }
-                        _ => assert!(false)
                     }
+
+                    assert!(
+                        burnchain_tip.block_snapshot.parent_burn_header_hash
+                            == chain_tip.metadata.burn_header_hash
+                    );
                 }
+                4 => {
+                    let state_transition = &burnchain_tip.state_transition;
+                    assert!(state_transition.accepted_ops.len() == 1);
+                    assert!(state_transition.consumed_leader_keys.len() == 1);
 
-                assert!(burnchain_tip.block_snapshot.parent_burn_header_hash == chain_tip.metadata.burn_header_hash);
-            },
-            4 => {
-                let state_transition = &burnchain_tip.state_transition;
-                assert!(state_transition.accepted_ops.len() == 1);
-                assert!(state_transition.consumed_leader_keys.len() == 1);
-
-                for op in &state_transition.accepted_ops {
-                    match op {
-                        LeaderKeyRegister(_op) => {
-                            unreachable!();
-                        },
-                        LeaderBlockCommit(op) => {
-                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
-                            assert_eq!(op.parent_block_ptr, 2006);
-                            assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                    for op in &state_transition.accepted_ops {
+                        match op {
+                            LeaderKeyRegister(_op) => {
+                                unreachable!();
+                            }
+                            LeaderBlockCommit(op) => {
+                                assert_eq!(
+                                    burnchain_tip.state_transition.consumed_leader_keys[0]
+                                        .public_key
+                                        .to_hex(),
+                                    leader_key
+                                );
+                                assert_eq!(op.parent_block_ptr, 2006);
+                                assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                            }
+                            _ => assert!(false),
                         }
-                        _ => assert!(false)
                     }
+
+                    assert!(
+                        burnchain_tip.block_snapshot.parent_burn_header_hash
+                            == chain_tip.metadata.burn_header_hash
+                    );
                 }
+                5 => {
+                    let state_transition = &burnchain_tip.state_transition;
+                    assert!(state_transition.accepted_ops.len() == 1);
+                    assert!(state_transition.consumed_leader_keys.len() == 1);
 
-                assert!(burnchain_tip.block_snapshot.parent_burn_header_hash == chain_tip.metadata.burn_header_hash);
-            },
-            5 => {
-                let state_transition = &burnchain_tip.state_transition;
-                assert!(state_transition.accepted_ops.len() == 1);
-                assert!(state_transition.consumed_leader_keys.len() == 1);
-
-                for op in &state_transition.accepted_ops {
-                    match op {
-                        LeaderKeyRegister(_op) => {
-                            unreachable!();
-                        },
-                        LeaderBlockCommit(op) => {
-                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
-                            assert_eq!(op.parent_block_ptr, 2007);
-                            assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                    for op in &state_transition.accepted_ops {
+                        match op {
+                            LeaderKeyRegister(_op) => {
+                                unreachable!();
+                            }
+                            LeaderBlockCommit(op) => {
+                                assert_eq!(
+                                    burnchain_tip.state_transition.consumed_leader_keys[0]
+                                        .public_key
+                                        .to_hex(),
+                                    leader_key
+                                );
+                                assert_eq!(op.parent_block_ptr, 2007);
+                                assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
+                            }
+                            _ => assert!(false),
                         }
-                        _ => assert!(false)
                     }
-                }
 
-                assert!(burnchain_tip.block_snapshot.parent_burn_header_hash == chain_tip.metadata.burn_header_hash);
-            },
-            _ => {}
-        }
-    });
+                    assert!(
+                        burnchain_tip.block_snapshot.parent_burn_header_hash
+                            == chain_tip.metadata.burn_header_hash
+                    );
+                }
+                _ => {}
+            }
+        });
 
     // Use tenure's hook for submitting transactions
     run_loop.callbacks.on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -192,8 +192,7 @@ fn bitcoind_integration(segwit_flag: bool) {
             assert_eq!(block.sortition, true);
             assert_eq!(block.num_sortitions, round as u64 + 1);
             assert_eq!(block.block_height, round as u64 + 2003);
-            // let leader_key = "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6";
-            let leader_key = "eb5b00d8ba6d3e40334364721014ead390dc995e9d00d17d8fd8ee544afd6e58"; // TODO: validate this value
+            let leader_key = "eb5b00d8ba6d3e40334364721014ead390dc995e9d00d17d8fd8ee544afd6e58";
 
             match round {
                 0 => {

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -189,7 +189,10 @@ fn bitcoind_integration(segwit_flag: bool) {
         assert_eq!(block.total_burn, expected_total_burn);
         assert_eq!(block.sortition, true);
         assert_eq!(block.num_sortitions, round as u64 + 1);
-        assert_eq!(block.block_height, round as u64 + 203);
+        assert_eq!(block.block_height, round as u64 + 2003);
+        // let leader_key = "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6";
+        let leader_key = "eb5b00d8ba6d3e40334364721014ead390dc995e9d00d17d8fd8ee544afd6e58"; // TODO: validate this value
+
         match round {
             0 => {
                 let state_transition = &burnchain_tip.state_transition;
@@ -202,7 +205,7 @@ fn bitcoind_integration(segwit_flag: bool) {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
                             assert!(op.parent_block_ptr == 0);
                             assert!(op.parent_vtxindex == 0);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
@@ -222,8 +225,8 @@ fn bitcoind_integration(segwit_flag: bool) {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
-                            assert!(op.parent_block_ptr == 203);
+                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
+                            assert_eq!(op.parent_block_ptr, 2003);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
                         _ => assert!(false)
@@ -243,8 +246,8 @@ fn bitcoind_integration(segwit_flag: bool) {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
-                            assert!(op.parent_block_ptr == 204);
+                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
+                            assert_eq!(op.parent_block_ptr, 2004);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
                         _ => assert!(false)
@@ -264,8 +267,8 @@ fn bitcoind_integration(segwit_flag: bool) {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
-                            assert!(op.parent_block_ptr == 205);
+                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
+                            assert_eq!(op.parent_block_ptr, 2005);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
                         _ => assert!(false)
@@ -285,8 +288,8 @@ fn bitcoind_integration(segwit_flag: bool) {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
-                            assert!(op.parent_block_ptr == 206);
+                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
+                            assert_eq!(op.parent_block_ptr, 2006);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
                         _ => assert!(false)
@@ -306,8 +309,8 @@ fn bitcoind_integration(segwit_flag: bool) {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
-                            assert!(op.parent_block_ptr == 207);
+                            assert_eq!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex(), leader_key);
+                            assert_eq!(op.parent_block_ptr, 2007);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
                         _ => assert!(false)

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -119,7 +119,19 @@ fn bitcoind_integration_test() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
     }
+    bitcoind_integration(false);
+}
 
+#[test]
+#[ignore]
+fn bitcoind_integration_test_segwit() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+    bitcoind_integration(true);
+}
+
+fn bitcoind_integration(segwit_flag: bool) {
     let mut conf = super::new_test_conf();
     conf.burnchain.commit_anchor_block_within = 2000;
     conf.burnchain.burn_fee_cap = BITCOIND_INT_TEST_COMMITS;
@@ -133,7 +145,7 @@ fn bitcoind_integration_test() {
     conf.miner.min_tx_fee = 0;
     conf.miner.first_attempt_time_ms = i64::max_value() as u64;
     conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
-    conf.miner.segwit = true;
+    conf.miner.segwit = segwit_flag;
 
     conf.initial_balances.push(InitialBalance {
         address: to_addr(


### PR DESCRIPTION
Fix for failing `bitcoind_integration_test` when miner is in segwit mode. Creating early draft PR for @igorsyl to participate.

run command (optionally add BLOCKSTACK_DEBUG=1 for a lot more debug)
```
BITCOIND_TEST=1 RUST_BACKTRACE=1 cargo test -- --nocapture --test-threads 1 --ignored bitcoin_regtest::bitcoind_integration_test_segwit
```

error
```
DEBG [1666809993.325984] [testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs:1257] [main] No UTXOs for 04ee0b1602eb18fef7986887a7e8769a30c9df981d33c8380d255edef003abdcd243a0eb74afdf6740e6c423e62aec631519a24cf5b1d62bf8a3e06ddc695dcb77 (mtFzK54XtpktHj7fKonFExEPEGkUMsiXdy) in epoch 2.0
thread 'main' panicked at 'FATAL: failed to submit leader key register operation', testnet/stacks-node/src/node.rs:611:14
```
