### PR TITLE
Feat/immutable keychain

### DIFF
--- a/testnet/stacks-node/src/keychain.rs
+++ b/testnet/stacks-node/src/keychain.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use stacks::address::AddressHashMode;
-use stacks::burnchains::{BurnchainSigner, PrivateKey};
+use stacks::burnchains::BurnchainSigner;
 use stacks::chainstate::stacks::{
     StacksPrivateKey, StacksPublicKey, StacksTransactionSigner, TransactionAuth,
 };
@@ -11,67 +9,56 @@ use stacks::util::vrf::{VRFPrivateKey, VRFProof, VRFPublicKey, VRF};
 
 use super::operations::BurnchainOpSigner;
 
+use stacks_common::address::{
+    C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+};
+
+const PURPOSE_MICROBLOCKS: &'static str = "microblocks";
+
+/// A wrapper around a node's seed, coupled with operations for using it
 #[derive(Clone)]
 pub struct Keychain {
-    secret_keys: Vec<StacksPrivateKey>,
-    threshold: u16,
-    hash_mode: AddressHashMode,
-    pub hashed_secret_state: Sha256Sum,
-    microblocks_secret_keys: Vec<StacksPrivateKey>,
-    vrf_secret_keys: Vec<VRFPrivateKey>,
-    vrf_map: HashMap<VRFPublicKey, VRFPrivateKey>,
+    secret_state: Vec<u8>,
 }
 
 impl Keychain {
-    pub fn new(
-        secret_keys: Vec<StacksPrivateKey>,
-        threshold: u16,
-        hash_mode: AddressHashMode,
-    ) -> Keychain {
-        // Compute hashed secret state
-        let hashed_secret_state = {
-            let mut buf: Vec<u8> = secret_keys.iter().flat_map(|sk| sk.to_bytes()).collect();
-            buf.extend_from_slice(&[
-                (threshold >> 8) as u8,
-                (threshold & 0xff) as u8,
-                hash_mode as u8,
-            ]);
-            Sha256Sum::from_data(&buf[..])
-        };
-
-        Self {
-            hash_mode,
-            hashed_secret_state,
-            microblocks_secret_keys: vec![],
-            secret_keys,
-            threshold,
-            vrf_secret_keys: vec![],
-            vrf_map: HashMap::new(),
-        }
-    }
-
-    pub fn default(seed: Vec<u8>) -> Keychain {
-        let mut re_hashed_seed = seed;
-        let secret_key = loop {
+    /// Create a secret key from some state.
+    /// Returns the bytes that can be fed into StacksPrivateKey
+    fn make_secret_key_bytes(seed: &[u8]) -> Vec<u8> {
+        let mut re_hashed_seed = seed.to_vec();
+        loop {
             match StacksPrivateKey::from_slice(&re_hashed_seed[..]) {
-                Ok(sk) => break sk,
+                Ok(_sk) => {
+                    break;
+                }
                 Err(_) => {
                     re_hashed_seed = Sha256Sum::from_data(&re_hashed_seed[..])
                         .as_bytes()
                         .to_vec()
                 }
             }
-        };
-
-        let threshold = 1;
-        let hash_mode = AddressHashMode::SerializeP2PKH;
-
-        Keychain::new(vec![secret_key], threshold, hash_mode)
+        }
+        re_hashed_seed
     }
 
-    pub fn rotate_vrf_keypair(&mut self, block_height: u64) -> VRFPublicKey {
+    /// Create a secret key from our secret state
+    fn get_secret_key(&self) -> StacksPrivateKey {
+        let sk_bytes = Keychain::make_secret_key_bytes(&self.secret_state);
+        StacksPrivateKey::from_slice(&sk_bytes[..]).expect("FATAL: Keychain::makee_secret_key_bytes() returned bytes that could not be parsed into a secp256k1 secret key!")
+    }
+
+    /// Create a default keychain from the seed
+    pub fn default(seed: Vec<u8>) -> Keychain {
+        Keychain {
+            secret_state: Keychain::make_secret_key_bytes(&seed),
+        }
+    }
+
+    /// Generate a VRF keypair for this burn block height.
+    /// The keypair is unique to this burn block height.
+    pub fn make_vrf_keypair(&self, block_height: u64) -> (VRFPublicKey, VRFPrivateKey) {
         let mut seed = {
-            let mut secret_state = self.hashed_secret_state.to_bytes().to_vec();
+            let mut secret_state = self.secret_state.clone();
             secret_state.extend_from_slice(&block_height.to_be_bytes());
             Sha256Sum::from_data(&secret_state)
         };
@@ -85,101 +72,73 @@ impl Keychain {
             }
         };
         let pk = VRFPublicKey::from_private(&sk);
-
-        self.vrf_secret_keys.push(sk.clone());
-        self.vrf_map.insert(pk.clone(), sk);
-        pk
+        (pk, sk)
     }
 
-    pub fn rotate_microblock_keypair(&mut self, burn_block_height: u64) -> StacksPrivateKey {
-        let mut secret_state = match self.microblocks_secret_keys.last() {
-            // First key is the hash of the secret state
-            None => self.hashed_secret_state.to_bytes().to_vec(),
-            // Next key is the hash of the last
-            Some(last_sk) => last_sk.to_bytes().to_vec(),
+    /// Generate a Stacks keypair for this burn block height.
+    /// The keypair is unique to this burn block height.
+    pub fn make_stacks_keypair(
+        &self,
+        block_height: u64,
+        purpose: &str,
+    ) -> (StacksPublicKey, StacksPrivateKey) {
+        let seed = {
+            let mut secret_state = self.secret_state.clone();
+            secret_state.extend_from_slice(&block_height.to_be_bytes());
+            secret_state.extend_from_slice(purpose.as_bytes());
+            Sha256Sum::from_data(&secret_state)
         };
 
-        secret_state.extend_from_slice(&burn_block_height.to_be_bytes());
+        let sk_bytes = Keychain::make_secret_key_bytes(&seed.0);
+        let sk = StacksPrivateKey::from_slice(&sk_bytes[..]).expect("FATAL: Keychain::makee_secret_key_bytes() returned bytes that could not be parsed into a secp256k1 secret key!");
+        let pk = StacksPublicKey::from_private(&sk);
 
-        let mut seed = Sha256Sum::from_data(&secret_state);
-
-        // Not every 256-bit number is a valid secp256k1 secret key.
-        // As such, we continuously generate seeds through re-hashing until one works.
-        let mut sk = loop {
-            match StacksPrivateKey::from_slice(&seed.to_bytes()[..]) {
-                Ok(sk) => break sk,
-                Err(_) => seed = Sha256Sum::from_data(seed.as_bytes()),
-            }
-        };
-        sk.set_compress_public(true);
-        self.microblocks_secret_keys.push(sk.clone());
-
-        debug!("Microblock keypair rotated";
-               "burn_block_height" => %burn_block_height,
-               "pubkey_hash" => %Hash160::from_node_public_key(&StacksPublicKey::from_private(&sk)).to_string(),);
-
-        sk
+        (pk, sk)
     }
 
-    pub fn get_microblock_key(&self) -> Option<StacksPrivateKey> {
-        self.microblocks_secret_keys.last().cloned()
-    }
+    /// Generate a VRF proof over a given byte message.
+    /// `block_height` must be the _same_ block height called to make_vrf_keypair()
+    pub fn generate_proof(&self, block_height: u64, bytes: &[u8; 32]) -> VRFProof {
+        let (pk, sk) = self.make_vrf_keypair(block_height);
+        let proof = VRF::prove(&sk, &bytes.to_vec());
 
-    pub fn sign_as_origin(&self, tx_signer: &mut StacksTransactionSigner) -> () {
-        let num_keys = if self.secret_keys.len() < self.threshold as usize {
-            self.secret_keys.len()
-        } else {
-            self.threshold as usize
-        };
-
-        for i in 0..num_keys {
-            tx_signer.sign_origin(&self.secret_keys[i]).unwrap();
-        }
-    }
-
-    /// Given a VRF public key, generates a VRF Proof
-    pub fn generate_proof(&self, vrf_pk: &VRFPublicKey, bytes: &[u8; 32]) -> Option<VRFProof> {
-        // Retrieve the corresponding VRF secret key
-        let vrf_sk = match self.vrf_map.get(vrf_pk) {
-            Some(vrf_pk) => vrf_pk,
-            None => {
-                warn!("No VRF secret key on file for {:?}", vrf_pk);
-                return None;
-            }
-        };
-
-        // Generate the proof
-        let proof = VRF::prove(&vrf_sk, &bytes.to_vec());
         // Ensure that the proof is valid by verifying
-        let is_valid = match VRF::verify(vrf_pk, &proof, &bytes.to_vec()) {
+        let is_valid = match VRF::verify(&pk, &proof, &bytes.to_vec()) {
             Ok(v) => v,
             Err(_) => false,
         };
         assert!(is_valid);
-        Some(proof)
+        proof
     }
 
-    /// Given the keychain's secret keys, computes and returns the corresponding Stack address.
+    /// Generate a microblock signing key for this burnchain block height
+    pub fn make_microblock_secret_key(&mut self, burn_block_height: u64) -> StacksPrivateKey {
+        let (_, mut sk) = self.make_stacks_keypair(burn_block_height, PURPOSE_MICROBLOCKS);
+        sk.set_compress_public(true);
+
+        debug!("Microblock keypair rotated";
+               "burn_block_height" => %burn_block_height,
+               "pubkey_hash" => %Hash160::from_node_public_key(&StacksPublicKey::from_private(&sk)).to_string()
+        );
+        sk
+    }
+
+    /// Get the Stacks address for the inner secret state
     pub fn get_address(&self, is_mainnet: bool) -> StacksAddress {
-        let public_keys = self
-            .secret_keys
-            .iter()
-            .map(|ref pk| StacksPublicKey::from_private(pk))
-            .collect();
+        let sk = self.get_secret_key();
+        let pk = StacksPublicKey::from_private(&sk);
+
         let version = if is_mainnet {
-            self.hash_mode.to_version_mainnet()
+            C32_ADDRESS_VERSION_MAINNET_SINGLESIG
         } else {
-            self.hash_mode.to_version_testnet()
+            C32_ADDRESS_VERSION_TESTNET_SINGLESIG
         };
-        StacksAddress::from_public_keys(
-            version,
-            &self.hash_mode,
-            self.threshold as usize,
-            &public_keys,
-        )
-        .unwrap()
+        StacksAddress::from_public_keys(version, &AddressHashMode::SerializeP2PKH, 1, &vec![pk])
+            .expect("FATAL: could not produce address from secret key")
     }
 
+    /// Create our address from a burnchain signer
+    /// (this is going to be removed in 2.1)
     pub fn address_from_burnchain_signer(
         signer: &BurnchainSigner,
         is_mainnet: bool,
@@ -195,35 +154,40 @@ impl Keychain {
             signer.num_sigs,
             &signer.public_keys,
         )
-        .unwrap()
+        .expect("FATAL: could not make StacksAddress from BurnchainSigner")
     }
 
+    /// Get a BurnchainSigner representation of this keychain
+    /// (this is going to be removed in 2.1)
     pub fn get_burnchain_signer(&self) -> BurnchainSigner {
-        let public_keys = self
-            .secret_keys
-            .iter()
-            .map(|ref pk| StacksPublicKey::from_private(pk))
-            .collect();
+        let pubk = StacksPublicKey::from_private(&self.get_secret_key());
         BurnchainSigner {
-            hash_mode: self.hash_mode,
-            num_sigs: self.threshold as usize,
-            public_keys,
+            hash_mode: AddressHashMode::SerializeP2PKH,
+            num_sigs: 1,
+            public_keys: vec![pubk],
         }
     }
 
+    /// Convenience wrapper around make_stacks_keypair
+    pub fn get_microblock_key(&self, block_height: u64) -> StacksPrivateKey {
+        self.make_stacks_keypair(block_height, PURPOSE_MICROBLOCKS)
+            .1
+    }
+
+    /// Sign a transaction as if we were the origin
+    pub fn sign_as_origin(&self, tx_signer: &mut StacksTransactionSigner) -> () {
+        let sk = self.get_secret_key();
+        tx_signer
+            .sign_origin(&sk)
+            .expect("FATAL: failed to sign transaction origin");
+    }
+
+    /// Create a transaction authorization struct from this keychain's secret state
     pub fn get_transaction_auth(&self) -> Option<TransactionAuth> {
-        match self.hash_mode {
-            AddressHashMode::SerializeP2PKH => TransactionAuth::from_p2pkh(&self.secret_keys[0]),
-            AddressHashMode::SerializeP2SH => {
-                TransactionAuth::from_p2sh(&self.secret_keys, self.threshold)
-            }
-            AddressHashMode::SerializeP2WPKH => TransactionAuth::from_p2wpkh(&self.secret_keys[0]),
-            AddressHashMode::SerializeP2WSH => {
-                TransactionAuth::from_p2wsh(&self.secret_keys, self.threshold)
-            }
-        }
+        TransactionAuth::from_p2pkh(&self.get_secret_key())
     }
 
+    /// Get the origin address that this keychain represents
     pub fn origin_address(&self, is_mainnet: bool) -> Option<StacksAddress> {
         match self.get_transaction_auth() {
             Some(auth) => {
@@ -238,7 +202,447 @@ impl Keychain {
         }
     }
 
+    /// Create a BurnchainOpSigner representation of this keychain
+    /// (this is going to be removed in 2.1)
     pub fn generate_op_signer(&self) -> BurnchainOpSigner {
-        BurnchainOpSigner::new(self.secret_keys[0], false)
+        BurnchainOpSigner::new(self.get_secret_key(), false)
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod tests {
+    use std::collections::HashMap;
+
+    use stacks::address::AddressHashMode;
+    use stacks::burnchains::{BurnchainSigner, PrivateKey};
+    use stacks::chainstate::stacks::{
+        StacksPrivateKey, StacksPublicKey, StacksTransactionSigner, TransactionAuth,
+    };
+    use stacks::types::chainstate::StacksAddress;
+    use stacks::util::hash::{Hash160, Sha256Sum};
+    use stacks::util::vrf::{VRFPrivateKey, VRFProof, VRFPublicKey, VRF};
+
+    use crate::operations::BurnchainOpSigner;
+
+    use super::Keychain;
+
+    use stacks::chainstate::stacks::StacksTransaction;
+    use stacks::chainstate::stacks::TokenTransferMemo;
+    use stacks::chainstate::stacks::TransactionPayload;
+    use stacks::chainstate::stacks::TransactionPostConditionMode;
+    use stacks::chainstate::stacks::TransactionVersion;
+
+    use crate::stacks_common::types::Address;
+
+    /// Legacy implementation; kept around for testing
+    #[derive(Clone)]
+    pub struct KeychainOld {
+        secret_keys: Vec<StacksPrivateKey>,
+        threshold: u16,
+        hash_mode: AddressHashMode,
+        pub hashed_secret_state: Sha256Sum,
+        microblocks_secret_keys: Vec<StacksPrivateKey>,
+        vrf_secret_keys: Vec<VRFPrivateKey>,
+        vrf_map: HashMap<VRFPublicKey, VRFPrivateKey>,
+    }
+
+    impl KeychainOld {
+        pub fn new(
+            secret_keys: Vec<StacksPrivateKey>,
+            threshold: u16,
+            hash_mode: AddressHashMode,
+        ) -> KeychainOld {
+            // Compute hashed secret state
+            let hashed_secret_state = {
+                let mut buf: Vec<u8> = secret_keys.iter().flat_map(|sk| sk.to_bytes()).collect();
+                buf.extend_from_slice(&[
+                    (threshold >> 8) as u8,
+                    (threshold & 0xff) as u8,
+                    hash_mode as u8,
+                ]);
+                Sha256Sum::from_data(&buf[..])
+            };
+
+            Self {
+                hash_mode,
+                hashed_secret_state,
+                microblocks_secret_keys: vec![],
+                secret_keys,
+                threshold,
+                vrf_secret_keys: vec![],
+                vrf_map: HashMap::new(),
+            }
+        }
+
+        pub fn default(seed: Vec<u8>) -> KeychainOld {
+            let mut re_hashed_seed = seed;
+            let secret_key = loop {
+                match StacksPrivateKey::from_slice(&re_hashed_seed[..]) {
+                    Ok(sk) => break sk,
+                    Err(_) => {
+                        re_hashed_seed = Sha256Sum::from_data(&re_hashed_seed[..])
+                            .as_bytes()
+                            .to_vec()
+                    }
+                }
+            };
+
+            let threshold = 1;
+            let hash_mode = AddressHashMode::SerializeP2PKH;
+
+            KeychainOld::new(vec![secret_key], threshold, hash_mode)
+        }
+
+        pub fn rotate_vrf_keypair(&mut self, block_height: u64) -> VRFPublicKey {
+            let mut seed = {
+                let mut secret_state = self.hashed_secret_state.to_bytes().to_vec();
+                secret_state.extend_from_slice(&block_height.to_be_bytes());
+                Sha256Sum::from_data(&secret_state)
+            };
+
+            // Not every 256-bit number is a valid Ed25519 secret key.
+            // As such, we continuously generate seeds through re-hashing until one works.
+            let sk = loop {
+                match VRFPrivateKey::from_bytes(seed.as_bytes()) {
+                    Some(sk) => break sk,
+                    None => seed = Sha256Sum::from_data(seed.as_bytes()),
+                }
+            };
+            let pk = VRFPublicKey::from_private(&sk);
+
+            self.vrf_secret_keys.push(sk.clone());
+            self.vrf_map.insert(pk.clone(), sk);
+            pk
+        }
+
+        pub fn rotate_microblock_keypair(&mut self, burn_block_height: u64) -> StacksPrivateKey {
+            let mut secret_state = match self.microblocks_secret_keys.last() {
+                // First key is the hash of the secret state
+                None => self.hashed_secret_state.to_bytes().to_vec(),
+                // Next key is the hash of the last
+                Some(last_sk) => last_sk.to_bytes().to_vec(),
+            };
+
+            secret_state.extend_from_slice(&burn_block_height.to_be_bytes());
+
+            let mut seed = Sha256Sum::from_data(&secret_state);
+
+            // Not every 256-bit number is a valid secp256k1 secret key.
+            // As such, we continuously generate seeds through re-hashing until one works.
+            let mut sk = loop {
+                match StacksPrivateKey::from_slice(&seed.to_bytes()[..]) {
+                    Ok(sk) => break sk,
+                    Err(_) => seed = Sha256Sum::from_data(seed.as_bytes()),
+                }
+            };
+            sk.set_compress_public(true);
+            self.microblocks_secret_keys.push(sk.clone());
+
+            debug!("Microblock keypair rotated";
+                   "burn_block_height" => %burn_block_height,
+                   "pubkey_hash" => %Hash160::from_node_public_key(&StacksPublicKey::from_private(&sk)).to_string(),);
+
+            sk
+        }
+
+        pub fn get_microblock_key(&self) -> Option<StacksPrivateKey> {
+            self.microblocks_secret_keys.last().cloned()
+        }
+
+        pub fn sign_as_origin(&self, tx_signer: &mut StacksTransactionSigner) -> () {
+            let num_keys = if self.secret_keys.len() < self.threshold as usize {
+                self.secret_keys.len()
+            } else {
+                self.threshold as usize
+            };
+
+            for i in 0..num_keys {
+                tx_signer.sign_origin(&self.secret_keys[i]).unwrap();
+            }
+        }
+
+        /// Given a VRF public key, generates a VRF Proof
+        pub fn generate_proof(&self, vrf_pk: &VRFPublicKey, bytes: &[u8; 32]) -> Option<VRFProof> {
+            // Retrieve the corresponding VRF secret key
+            let vrf_sk = match self.vrf_map.get(vrf_pk) {
+                Some(vrf_pk) => vrf_pk,
+                None => {
+                    warn!("No VRF secret key on file for {:?}", vrf_pk);
+                    return None;
+                }
+            };
+
+            // Generate the proof
+            let proof = VRF::prove(&vrf_sk, &bytes.to_vec());
+            // Ensure that the proof is valid by verifying
+            let is_valid = match VRF::verify(vrf_pk, &proof, &bytes.to_vec()) {
+                Ok(v) => v,
+                Err(_) => false,
+            };
+            assert!(is_valid);
+            Some(proof)
+        }
+
+        /// Given the keychain's secret keys, computes and returns the corresponding Stack address.
+        pub fn get_address(&self, is_mainnet: bool) -> StacksAddress {
+            let public_keys = self
+                .secret_keys
+                .iter()
+                .map(|ref pk| StacksPublicKey::from_private(pk))
+                .collect();
+            let version = if is_mainnet {
+                self.hash_mode.to_version_mainnet()
+            } else {
+                self.hash_mode.to_version_testnet()
+            };
+            StacksAddress::from_public_keys(
+                version,
+                &self.hash_mode,
+                self.threshold as usize,
+                &public_keys,
+            )
+            .unwrap()
+        }
+
+        pub fn address_from_burnchain_signer(
+            signer: &BurnchainSigner,
+            is_mainnet: bool,
+        ) -> StacksAddress {
+            let version = if is_mainnet {
+                signer.hash_mode.to_version_mainnet()
+            } else {
+                signer.hash_mode.to_version_testnet()
+            };
+            StacksAddress::from_public_keys(
+                version,
+                &signer.hash_mode,
+                signer.num_sigs,
+                &signer.public_keys,
+            )
+            .unwrap()
+        }
+
+        pub fn get_burnchain_signer(&self) -> BurnchainSigner {
+            let public_keys = self
+                .secret_keys
+                .iter()
+                .map(|ref pk| StacksPublicKey::from_private(pk))
+                .collect();
+            BurnchainSigner {
+                hash_mode: self.hash_mode,
+                num_sigs: self.threshold as usize,
+                public_keys,
+            }
+        }
+
+        pub fn get_transaction_auth(&self) -> Option<TransactionAuth> {
+            match self.hash_mode {
+                AddressHashMode::SerializeP2PKH => {
+                    TransactionAuth::from_p2pkh(&self.secret_keys[0])
+                }
+                AddressHashMode::SerializeP2SH => {
+                    TransactionAuth::from_p2sh(&self.secret_keys, self.threshold)
+                }
+                AddressHashMode::SerializeP2WPKH => {
+                    TransactionAuth::from_p2wpkh(&self.secret_keys[0])
+                }
+                AddressHashMode::SerializeP2WSH => {
+                    TransactionAuth::from_p2wsh(&self.secret_keys, self.threshold)
+                }
+            }
+        }
+
+        pub fn origin_address(&self, is_mainnet: bool) -> Option<StacksAddress> {
+            match self.get_transaction_auth() {
+                Some(auth) => {
+                    let address = if is_mainnet {
+                        auth.origin().address_mainnet()
+                    } else {
+                        auth.origin().address_testnet()
+                    };
+                    Some(address)
+                }
+                None => None,
+            }
+        }
+
+        pub fn generate_op_signer(&self) -> BurnchainOpSigner {
+            BurnchainOpSigner::new(self.secret_keys[0], false)
+        }
+    }
+
+    #[test]
+    fn test_origin_address() {
+        let seeds = [
+            [0u8; 32],
+            [
+                0xc2, 0x7e, 0x1d, 0x7e, 0x9a, 0x0d, 0x47, 0xfa, 0xa5, 0x10, 0xbe, 0x50, 0x9b, 0xce,
+                0xd4, 0x95, 0x99, 0x64, 0x40, 0x34, 0xbd, 0x5a, 0xf2, 0x2b, 0x51, 0x9c, 0x21, 0x19,
+                0xbd, 0xaa, 0x5d, 0x62,
+            ],
+        ];
+
+        for seed in seeds {
+            let k1 = Keychain::default(seed.to_vec());
+            let k2 = KeychainOld::default(seed.to_vec());
+
+            assert_eq!(k1.origin_address(true), k2.origin_address(true));
+            assert_eq!(k1.origin_address(false), k2.origin_address(false));
+        }
+    }
+
+    #[test]
+    fn test_get_address() {
+        let seeds = [
+            [0u8; 32],
+            [
+                0xc2, 0x7e, 0x1d, 0x7e, 0x9a, 0x0d, 0x47, 0xfa, 0xa5, 0x10, 0xbe, 0x50, 0x9b, 0xce,
+                0xd4, 0x95, 0x99, 0x64, 0x40, 0x34, 0xbd, 0x5a, 0xf2, 0x2b, 0x51, 0x9c, 0x21, 0x19,
+                0xbd, 0xaa, 0x5d, 0x62,
+            ],
+        ];
+
+        for seed in seeds {
+            let k1 = Keychain::default(seed.to_vec());
+            let k2 = KeychainOld::default(seed.to_vec());
+
+            assert_eq!(k1.get_address(true), k2.get_address(true));
+            assert_eq!(k1.get_address(false), k2.get_address(false));
+        }
+    }
+
+    #[test]
+    fn test_get_transaction_auth() {
+        let seeds = [
+            [0u8; 32],
+            [
+                0xc2, 0x7e, 0x1d, 0x7e, 0x9a, 0x0d, 0x47, 0xfa, 0xa5, 0x10, 0xbe, 0x50, 0x9b, 0xce,
+                0xd4, 0x95, 0x99, 0x64, 0x40, 0x34, 0xbd, 0x5a, 0xf2, 0x2b, 0x51, 0x9c, 0x21, 0x19,
+                0xbd, 0xaa, 0x5d, 0x62,
+            ],
+        ];
+
+        for seed in seeds {
+            let k1 = Keychain::default(seed.to_vec());
+            let k2 = KeychainOld::default(seed.to_vec());
+
+            assert_eq!(k1.get_transaction_auth(), k2.get_transaction_auth());
+        }
+    }
+
+    #[test]
+    fn test_sign_as_origin() {
+        let seeds = [
+            [0u8; 32],
+            [
+                0xc2, 0x7e, 0x1d, 0x7e, 0x9a, 0x0d, 0x47, 0xfa, 0xa5, 0x10, 0xbe, 0x50, 0x9b, 0xce,
+                0xd4, 0x95, 0x99, 0x64, 0x40, 0x34, 0xbd, 0x5a, 0xf2, 0x2b, 0x51, 0x9c, 0x21, 0x19,
+                0xbd, 0xaa, 0x5d, 0x62,
+            ],
+        ];
+
+        for seed in seeds {
+            let k1 = Keychain::default(seed.to_vec());
+            let k2 = KeychainOld::default(seed.to_vec());
+
+            let recv_addr =
+                StacksAddress::from_string("SP1Z4P459B2M5XC2PMM2CSCNZ6824DN5GZG2XYWFH").unwrap();
+
+            let mut tx_stx_transfer_1 = StacksTransaction::new(
+                TransactionVersion::Testnet,
+                k1.get_transaction_auth().unwrap(),
+                TransactionPayload::TokenTransfer(
+                    recv_addr.clone().into(),
+                    123,
+                    TokenTransferMemo([0u8; 34]),
+                ),
+            );
+            let mut tx_stx_transfer_2 = StacksTransaction::new(
+                TransactionVersion::Testnet,
+                k2.get_transaction_auth().unwrap(),
+                TransactionPayload::TokenTransfer(
+                    recv_addr.clone().into(),
+                    123,
+                    TokenTransferMemo([0u8; 34]),
+                ),
+            );
+
+            tx_stx_transfer_1.chain_id = 0x80000000;
+            tx_stx_transfer_1.post_condition_mode = TransactionPostConditionMode::Allow;
+            tx_stx_transfer_1.set_tx_fee(0);
+
+            tx_stx_transfer_2.chain_id = 0x80000000;
+            tx_stx_transfer_2.post_condition_mode = TransactionPostConditionMode::Allow;
+            tx_stx_transfer_2.set_tx_fee(0);
+
+            let mut signer_1 = StacksTransactionSigner::new(&tx_stx_transfer_1);
+            k1.sign_as_origin(&mut signer_1);
+            let tx_1 = signer_1.get_tx().unwrap();
+
+            let mut signer_2 = StacksTransactionSigner::new(&tx_stx_transfer_2);
+            k2.sign_as_origin(&mut signer_2);
+            let tx_2 = signer_2.get_tx().unwrap();
+
+            assert_eq!(tx_1, tx_2);
+        }
+    }
+
+    #[test]
+    fn test_get_burnchain_signer() {
+        // this is going to be deleted for 2.1
+        let seeds = [
+            [0u8; 32],
+            [
+                0xc2, 0x7e, 0x1d, 0x7e, 0x9a, 0x0d, 0x47, 0xfa, 0xa5, 0x10, 0xbe, 0x50, 0x9b, 0xce,
+                0xd4, 0x95, 0x99, 0x64, 0x40, 0x34, 0xbd, 0x5a, 0xf2, 0x2b, 0x51, 0x9c, 0x21, 0x19,
+                0xbd, 0xaa, 0x5d, 0x62,
+            ],
+        ];
+
+        for seed in seeds {
+            let k1 = Keychain::default(seed.to_vec());
+            let k2 = KeychainOld::default(seed.to_vec());
+
+            assert_eq!(k1.get_burnchain_signer(), k2.get_burnchain_signer());
+        }
+    }
+
+    #[test]
+    fn test_address_from_burnchain_signer() {
+        // this is going to be deleted for 2.1
+        let seeds = [
+            [0u8; 32],
+            [
+                0xc2, 0x7e, 0x1d, 0x7e, 0x9a, 0x0d, 0x47, 0xfa, 0xa5, 0x10, 0xbe, 0x50, 0x9b, 0xce,
+                0xd4, 0x95, 0x99, 0x64, 0x40, 0x34, 0xbd, 0x5a, 0xf2, 0x2b, 0x51, 0x9c, 0x21, 0x19,
+                0xbd, 0xaa, 0x5d, 0x62,
+            ],
+        ];
+
+        for seed in seeds {
+            let k1 = Keychain::default(seed.to_vec());
+            let k2 = KeychainOld::default(seed.to_vec());
+
+            let s1 = k1.get_burnchain_signer();
+            assert_eq!(
+                Keychain::address_from_burnchain_signer(&s1, false),
+                KeychainOld::address_from_burnchain_signer(&s1, false)
+            );
+            assert_eq!(
+                Keychain::address_from_burnchain_signer(&s1, true),
+                KeychainOld::address_from_burnchain_signer(&s1, true)
+            );
+
+            let s2 = k2.get_burnchain_signer();
+            assert_eq!(
+                Keychain::address_from_burnchain_signer(&s2, false),
+                KeychainOld::address_from_burnchain_signer(&s2, false)
+            );
+            assert_eq!(
+                Keychain::address_from_burnchain_signer(&s2, true),
+                KeychainOld::address_from_burnchain_signer(&s2, true)
+            );
+        }
     }
 }

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1390,31 +1390,32 @@ impl BlockMinerThread {
     ///
     /// In testing, we ignore the parent stacks block hash because we don't have an easy way to
     /// reproduce it in integration tests.
-    #[cfg(test)]
+    #[cfg(not(any(test, feature = "testing")))]
     fn make_microblock_private_key(
         &mut self,
-        _parent_stacks_hash: &StacksBlockId,
+        parent_stacks_hash: &StacksBlockId,
     ) -> Secp256k1PrivateKey {
         // Generates a new secret key for signing the trail of microblocks
         // of the upcoming tenure.
-        self.keychain.make_microblock_secret_key(
-            self.burn_block.block_height,
-            &self.burn_block.block_height.to_be_bytes(),
-        )
+        self.keychain
+            .make_microblock_secret_key(self.burn_block.block_height, &parent_stacks_hash.0)
     }
 
     /// Get the microblock private key we'll be using for this tenure, should we win.
     /// Return the private key on success
     /// return None if we were unable to generate the key.
-    #[cfg(not(test))]
+    #[cfg(any(test, feature = "testing"))]
     fn make_microblock_private_key(
         &mut self,
         _parent_stacks_hash: &StacksBlockId,
     ) -> Secp256k1PrivateKey {
         // Generates a new secret key for signing the trail of microblocks
         // of the upcoming tenure.
-        self.keychain
-            .make_microblock_secret_key(self.burn_block.block_height, &[])
+        warn!("test version of make_microblock_secret_key");
+        self.keychain.make_microblock_secret_key(
+            self.burn_block.block_height,
+            &self.burn_block.block_height.to_be_bytes(),
+        )
     }
 
     /// Load the parent microblock stream and vet it for the absence of forks.

--- a/testnet/stacks-node/src/node.rs
+++ b/testnet/stacks-node/src/node.rs
@@ -674,7 +674,7 @@ impl Node {
         // of the upcoming tenure.
         let microblock_secret_key = self
             .keychain
-            .make_microblock_secret_key(block_to_build_upon.block_snapshot.block_height);
+            .get_microblock_key(block_to_build_upon.block_snapshot.block_height);
 
         // Get the stack's chain tip
         let chain_tip = match self.bootstraping_chain {

--- a/testnet/stacks-node/src/run_loop/mod.rs
+++ b/testnet/stacks-node/src/run_loop/mod.rs
@@ -143,7 +143,12 @@ impl RunLoopCallbacks {
 
 #[derive(Clone, Debug)]
 pub struct RegisteredKey {
+    /// burn block height we intended this VRF key register to land in
+    pub target_block_height: u64,
+    /// burn block height it actually landed in
     pub block_height: u64,
+    /// offset in the block's tx list where this operation is
     pub op_vtxindex: u32,
+    /// the public key itself
     pub vrf_public_key: VRFPublicKey,
 }

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -189,7 +189,7 @@ fn bitcoind_integration_test() {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "d90cb4d7e9de9bc6bafbf7bff898b78d51a467080bc921de569b6df61eb61518");
                             assert!(op.parent_block_ptr == 0);
                             assert!(op.parent_vtxindex == 0);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
@@ -209,7 +209,7 @@ fn bitcoind_integration_test() {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "d90cb4d7e9de9bc6bafbf7bff898b78d51a467080bc921de569b6df61eb61518");
                             assert!(op.parent_block_ptr == 203);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
@@ -230,7 +230,7 @@ fn bitcoind_integration_test() {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "d90cb4d7e9de9bc6bafbf7bff898b78d51a467080bc921de569b6df61eb61518");
                             assert!(op.parent_block_ptr == 204);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
@@ -251,7 +251,7 @@ fn bitcoind_integration_test() {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "d90cb4d7e9de9bc6bafbf7bff898b78d51a467080bc921de569b6df61eb61518");
                             assert!(op.parent_block_ptr == 205);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
@@ -272,7 +272,7 @@ fn bitcoind_integration_test() {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "d90cb4d7e9de9bc6bafbf7bff898b78d51a467080bc921de569b6df61eb61518");
                             assert!(op.parent_block_ptr == 206);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }
@@ -293,7 +293,7 @@ fn bitcoind_integration_test() {
                             unreachable!();
                         },
                         LeaderBlockCommit(op) => {
-                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "63765f54b850bdcecc6df4ff0bf3fdb55e862d69aad4411d7093a07e5b39c7a6");
+                            assert!(burnchain_tip.state_transition.consumed_leader_keys[0].public_key.to_hex() == "d90cb4d7e9de9bc6bafbf7bff898b78d51a467080bc921de569b6df61eb61518");
                             assert!(op.parent_block_ptr == 207);
                             assert_eq!(op.burn_fee, BITCOIND_INT_TEST_COMMITS);
                         }

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -855,7 +855,7 @@ fn integration_test_get_info() {
                 // evaluate check for explicit compliance against the chain tip of the first block (contract DNE at that block)
                 // N.B. if the block version changes (e.g. due to a new release), this tip value
                 // will also change
-                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}?tip=fa1ba17dbe3d085753b228e3d74726d6f04486c1e2249e3d2e4ba6dab5089ca9", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info",  "trait-1");
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}?tip=77fe703cad3fd94b0c04328bb95c3312fb0ae26830de9b7a5585639ecf5c529c", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info",  "trait-1");
                 let res = client.get(&path).send().unwrap();
                 eprintln!("Test: GET {}", path);
                 assert_eq!(res.text().unwrap(), "No contract analysis found or trait definition not found");

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -855,7 +855,7 @@ fn integration_test_get_info() {
                 // evaluate check for explicit compliance against the chain tip of the first block (contract DNE at that block)
                 // N.B. if the block version changes (e.g. due to a new release), this tip value
                 // will also change
-                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}?tip=7d0edc26639d8da442da75999909f4fb0247f66d4d87f72e7ea63e5d9f7fabd0", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info",  "trait-1");
+                let path = format!("{}/v2/traits/{}/{}/{}/{}/{}?tip=fa1ba17dbe3d085753b228e3d74726d6f04486c1e2249e3d2e4ba6dab5089ca9", &http_origin, &contract_addr, "impl-trait-contract", &contract_addr, "get-info",  "trait-1");
                 let res = client.get(&path).send().unwrap();
                 eprintln!("Test: GET {}", path);
                 assert_eq!(res.text().unwrap(), "No contract analysis found or trait definition not found");

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -660,7 +660,6 @@ fn mempool_setup_chainstate() {
 
                 let keychain = Keychain::default(conf.node.seed.clone());
                 for i in 0..4 {
-                    // let microblock_secret_key = keychain.rotate_microblock_keypair(1 + i);
                     let microblock_secret_key = keychain.get_microblock_key(1 + i);
                     let mut microblock_pubkey =
                         Secp256k1PublicKey::from_private(&microblock_secret_key);

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -658,9 +658,10 @@ fn mempool_setup_chainstate() {
                 let mut conf = super::new_test_conf();
                 conf.node.seed = vec![0x00];
 
-                let mut keychain = Keychain::default(conf.node.seed.clone());
+                let keychain = Keychain::default(conf.node.seed.clone());
                 for i in 0..4 {
-                    let microblock_secret_key = keychain.rotate_microblock_keypair(1 + i);
+                    // let microblock_secret_key = keychain.rotate_microblock_keypair(1 + i);
+                    let microblock_secret_key = keychain.get_microblock_key(1 + i);
                     let mut microblock_pubkey =
                         Secp256k1PublicKey::from_private(&microblock_secret_key);
                     microblock_pubkey.set_compressed(true);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -695,7 +695,8 @@ fn find_microblock_privkey(
     let mut keychain = Keychain::default(conf.node.seed.clone());
     for ix in 0..max_tries {
         // the first rotation occurs at 203.
-        let privk = keychain.make_microblock_secret_key(203 + ix);
+        let privk =
+            keychain.make_microblock_secret_key(203 + ix, &((203 + ix) as u64).to_be_bytes());
         let pubkh = Hash160::from_node_public_key(&StacksPublicKey::from_private(&privk));
         if pubkh == *pubkey_hash {
             return Some(privk);
@@ -9599,7 +9600,6 @@ fn make_runtime_sized_contract(num_index_of: usize, nonce: u64, addr_prefix: &st
 }
 
 enum TxChainStrategy {
-    Nothing,
     Expensive,
     Random,
 }
@@ -9891,7 +9891,6 @@ fn test_competing_miners_build_on_same_chain(
         .map(|(i, pk)| match chain_strategy {
             TxChainStrategy::Expensive => make_expensive_tx_chain(pk, (25 * i) as u64, mblock_only),
             TxChainStrategy::Random => make_random_tx_chain(pk, (25 * i) as u64, mblock_only),
-            TxChainStrategy::Nothing => vec![],
         })
         .collect();
     let mut cnt = 0;


### PR DESCRIPTION
This PR reworks the `Keychain` struct in the node so that it's immutable.  It has no internal state to mutate; instead, all key data is generated from arguments.

We believe this fixes a bug we discovered today in which a node might accidentally re-use the same microblock public key hash in a block, causing it to be invalid.  This PR ensures that each microblock keypair is derived from both the miner's current burnchain block height and the parent Stacks block ID, instead of any internal state.

We will want to test this in prod before merging.