### PR TITLE
Feat/3346: epoch marker for LeaderBlockCommitOp

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -86,6 +86,7 @@ jobs:
           - tests::epoch_21::transition_adds_pay_to_contract
           - tests::epoch_21::transition_adds_get_pox_addr_recipients
           - tests::epoch_21::transition_removes_pox_sunset
+          - tests::epoch_21::transition_empty_blocks
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -1074,6 +1074,9 @@ pub mod test {
             if epoch.epoch_id >= StacksEpochId::Epoch2_05 {
                 txop.memo = vec![STACKS_EPOCH_2_05_MARKER];
             }
+            if epoch.epoch_id >= StacksEpochId::Epoch21 {
+                txop.memo = vec![STACKS_EPOCH_2_1_MARKER];
+            }
 
             self.txs
                 .push(BlockstackOperationType::LeaderBlockCommit(txop.clone()));

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -569,7 +569,7 @@ fn make_genesis_block_with_recipients(
         },
         key_block_ptr: 1, // all registers happen in block height 1
         key_vtxindex: (1 + key_index) as u16,
-        memo: vec![STACKS_EPOCH_2_05_MARKER],
+        memo: vec![STACKS_EPOCH_2_1_MARKER],
         new_seed: VRFSeed::from_proof(&proof),
         commit_outs,
 
@@ -791,7 +791,7 @@ fn make_stacks_block_with_input(
         },
         key_block_ptr: 1, // all registers happen in block height 1
         key_vtxindex: (1 + key_index) as u16,
-        memo: vec![STACKS_EPOCH_2_05_MARKER],
+        memo: vec![STACKS_EPOCH_2_1_MARKER],
         new_seed: VRFSeed::from_proof(&proof),
         commit_outs,
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -176,7 +176,7 @@ use stacks::chainstate::stacks::{
 use stacks::codec::StacksMessageCodec;
 use stacks::core::mempool::MemPoolDB;
 use stacks::core::FIRST_BURNCHAIN_CONSENSUS_HASH;
-use stacks::core::STACKS_EPOCH_2_05_MARKER;
+use stacks::core::STACKS_EPOCH_2_1_MARKER;
 use stacks::cost_estimates::metrics::CostMetric;
 use stacks::cost_estimates::metrics::UnitMetric;
 use stacks::cost_estimates::UnitEstimator;
@@ -1285,7 +1285,7 @@ impl BlockMinerThread {
             apparent_sender: sender,
             key_block_ptr: key.block_height as u32,
             key_vtxindex: key.op_vtxindex as u16,
-            memo: vec![STACKS_EPOCH_2_05_MARKER],
+            memo: vec![STACKS_EPOCH_2_1_MARKER],
             new_seed: vrf_seed,
             parent_block_ptr,
             parent_vtxindex,

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -18,7 +18,7 @@ use stacks::chainstate::stacks::{
 };
 use stacks::chainstate::{burn::db::sortdb::SortitionDB, stacks::db::StacksEpochReceipt};
 use stacks::core::mempool::MemPoolDB;
-use stacks::core::STACKS_EPOCH_2_05_MARKER;
+use stacks::core::STACKS_EPOCH_2_1_MARKER;
 use stacks::cost_estimates::metrics::UnitMetric;
 use stacks::cost_estimates::UnitEstimator;
 use stacks::net::atlas::AttachmentInstance;
@@ -1030,7 +1030,7 @@ impl Node {
             apparent_sender: self.keychain.get_burnchain_signer(),
             key_block_ptr: key.block_height as u32,
             key_vtxindex: key.op_vtxindex as u16,
-            memo: vec![STACKS_EPOCH_2_05_MARKER],
+            memo: vec![STACKS_EPOCH_2_1_MARKER],
             new_seed: vrf_seed,
             parent_block_ptr,
             parent_vtxindex,

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -23,8 +23,10 @@ use stacks::core;
 
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::distribution::BurnSamplePoint;
+use stacks::chainstate::burn::operations::leader_block_commit::BURN_BLOCK_MINED_AT_MODULUS;
 use stacks::chainstate::burn::operations::leader_block_commit::OUTPUTS_PER_COMMIT;
 use stacks::chainstate::burn::operations::BlockstackOperationType;
+use stacks::chainstate::burn::operations::LeaderBlockCommitOp;
 use stacks::chainstate::burn::operations::PreStxOp;
 use stacks::chainstate::burn::operations::TransferStxOp;
 
@@ -39,7 +41,9 @@ use crate::stacks_common::address::AddressHashMode;
 use crate::stacks_common::types::Address;
 use crate::stacks_common::util::hash::{bytes_to_hex, hex_bytes};
 
+use stacks_common::types::chainstate::BlockHeaderHash;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::chainstate::VRFSeed;
 use stacks_common::util::hash::Hash160;
 use stacks_common::util::secp256k1::Secp256k1PublicKey;
 
@@ -1555,5 +1559,161 @@ fn transition_removes_pox_sunset() {
     }
 
     test_observer::clear();
+    channel.stop_chains_coordinator();
+}
+
+#[test]
+#[ignore]
+fn transition_empty_blocks() {
+    // very simple test to verify that the miner will keep making valid (empty) blocks after the
+    // transition.  Really tests that the block-commits are well-formed before and after the epoch
+    // transition.
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let epoch_2_05 = 210;
+    let epoch_2_1 = 215;
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = epoch_2_05;
+    epochs[2].start_height = epoch_2_05;
+    epochs[2].end_height = epoch_2_1;
+    epochs[3].start_height = epoch_2_1;
+
+    conf.node.mine_microblocks = false;
+    conf.burnchain.max_rbf = 1000000;
+    conf.miner.first_attempt_time_ms = 5_000;
+    conf.miner.subsequent_attempt_time_ms = 10_000;
+    conf.node.wait_time_for_blocks = 0;
+
+    conf.burnchain.epochs = Some(epochs);
+
+    let keychain = Keychain::default(conf.node.seed.clone());
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let tip_info = get_chain_info(&conf);
+    let key_block_ptr = tip_info.burn_block_height as u32;
+    let key_vtxindex = 1; // nothing else here but the coinbase
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let burnchain = Burnchain::regtest(&conf.get_burn_db_path());
+    let mut bitcoin_controller = BitcoinRegtestController::new_dummy(conf.clone());
+
+    // these should all succeed across the epoch boundary
+    for _i in 0..15 {
+        // also, make *huge* block-commits with invalid marker bytes once we reach the new
+        // epoch, and verify that it fails.
+        let tip_info = get_chain_info(&conf);
+
+        // this block is the epoch transition?
+        let (chainstate, _) = StacksChainState::open(
+            false,
+            conf.burnchain.chain_id,
+            &conf.get_chainstate_path_str(),
+            None,
+        )
+        .unwrap();
+        let res = StacksChainState::block_crosses_epoch_boundary(
+            &chainstate.db(),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+        )
+        .unwrap();
+        debug!(
+            "Epoch transition at {} ({}/{}) height {}: {}",
+            &StacksBlockHeader::make_index_block_hash(
+                &tip_info.stacks_tip_consensus_hash,
+                &tip_info.stacks_tip
+            ),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+            tip_info.burn_block_height,
+            res
+        );
+
+        if tip_info.burn_block_height == epoch_2_05 || tip_info.burn_block_height == epoch_2_1 {
+            assert!(res);
+        } else {
+            assert!(!res);
+        }
+
+        if tip_info.burn_block_height + 1 >= epoch_2_1 {
+            let burn_fee_cap = 100000000; // 1 BTC
+            let commit_outs = if !burnchain.is_in_prepare_phase(tip_info.burn_block_height + 1) {
+                vec![
+                    PoxAddress::standard_burn_address(conf.is_mainnet()),
+                    PoxAddress::standard_burn_address(conf.is_mainnet()),
+                ]
+            } else {
+                vec![PoxAddress::standard_burn_address(conf.is_mainnet())]
+            };
+
+            // let's commit
+            let burn_parent_modulus =
+                (tip_info.burn_block_height % BURN_BLOCK_MINED_AT_MODULUS) as u8;
+            let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                sunset_burn: 0,
+                block_header_hash: BlockHeaderHash([0xff; 32]),
+                burn_fee: burn_fee_cap,
+                input: (Txid([0; 32]), 0),
+                apparent_sender: keychain.get_burnchain_signer(),
+                key_block_ptr,
+                key_vtxindex,
+                memo: vec![0], // bad epoch marker
+                new_seed: VRFSeed([0x11; 32]),
+                parent_block_ptr: 0,
+                parent_vtxindex: 0,
+                // to be filled in
+                vtxindex: 0,
+                txid: Txid([0u8; 32]),
+                block_height: 0,
+                burn_header_hash: BurnchainHeaderHash::zero(),
+                burn_parent_modulus,
+                commit_outs,
+            });
+            let mut op_signer = keychain.generate_op_signer();
+            let res = bitcoin_controller.submit_operation(op, &mut op_signer, 1);
+            assert!(res, "Failed to submit block-commit");
+        }
+
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 16);
+
     channel.stop_chains_coordinator();
 }


### PR DESCRIPTION
This addresses #3346.  It's much the same as the code that added the epoch 2.05 marker:

* It modifies the consensus logic for `LeaderBlockCommitOp` to require an epoch 2.1 marker in the `memo` bits after Epoch 2.1

* It changes the miner to use the epoch 2.1 marker when mining (this is backwards-compatible with epoch 2.05)

* It adds test coverage for both validating `LeaderBlockCommitOp`s in epoch 2.1 as well as mining through the epoch 2.1 transition.

~~Note that this is currently based on PR #3358, so let's get that merged first.~~ EDIT: this is now ready