### PR TITLE
[Stacks 2.1] Include pox contract in `stx_lock_event` payloads

### DIFF
--- a/clarity/src/vm/events.rs
+++ b/clarity/src/vm/events.rs
@@ -181,6 +181,7 @@ pub struct STXLockEventData {
     pub locked_amount: u128,
     pub unlock_height: u64,
     pub locked_address: PrincipalData,
+    pub contract_identifier: QualifiedContractIdentifier,
 }
 
 impl STXLockEventData {
@@ -189,6 +190,7 @@ impl STXLockEventData {
             "locked_amount": format!("{}",self.locked_amount),
             "unlock_height": format!("{}", self.unlock_height),
             "locked_address": format!("{}", self.locked_address),
+            "contract_identifier": self.contract_identifier.to_string(),
         })
     }
 }

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -217,6 +217,10 @@ fn handle_pox_v1_api_contract_call(
                                     locked_amount,
                                     unlock_height,
                                     locked_address: stacker,
+                                    contract_identifier: boot_code_id(
+                                        "pox",
+                                        global_context.mainnet,
+                                    ),
                                 }),
                             ));
                         }
@@ -668,6 +672,7 @@ fn handle_stack_lockup(
                             locked_amount,
                             unlock_height,
                             locked_address: stacker,
+                            contract_identifier: boot_code_id("pox-2", global_context.mainnet),
                         },
                     ));
                     return Ok(Some(event));
@@ -726,6 +731,7 @@ fn handle_stack_lockup_extension(
                         locked_amount,
                         unlock_height,
                         locked_address: stacker,
+                        contract_identifier: boot_code_id("pox-2", global_context.mainnet),
                     },
                 ));
                 return Ok(Some(event));
@@ -787,6 +793,7 @@ fn handle_stack_lockup_increase(
                         locked_amount: new_balance.amount_locked(),
                         unlock_height: new_balance.unlock_height(),
                         locked_address: stacker,
+                        contract_identifier: boot_code_id("pox-2", global_context.mainnet),
                     },
                 ));
 


### PR DESCRIPTION
Resolves https://github.com/stacks-network/stacks-blockchain/issues/3413

Adds the pox contract ID used to the `stx_lock_event` payloads. This is working as expected in API integration tests. Not sure if it needs test changes in this repo as well. 

This follows the same convention used in the similar `contract_event` payload of including `contract_identifier: string` in the event JSON.