### PR TITLE
fix: Miner rewards event for alternative recipients

### DIFF
--- a/testnet/stacks-node/src/event_dispatcher.rs
+++ b/testnet/stacks-node/src/event_dispatcher.rs
@@ -700,7 +700,8 @@ impl EventDispatcher {
                     .iter()
                     .map(|reward| {
                         json!({
-                            "recipient": reward.address.to_string(),
+                            "recipient": reward.recipient.to_string(),
+                            "miner_address": reward.address.to_string(),
                             "coinbase_amount": reward.coinbase.to_string(),
                             "tx_fees_anchored": reward.tx_fees_anchored.to_string(),
                             "tx_fees_streamed_confirmed": reward.tx_fees_streamed_confirmed.to_string(),


### PR DESCRIPTION
### Applicable issues
- fixes #3258

### Description
1) Replace "recipient" field with the generalized recipient (currently it's hard-coded to miner).
2) Use "miner_address" to encode the miner address.


### Additional info (benefits, drawbacks, caveats)
* waiting to see how the tests do on CI

### Checklist
- [ ] Testsw