### PR TITLE
feat: add bootstrap nodes to /v2/neighbors

### DIFF
--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -6097,6 +6097,7 @@ mod test {
     #[test]
     fn test_http_response_type_codec() {
         let test_neighbors_info = RPCNeighborsInfo {
+            bootstrap: vec![],
             sample: vec![
                 RPCNeighbor {
                     network_id: 1,
@@ -6731,6 +6732,7 @@ mod test {
             ) => assert_eq!(
                 neighbors_data,
                 RPCNeighborsInfo {
+                    bootstrap: vec![],
                     sample: vec![],
                     inbound: vec![],
                     outbound: vec![]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1401,6 +1401,7 @@ impl RPCNeighbor {
 /// Struct given back from a call to `/v2/neighbors`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RPCNeighborsInfo {
+    pub bootstrap: Vec<RPCNeighbor>,
     pub sample: Vec<RPCNeighbor>,
     pub inbound: Vec<RPCNeighbor>,
     pub outbound: Vec<RPCNeighbor>,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -444,6 +444,19 @@ impl RPCNeighborsInfo {
         chain_view: &BurnchainView,
         peerdb: &PeerDB,
     ) -> Result<RPCNeighborsInfo, net_error> {
+        let bootstrap_nodes =
+            PeerDB::get_bootstrap_peers(peerdb.conn(), network_id).map_err(net_error::DBError)?;
+        let bootstrap = bootstrap_nodes
+            .into_iter()
+            .map(|n| {
+                RPCNeighbor::from_neighbor_key_and_pubkh(
+                    n.addr.clone(),
+                    Hash160::from_node_public_key(&n.public_key),
+                    true,
+                )
+            })
+            .collect();
+
         let neighbor_sample = PeerDB::get_random_neighbors(
             peerdb.conn(),
             network_id,
@@ -486,9 +499,10 @@ impl RPCNeighborsInfo {
         }
 
         Ok(RPCNeighborsInfo {
-            sample: sample,
-            inbound: inbound,
-            outbound: outbound,
+            bootstrap,
+            sample,
+            inbound,
+            outbound,
         })
     }
 }
@@ -4275,6 +4289,11 @@ mod test {
                     HttpResponseType::Neighbors(response_md, neighbor_info) => {
                         assert_eq!(neighbor_info.sample.len(), 1);
                         assert_eq!(neighbor_info.sample[0].port, peer_client.config.server_port); // we see ourselves as the neighbor
+                        assert_eq!(neighbor_info.bootstrap.len(), 1);
+                        assert_eq!(
+                            neighbor_info.bootstrap[0].port,
+                            peer_client.config.server_port
+                        ); // we see ourselves as the bootstrap
                         true
                     }
                     _ => {


### PR DESCRIPTION
Adding the bootstrap nodes to this endpoint will help new nodes discover reliable nodes to boot from.