### PR TITLE
[Stacks 2.1] fix: regression with pox_2_activation config

### DIFF
--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -346,7 +346,8 @@ impl BitcoinRegtestController {
                 }
             }
         };
-        self.config.update_pox_constants(&mut burnchain.pox_constants);
+        self.config
+            .update_pox_constants(&mut burnchain.pox_constants);
         burnchain
     }
 

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -333,7 +333,7 @@ impl BitcoinRegtestController {
     /// Get the default Burnchain instance from our config
     fn default_burnchain(&self) -> Burnchain {
         let (network_name, _network_type) = self.config.burnchain.get_bitcoin_network();
-        match &self.burnchain_config {
+        let mut burnchain = match &self.burnchain_config {
             Some(burnchain) => burnchain.clone(),
             None => {
                 let working_dir = self.config.get_burn_db_path();
@@ -345,7 +345,9 @@ impl BitcoinRegtestController {
                     }
                 }
             }
-        }
+        };
+        self.config.update_pox_constants(&mut burnchain.pox_constants);
+        burnchain
     }
 
     /// Get the PoX constants in use


### PR DESCRIPTION
This fixes a regression from the recent merge from master into next: https://github.com/stacks-network/stacks-blockchain/pull/3358/files#diff-06a6e88675e542d59fefd0f0e8b3738028510b196074d2a7c77a07f79383a79cL317-R348. The ability to configure pox-2 activation block height in regtest mode no longer worked.

This function
```rs
    fn default_burnchain(config: &Config) -> Burnchain {
        let (network_name, _network_type) = config.burnchain.get_bitcoin_network();
        let working_dir = config.get_burn_db_path();
        let mut burnchain = Burnchain::new(&working_dir, &config.burnchain.chain, &network_name)
            .expect("Failed to instantiate burnchain");
        config.update_pox_constants(&mut burnchain.pox_constants);
        burnchain
    }
```
was refactored and the `update_pox_constants` call was dropped:
```rs
    fn default_burnchain(&self) -> Burnchain {
        let (network_name, _network_type) = self.config.burnchain.get_bitcoin_network();
        match &self.burnchain_config {
            Some(burnchain) => burnchain.clone(),
            None => {
                let working_dir = self.config.get_burn_db_path();
                match Burnchain::new(&working_dir, &self.config.burnchain.chain, &network_name) {
                    Ok(burnchain) => burnchain,
                    Err(e) => {
                        error!("Failed to instantiate burnchain: {}", e);
                        panic!()
                    }
                }
            }
        }
    }
```

Sample config that now works again:
```toml
[burnchain]
chain = "bitcoin"
mode = "krypton"
pox_2_activation = 200

[[burnchain.epochs]]
epoch_name = "1.0"
start_height = 0

[[burnchain.epochs]]
epoch_name = "2.0"
start_height = 0

[[burnchain.epochs]]
epoch_name = "2.05"
start_height = 1

[[burnchain.epochs]]
epoch_name = "2.1"
start_height = 2
```