### PR TITLE
Fix/3400

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -78,6 +78,7 @@ jobs:
           - tests::neon_integrations::test_problematic_blocks_are_not_relayed_or_stored
           - tests::neon_integrations::test_problematic_microblocks_are_not_mined
           - tests::neon_integrations::test_problematic_microblocks_are_not_relayed_or_stored
+          - tests::neon_integrations::bad_microblock_pubkey
     steps:
       - uses: actions/checkout@v2
       - name: Download docker image

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -723,8 +723,7 @@ impl<
                 debug!("Bump blocks processed (invalid)");
                 self.notifier.notify_stacks_block_processed();
                 increment_stx_blocks_processed_counter();
-            }
-            else if let (Some(block_receipt), _) = block_result {
+            } else if let (Some(block_receipt), _) = block_result {
                 // only bump the coordinator's state if the processed block
                 //   is in our sortition fork
                 //  TODO: we should update the staging block logic to prevent
@@ -745,7 +744,7 @@ impl<
                     let new_canonical_stacks_block =
                         new_canonical_block_snapshot.get_canonical_stacks_block_id();
                     self.canonical_chain_tip = Some(new_canonical_stacks_block);
-                    
+
                     debug!("Bump blocks processed");
                     self.notifier.notify_stacks_block_processed();
                     increment_stx_blocks_processed_counter();

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -718,7 +718,13 @@ impl<
                 .process_blocks(sortdb_handle, 1, self.dispatcher)?;
 
         while let Some(block_result) = processed_blocks.pop() {
-            if let (Some(block_receipt), _) = block_result {
+            if block_result.0.is_none() && block_result.1.is_none() {
+                // this block was invalid
+                debug!("Bump blocks processed (invalid)");
+                self.notifier.notify_stacks_block_processed();
+                increment_stx_blocks_processed_counter();
+            }
+            else if let (Some(block_receipt), _) = block_result {
                 // only bump the coordinator's state if the processed block
                 //   is in our sortition fork
                 //  TODO: we should update the staging block logic to prevent
@@ -739,6 +745,7 @@ impl<
                     let new_canonical_stacks_block =
                         new_canonical_block_snapshot.get_canonical_stacks_block_id();
                     self.canonical_chain_tip = Some(new_canonical_stacks_block);
+                    
                     debug!("Bump blocks processed");
                     self.notifier.notify_stacks_block_processed();
                     increment_stx_blocks_processed_counter();

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -6028,7 +6028,8 @@ impl StacksChainState {
     /// Process some staging blocks, up to max_blocks.
     /// Return new chain tips, and optionally any poison microblock payloads for each chain tip
     /// found.  For each chain tip produced, return the header info, receipts, parent microblock
-    /// stream execution cost, and block execution cost
+    /// stream execution cost, and block execution cost.  A value of None will be returned for the
+    /// epoch receipt if the block was invalid.
     pub fn process_blocks<'a, T: BlockEventDispatcher>(
         &mut self,
         mut sort_tx: SortitionHandleTx,
@@ -6063,15 +6064,18 @@ impl StacksChainState {
                 },
                 Err(Error::InvalidStacksBlock(msg)) => {
                     warn!("Encountered invalid block: {}", &msg);
+                    ret.push((None, None));
                     continue;
                 }
                 Err(Error::InvalidStacksMicroblock(msg, hash)) => {
                     warn!("Encountered invalid microblock {}: {}", hash, &msg);
+                    ret.push((None, None));
                     continue;
                 }
                 Err(Error::NetError(net_error::DeserializeError(msg))) => {
                     // happens if we load a zero-sized block (i.e. an invalid block)
                     warn!("Encountered invalid block: {}", &msg);
+                    ret.push((None, None));
                     continue;
                 }
                 Err(e) => {

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -2486,7 +2486,7 @@ impl RelayerThread {
             self.last_tenure_consensus_hash = Some(consensus_hash);
         }
 
-        if let Some(miner_tip) = miner_tip.take() {
+        if let Some(mtip) = miner_tip.take() {
             // sanity check -- is this also the canonical tip?
             let (stacks_tip_consensus_hash, stacks_tip_block_hash) =
                 self.with_chainstate(|_relayer_thread, sortdb, _chainstate, _| {
@@ -2495,25 +2495,25 @@ impl RelayerThread {
                     )
                 });
 
-            if miner_tip.consensus_hash != stacks_tip_consensus_hash
-                || miner_tip.block_hash != stacks_tip_block_hash
+            if mtip.consensus_hash != stacks_tip_consensus_hash
+                || mtip.block_hash != stacks_tip_block_hash
             {
                 debug!(
                     "Relayer: miner tip {}/{} is NOT canonical ({}/{})",
-                    &miner_tip.consensus_hash,
-                    &miner_tip.block_hash,
+                    &mtip.consensus_hash,
+                    &mtip.block_hash,
                     &stacks_tip_consensus_hash,
                     &stacks_tip_block_hash
                 );
-                self.miner_tip = None;
+                miner_tip = None;
             } else {
                 debug!(
                     "Relayer: Microblock miner tip is now {}/{} ({})",
-                    miner_tip.consensus_hash,
-                    miner_tip.block_hash,
+                    mtip.consensus_hash,
+                    mtip.block_hash,
                     StacksBlockHeader::make_index_block_hash(
-                        &miner_tip.consensus_hash,
-                        &miner_tip.block_hash
+                        &mtip.consensus_hash,
+                        &mtip.block_hash
                     )
                 );
 
@@ -2522,7 +2522,7 @@ impl RelayerThread {
                     relayer_thread.globals.send_unconfirmed_txs(chainstate);
                 });
 
-                self.miner_tip = Some(miner_tip);
+                miner_tip = Some(mtip);
             }
         }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1632,8 +1632,16 @@ impl BlockMinerThread {
         let microblock_private_key = self.make_microblock_private_key(
             &parent_block_info.stacks_parent_header.index_block_hash(),
         );
-        let mblock_pubkey_hash =
-            Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_private_key));
+        let mblock_pubkey_hash = {
+            let mut pubkh = Hash160::from_node_public_key(&StacksPublicKey::from_private(&microblock_private_key));
+            if cfg!(test) {
+                if let Ok(mblock_pubkey_hash_str) = std::env::var("STACKS_MICROBLOCK_PUBKEY_HASH") {
+                    debug!("Fault injection: set microblock public key hash to {}", &mblock_pubkey_hash_str);
+                    pubkh = Hash160::from_hex(&mblock_pubkey_hash_str).expect(&format!("Malformed fault-injected microblock public key hash '{}'", &mblock_pubkey_hash_str));
+                }
+            }
+            pubkh
+        };
 
         // create our coinbase
         let coinbase_tx = self.inner_generate_coinbase_tx(parent_block_info.coinbase_nonce);
@@ -2185,10 +2193,10 @@ impl RelayerThread {
     /// Return Err(..) if we couldn't reach the chains coordiantor thread
     fn process_new_block(&self) -> Result<bool, Error> {
         // process the block
+        let stacks_blocks_processed = self.globals.coord_comms.get_stacks_blocks_processed();
         if !self.globals.coord_comms.announce_new_stacks_block() {
             return Err(Error::CoordinatorClosed);
         }
-        let stacks_blocks_processed = self.globals.coord_comms.get_stacks_blocks_processed();
         if !self
             .globals
             .coord_comms
@@ -2471,21 +2479,35 @@ impl RelayerThread {
             self.last_tenure_consensus_hash = Some(consensus_hash);
         }
 
-        if let Some(miner_tip) = miner_tip.as_ref() {
-            debug!(
-                "Relayer: Microblock miner tip is now {}/{} ({})",
-                miner_tip.consensus_hash,
-                miner_tip.block_hash,
-                StacksBlockHeader::make_index_block_hash(
-                    &miner_tip.consensus_hash,
-                    &miner_tip.block_hash
-                )
-            );
-
-            self.with_chainstate(|relayer_thread, sortdb, chainstate, _mempool| {
-                Relayer::refresh_unconfirmed(chainstate, sortdb);
-                relayer_thread.globals.send_unconfirmed_txs(chainstate);
+        if let Some(miner_tip) = miner_tip.take() {
+            // sanity check -- is this also the canonical tip?
+            let (stacks_tip_consensus_hash, stacks_tip_block_hash) = self.with_chainstate(|_relayer_thread, sortdb, _chainstate, _| {
+                SortitionDB::get_canonical_stacks_chain_tip_hash(sortdb.conn())
+                    .expect("FATAL: failed to query sortition DB for canonical stacks chain tip hashes")
             });
+
+            if miner_tip.consensus_hash != stacks_tip_consensus_hash || miner_tip.block_hash != stacks_tip_block_hash {
+                debug!("Relayer: miner tip {}/{} is NOT canonical ({}/{})", &miner_tip.consensus_hash, &miner_tip.block_hash, &stacks_tip_consensus_hash, &stacks_tip_block_hash);
+                self.miner_tip = None;
+            }
+            else {
+                debug!(
+                    "Relayer: Microblock miner tip is now {}/{} ({})",
+                    miner_tip.consensus_hash,
+                    miner_tip.block_hash,
+                    StacksBlockHeader::make_index_block_hash(
+                        &miner_tip.consensus_hash,
+                        &miner_tip.block_hash
+                    )
+                );
+
+                self.with_chainstate(|relayer_thread, sortdb, chainstate, _mempool| {
+                    Relayer::refresh_unconfirmed(chainstate, sortdb);
+                    relayer_thread.globals.send_unconfirmed_txs(chainstate);
+                });
+
+                self.miner_tip = Some(miner_tip);
+            }
         }
 
         // update state for microblock mining

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -5014,6 +5014,11 @@ fn microblock_limit_hit_integration_test() {
     let txid_3 = submit_tx(&http_origin, &tx_3);
     let txid_4 = submit_tx(&http_origin, &tx_4);
 
+    eprintln!(
+        "transactions: {},{},{},{}",
+        &txid_1, &txid_2, &txid_3, &txid_4
+    );
+
     sleep_ms(50_000);
 
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
@@ -5024,6 +5029,16 @@ fn microblock_limit_hit_integration_test() {
 
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     sleep_ms(50_000);
+
+    loop {
+        let res = get_account(&http_origin, &addr);
+        if res.nonce < 2 {
+            next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+            sleep_ms(50_000);
+        } else {
+            break;
+        }
+    }
 
     let res = get_account(&http_origin, &addr);
     assert_eq!(res.nonce, 2);

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1150,7 +1150,6 @@ fn bad_microblock_pubkey() {
 
     let mut run_loop = neon::RunLoop::new(conf.clone());
     let blocks_processed = run_loop.get_blocks_processed_arc();
-    let _client = reqwest::blocking::Client::new();
     let channel = run_loop.get_coordinator_channel().unwrap();
 
     thread::spawn(move || run_loop.start(Some(burnchain_config), 0));
@@ -1167,8 +1166,11 @@ fn bad_microblock_pubkey() {
     // second block will be the first mined Stacks block
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
-    // fault injection 
-    env::set_var("STACKS_MICROBLOCK_PUBKEY_HASH", "0000000000000000000000000000000000000000");
+    // fault injection
+    env::set_var(
+        "STACKS_MICROBLOCK_PUBKEY_HASH",
+        "0000000000000000000000000000000000000000",
+    );
     for _i in 0..10 {
         next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     }
@@ -1179,7 +1181,8 @@ fn bad_microblock_pubkey() {
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
 
     let blocks = test_observer::get_blocks();
-    assert!(blocks.len() <= 3);
+    assert!(blocks.len() >= 5);
+    assert!(blocks.len() <= 6);
 
     channel.stop_chains_coordinator();
     test_observer::clear();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1172,6 +1172,7 @@ fn bad_microblock_pubkey() {
     for _i in 0..10 {
         next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     }
+    env::set_var("STACKS_MICROBLOCK_PUBKEY_HASH", "");
 
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);


### PR DESCRIPTION
This fixes #3400.

The root cause was that if the node mined an invalid block for some reason (e.g. due to a duplicate microblock public key hash, which was recently fixed by #3387), the chains coordinator will report that no block has been processed when the node proceeds to process its newly-mined block.  Specifically, the chains coordinator maintains an atomic counter of the number of blocks processed, which today is only incremented when it processes a _valid_ block (but not an _invalid_ block).  Other threads can wake up the coordinator to process a block, and use this counter to wait for the coordinator to finish processing it.

Due to this behavior, the coordinator's processing of an invalid block would _not_ bump this counter.  This, in turn, caused the relayer thread to hang on waiting for the coordinator.

The fix is as follows:

* The coordinator will always increment the blocks-processed counter, even if the block is invalid.
* The relayer will check its miner's tip against the canonical Stacks tip when it finishes processing unhandled blocks, and if they are _different_, it will conclude that there was an invalid block mined and it should not mine microblocks (meaning, it should transition back to attempting to mine Stacks blocks).