### PR TITLE
Refactor/introduce function name macro in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "stacks-common",
+ "stdext",
  "stx-genesis",
  "time 0.2.27",
  "url",
@@ -2686,6 +2687,12 @@ checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "stdext"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3b6b32ae82412fb897ef134867d53a294f57ba5b758f06d71e865352c3e207"
 
 [[package]]
 name = "stdweb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ features = ["std"]
 [dev-dependencies]
 assert-json-diff = "1.0.0"
 criterion = "0.3.5"
+stdext = "0.3.1"
 stx_genesis = { package = "stx-genesis", path = "./stx-genesis/."}
 clarity = { package = "clarity", features = ["default", "testing"], path = "./clarity/." }
 stacks_common = { package = "stacks-common", features = ["default", "testing"], path = "./stacks-common/." }

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -1081,7 +1081,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, keys) = instantiate_pox_peer(&burnchain, "test-liquid-ustx", 6000);
+        let (mut peer, keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6000);
 
         let num_blocks = 10;
         let mut expected_liquid_ustx = 1024 * POX_THRESHOLD_STEPS_USTX * (keys.len() as u128);
@@ -1150,7 +1150,7 @@ pub mod test {
 
     #[test]
     fn test_lockups() {
-        let mut peer_config = TestPeerConfig::new("test_lockups", 2000, 2001);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2000, 2001);
         let alice = StacksAddress::from_string("STVK1K405H6SK9NKJAP32GHYHDJ98MMNP8Y6Z9N0").unwrap();
         let bob = StacksAddress::from_string("ST76D2FMXZ7D2719PNE4N71KPSX84XCCNCMYC940").unwrap();
         peer_config.initial_lockups = vec![
@@ -1266,8 +1266,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 1;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-hook-special-contract-call", 6007);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6007);
 
         let num_blocks = 15;
 
@@ -1379,7 +1378,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, "test-liquid-ustx", 6026);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6026);
 
         let num_blocks = 10;
         let mut expected_liquid_ustx = 1024 * POX_THRESHOLD_STEPS_USTX * (keys.len() as u128);
@@ -1481,8 +1480,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-single-tx-sender", 6002);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6002);
 
         let num_blocks = 10;
 
@@ -1688,8 +1686,7 @@ pub mod test {
         burnchain.pox_constants.anchor_threshold = 1;
         assert_eq!(burnchain.pox_constants.reward_slots(), 4);
 
-        let (mut peer, keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-single-tx-sender-100", 6026);
+        let (mut peer, keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6026);
 
         let num_blocks = 20;
 
@@ -1944,8 +1941,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-contract", 6018);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6018);
 
         let num_blocks = 10;
 
@@ -2205,8 +2201,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-multi-tx-sender", 6004);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6004);
 
         let num_blocks = 10;
 
@@ -2412,8 +2407,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-no-double-stacking", 6006);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6006);
 
         let num_blocks = 3;
 
@@ -2622,8 +2616,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-single-tx-sender-unlock", 6012);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6012);
 
         let num_blocks = 2;
 
@@ -2857,8 +2850,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-unlock-relock", 6014);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6014);
 
         let num_blocks = 25;
 
@@ -3373,8 +3365,7 @@ pub mod test {
         burnchain.pox_constants.prepare_length = 2;
         burnchain.pox_constants.anchor_threshold = 1;
 
-        let (mut peer, mut keys) =
-            instantiate_pox_peer(&burnchain, "test-pox-lockup-unlock-on-spend", 6016);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6016);
 
         let num_blocks = 20;
 
@@ -3821,7 +3812,7 @@ pub mod test {
         //   owned by charlie.
         burnchain.pox_constants.pox_rejection_fraction = 5;
 
-        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, "test-pox-lockup-reject", 6024);
+        let (mut peer, mut keys) = instantiate_pox_peer(&burnchain, stdext::function_name!(), 6024);
 
         let num_blocks = 15;
 

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -10404,11 +10404,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_get_blocks_inventory_for_reward_cycle() {
-        let mut peer_config = TestPeerConfig::new(
-            "stacks_db_get_blocks_inventory_for_reward_cycle",
-            21313,
-            21314,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 21313, 21314);
 
         let privk = StacksPrivateKey::new();
         let addr = StacksAddress::from_public_keys(
@@ -10700,7 +10696,7 @@ pub mod test {
 
     #[test]
     fn test_get_parent_block_header() {
-        let peer_config = TestPeerConfig::new("test_get_parent_block_header", 21313, 21314);
+        let peer_config = TestPeerConfig::new(stdext::function_name!(), 21313, 21314);
         let mut peer = TestPeer::new(peer_config);
 
         let chainstate_path = peer.chainstate_path.clone();

--- a/src/chainstate/stacks/db/unconfirmed.rs
+++ b/src/chainstate/stacks/db/unconfirmed.rs
@@ -674,11 +674,7 @@ mod test {
         .unwrap();
 
         let initial_balance = 1000000000;
-        let mut peer_config = TestPeerConfig::new(
-            "test_unconfirmed_refresh_one_microblock_stx_transfer",
-            7000,
-            7001,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 7000, 7001);
         peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
 
         let mut peer = TestPeer::new(peer_config);
@@ -902,11 +898,7 @@ mod test {
         .unwrap();
 
         let initial_balance = 1000000000;
-        let mut peer_config = TestPeerConfig::new(
-            "test_unconfirmed_refresh_10_microblocks_10_stx_transfers",
-            7002,
-            7003,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 7002, 7003);
         peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
 
         let mut peer = TestPeer::new(peer_config);
@@ -1138,8 +1130,7 @@ mod test {
         .unwrap();
 
         let initial_balance = 1000000000;
-        let mut peer_config =
-            TestPeerConfig::new("test_unconfirmed_refresh_invalid_microblock", 7004, 7005);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 7004, 7005);
         peer_config.initial_balances = vec![(addr.to_account_principal(), initial_balance)];
         peer_config.epochs = Some(vec![StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -7402,7 +7402,7 @@ pub mod test {
 
     #[test]
     fn test_build_anchored_blocks_empty() {
-        let peer_config = TestPeerConfig::new("test_build_anchored_blocks_empty", 2000, 2001);
+        let peer_config = TestPeerConfig::new(stdext::function_name!(), 2000, 2001);
         let mut peer = TestPeer::new(peer_config);
 
         let chainstate_path = peer.chainstate_path.clone();
@@ -7502,11 +7502,7 @@ pub mod test {
         )
         .unwrap();
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_anchored_blocks_stx_transfers_single",
-            2002,
-            2003,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2002, 2003);
         peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
         let mut peer = TestPeer::new(peer_config);
@@ -7643,11 +7639,7 @@ pub mod test {
         )
         .unwrap();
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_anchored_blocks_empty_with_builder_timeout",
-            2022,
-            2023,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2022, 2023);
         peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
         let mut peer = TestPeer::new(peer_config);
@@ -7786,8 +7778,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), 100000000));
         }
 
-        let mut peer_config =
-            TestPeerConfig::new("test_build_anchored_blocks_stx_transfers_multi", 2004, 2005);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2004, 2005);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -7952,11 +7943,7 @@ pub mod test {
         )
         .unwrap();
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_anchored_blocks_connected_by_microblocks_across_epoch",
-            2016,
-            2017,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2016, 2017);
         peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
         let epochs = vec![
@@ -8193,11 +8180,7 @@ pub mod test {
         )
         .unwrap();
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid",
-            2018,
-            2019,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2018, 2019);
         peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
         let epochs = vec![
@@ -8524,7 +8507,7 @@ pub mod test {
             .map(|addr| (addr.to_account_principal(), 100000000000))
             .collect();
 
-        let mut peer_config = TestPeerConfig::new("build_anchored_incrementing_nonces", 2030, 2031);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2030, 2031);
         peer_config.initial_balances = initial_balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -8692,8 +8675,7 @@ pub mod test {
         initial_balances.push((addr.to_account_principal(), 100000000000));
         initial_balances.push((addr_extra.to_account_principal(), 200000000000));
 
-        let mut peer_config =
-            TestPeerConfig::new("test_build_anchored_blocks_skip_too_expensive", 2006, 2007);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2006, 2007);
         peer_config.initial_balances = initial_balances;
         peer_config.epochs = Some(vec![StacksEpoch {
             epoch_id: StacksEpochId::Epoch20,
@@ -8905,8 +8887,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), 100000000));
         }
 
-        let mut peer_config =
-            TestPeerConfig::new("test_build_anchored_blocks_multiple_chaintips", 2008, 2009);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2008, 2009);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -9058,8 +9039,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), 100000000));
         }
 
-        let mut peer_config =
-            TestPeerConfig::new("test_build_anchored_blocks_empty_chaintips", 2010, 2011);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2010, 2011);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -9202,11 +9182,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), 100000000));
         }
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_anchored_blocks_too_expensive_transactions",
-            2013,
-            2014,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2013, 2014);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -9360,7 +9336,7 @@ pub mod test {
 
     #[test]
     fn test_build_anchored_blocks_invalid() {
-        let peer_config = TestPeerConfig::new("test_build_anchored_blocks_invalid", 2014, 2015);
+        let peer_config = TestPeerConfig::new(stdext::function_name!(), 2014, 2015);
         let mut peer = TestPeer::new(peer_config);
 
         let chainstate_path = peer.chainstate_path.clone();
@@ -9574,11 +9550,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), 100000000));
         }
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_anchored_blocks_too_expensive_transactions",
-            2012,
-            2013,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2012, 2013);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -9847,7 +9819,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), initial_balance));
         }
 
-        let mut peer_config = TestPeerConfig::new("test_build_microblock_stream_forks", 2014, 2015);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2014, 2015);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -10147,11 +10119,7 @@ pub mod test {
             balances.push((addr.to_account_principal(), initial_balance));
         }
 
-        let mut peer_config = TestPeerConfig::new(
-            "test_build_microblock_stream_forks_with_descendants",
-            2014,
-            2015,
-        );
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2014, 2015);
         peer_config.initial_balances = balances;
 
         let mut peer = TestPeer::new(peer_config);
@@ -10672,7 +10640,7 @@ pub mod test {
         initial_balances.push((addr.to_account_principal(), 100000000000));
         initial_balances.push((addr_extra.to_account_principal(), 200000000000));
 
-        let mut peer_config = TestPeerConfig::new("test_is_tx_problematic", 2018, 2019);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2018, 2019);
         peer_config.initial_balances = initial_balances;
         peer_config.epochs = Some(vec![
             StacksEpoch {
@@ -11137,8 +11105,7 @@ pub mod test {
         )
         .unwrap();
 
-        let mut peer_config =
-            TestPeerConfig::new("test_fee_order_mismatch_nonce_order", 2002, 2003);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 2002, 2003);
         peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
         let mut peer = TestPeer::new(peer_config);

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -2622,8 +2622,8 @@ pub mod test {
     #[test]
     fn test_get_block_availability() {
         with_timeout(600, || {
-            let mut peer_1_config = TestPeerConfig::new("test_get_block_availability", 3210, 3211);
-            let mut peer_2_config = TestPeerConfig::new("test_get_block_availability", 3212, 3213);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 3210, 3211);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 3212, 3213);
 
             // don't bother downloading blocks
             peer_1_config.connection_opts.disable_block_download = true;
@@ -3081,7 +3081,7 @@ pub mod test {
     pub fn test_get_blocks_and_microblocks_2_peers_download_plain() {
         with_timeout(600, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_2_peers_download_plain",
+                stdext::function_name!(),
                 3200,
                 2,
                 |ref mut peer_configs| {
@@ -3162,7 +3162,7 @@ pub mod test {
     pub fn test_get_blocks_and_microblocks_5_peers_star() {
         with_timeout(600, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_5_peers_star",
+                stdext::function_name!(),
                 3210,
                 5,
                 |ref mut peer_configs| {
@@ -3238,7 +3238,7 @@ pub mod test {
     pub fn test_get_blocks_and_microblocks_5_peers_line() {
         with_timeout(600, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_5_peers_line",
+                stdext::function_name!(),
                 3220,
                 5,
                 |ref mut peer_configs| {
@@ -3313,7 +3313,7 @@ pub mod test {
     pub fn test_get_blocks_and_microblocks_overwhelmed_connections() {
         with_timeout(600, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_overwhelmed_connections",
+                stdext::function_name!(),
                 3230,
                 5,
                 |ref mut peer_configs| {
@@ -3397,7 +3397,7 @@ pub mod test {
         // this one can go for a while
         with_timeout(1200, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_overwhelmed_sockets",
+                stdext::function_name!(),
                 3240,
                 5,
                 |ref mut peer_configs| {
@@ -3494,7 +3494,7 @@ pub mod test {
         });
 
         run_get_blocks_and_microblocks(
-            "test_get_blocks_and_microblocks_ban_url",
+            stdext::function_name!(),
             3250,
             2,
             |ref mut peer_configs| {
@@ -3568,7 +3568,7 @@ pub mod test {
     pub fn test_get_blocks_and_microblocks_2_peers_download_multiple_microblock_descendants() {
         with_timeout(600, || {
             run_get_blocks_and_microblocks(
-                "test_get_blocks_and_microblocks_2_peers_download_multiple_microblock_descendants",
+                stdext::function_name!(),
                 3260,
                 2,
                 |ref mut peer_configs| {

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3156,16 +3156,8 @@ mod test {
 
     #[test]
     fn test_sync_inv_set_blocks_microblocks_available() {
-        let mut peer_1_config = TestPeerConfig::new(
-            "test_sync_inv_set_blocks_microblocks_available",
-            31981,
-            41981,
-        );
-        let mut peer_2_config = TestPeerConfig::new(
-            "test_sync_inv_set_blocks_microblocks_available",
-            31982,
-            41982,
-        );
+        let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 31981, 41981);
+        let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 31982, 41982);
 
         peer_1_config.burnchain.first_block_height = 5;
         peer_2_config.burnchain.first_block_height = 5;
@@ -3342,7 +3334,7 @@ mod test {
 
     #[test]
     fn test_sync_inv_make_inv_messages() {
-        let peer_1_config = TestPeerConfig::new("test_sync_inv_make_inv_messages", 31985, 41986);
+        let peer_1_config = TestPeerConfig::new(stdext::function_name!(), 31985, 41986);
 
         let reward_cycle_length = peer_1_config.burnchain.pox_constants.reward_cycle_length;
         let num_blocks = peer_1_config.burnchain.pox_constants.reward_cycle_length * 2;
@@ -3768,7 +3760,7 @@ mod test {
 
     #[test]
     fn test_sync_inv_diagnose_nack() {
-        let peer_config = TestPeerConfig::new("test_sync_inv_diagnose_nack", 31983, 41983);
+        let peer_config = TestPeerConfig::new(stdext::function_name!(), 31983, 41983);
         let neighbor = peer_config.to_neighbor();
         let neighbor_key = neighbor.addr.clone();
         let nack_no_block = NackData {
@@ -3874,10 +3866,8 @@ mod test {
     #[ignore]
     fn test_sync_inv_2_peers_plain() {
         with_timeout(600, || {
-            let mut peer_1_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_plain", 31992, 41992);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_plain", 31993, 41993);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 31992, 41992);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 31993, 41993);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
@@ -4052,10 +4042,8 @@ mod test {
     #[ignore]
     fn test_sync_inv_2_peers_stale() {
         with_timeout(600, || {
-            let mut peer_1_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_stale", 31994, 41995);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_stale", 31995, 41996);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 31994, 41995);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 31995, 41996);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
@@ -4162,10 +4150,8 @@ mod test {
     #[ignore]
     fn test_sync_inv_2_peers_unstable() {
         with_timeout(600, || {
-            let mut peer_1_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_unstable", 31996, 41997);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_unstable", 31997, 41998);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 31996, 41997);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 31997, 41998);
 
             let stable_confs = peer_1_config.burnchain.stable_confirmations as u64;
 
@@ -4377,10 +4363,8 @@ mod test {
     #[ignore]
     fn test_sync_inv_2_peers_different_pox_vectors() {
         with_timeout(600, || {
-            let mut peer_1_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_different_pox_vectors", 31998, 41998);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_sync_inv_2_peers_different_pox_vectors", 31999, 41999);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 31998, 41998);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 31999, 41999);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2659,8 +2659,10 @@ pub mod test {
 
                         let smart_contract =
                             TransactionPayload::SmartContract(TransactionSmartContract {
-                                name: ContractName::try_from(conf.test_name.as_str())
-                                    .expect("FATAL: invalid boot-code contract name"),
+                                name: ContractName::try_from(
+                                    conf.test_name.replace("::", "-").to_string(),
+                                )
+                                .expect("FATAL: invalid boot-code contract name"),
                                 code_body: StacksString::from_str(&conf.setup_code)
                                     .expect("FATAL: invalid boot code body"),
                             });

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -5733,8 +5733,8 @@ mod test {
         with_timeout(600, || {
             // peer 1 gets some transactions; verify peer 2 gets the recent ones and not the old
             // ones
-            let mut peer_1_config = TestPeerConfig::new("test_mempool_sync_2_peers", 2210, 2211);
-            let mut peer_2_config = TestPeerConfig::new("test_mempool_sync_2_peers", 2212, 2213);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 2210, 2211);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 2212, 2213);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
@@ -5996,10 +5996,8 @@ mod test {
     fn test_mempool_sync_2_peers_paginated() {
         with_timeout(600, || {
             // peer 1 gets some transactions; verify peer 2 gets them all
-            let mut peer_1_config =
-                TestPeerConfig::new("test_mempool_sync_2_peers_paginated", 2214, 2215);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_mempool_sync_2_peers_paginated", 2216, 2217);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 2214, 2215);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 2216, 2217);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
@@ -6188,10 +6186,8 @@ mod test {
         with_timeout(600, || {
             // peer 1 gets some transactions; peer 2 blacklists some of them;
             // verify peer 2 gets only the non-blacklisted ones.
-            let mut peer_1_config =
-                TestPeerConfig::new("test_mempool_sync_2_peers_blacklisted", 2218, 2219);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_mempool_sync_2_peers_blacklisted", 2220, 2221);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 2218, 2219);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 2220, 2221);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
@@ -6401,10 +6397,8 @@ mod test {
         with_timeout(600, || {
             // peer 1 gets some transactions; peer 2 blacklists them all due to being invalid.
             // verify peer 2 stores nothing.
-            let mut peer_1_config =
-                TestPeerConfig::new("test_mempool_sync_2_peers_problematic", 2218, 2219);
-            let mut peer_2_config =
-                TestPeerConfig::new("test_mempool_sync_2_peers_problematic", 2220, 2221);
+            let mut peer_1_config = TestPeerConfig::new(stdext::function_name!(), 2218, 2219);
+            let mut peer_2_config = TestPeerConfig::new(stdext::function_name!(), 2220, 2221);
 
             peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
             peer_2_config.add_neighbor(&peer_1_config.to_neighbor());

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -4802,8 +4802,7 @@ pub mod test {
 
         let initial_balances = vec![(addr.to_account_principal(), 100000000000)];
 
-        let mut peer_config =
-            TestPeerConfig::new("process_new_blocks_rejects_problematic_asts", 32019, 32020);
+        let mut peer_config = TestPeerConfig::new(stdext::function_name!(), 32019, 32020);
         peer_config.initial_balances = initial_balances;
         peer_config.epochs = Some(vec![
             StacksEpoch {

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -4089,7 +4089,7 @@ mod test {
         let peer_server_info = RefCell::new(None);
         let client_stacks_height = 17;
         test_rpc(
-            "test_rpc_getinfo",
+            stdext::function_name!(),
             40000,
             40001,
             50000,
@@ -4157,7 +4157,7 @@ mod test {
         // Thus, the query for pox info will be against the canonical Stacks tip, which we expect to succeed.
         let pox_server_info = RefCell::new(None);
         test_rpc(
-            "test_rpc_getpoxinfo",
+            stdext::function_name!(),
             40002,
             40003,
             50002,
@@ -4215,7 +4215,7 @@ mod test {
         // info against the unconfirmed state will succeed.
         let pox_server_info = RefCell::new(None);
         test_rpc(
-            "test_rpc_getpoxinfo_use_latest_tip",
+            stdext::function_name!(),
             40004,
             40005,
             50004,
@@ -4268,7 +4268,7 @@ mod test {
     #[ignore]
     fn test_rpc_getneighbors() {
         test_rpc(
-            "test_rpc_getneighbors",
+            stdext::function_name!(),
             40010,
             40011,
             50010,
@@ -4311,7 +4311,7 @@ mod test {
         let server_blocks_cell = RefCell::new(None);
 
         test_rpc(
-            "test_rpc_getheaders",
+            stdext::function_name!(),
             40012,
             40013,
             50012,
@@ -4404,7 +4404,7 @@ mod test {
         let server_block_cell = RefCell::new(None);
 
         test_rpc(
-            "test_rpc_unconfirmed_getblock",
+            stdext::function_name!(),
             40020,
             40021,
             50020,
@@ -4467,7 +4467,7 @@ mod test {
         let server_block_cell = RefCell::new(None);
 
         test_rpc(
-            "test_rpc_confirmed_getblock",
+            stdext::function_name!(),
             40030,
             40031,
             50030,
@@ -4536,7 +4536,7 @@ mod test {
         let server_microblocks_cell = RefCell::new(vec![]);
 
         test_rpc(
-            "test_rpc_indexed_microblocks",
+            stdext::function_name!(),
             40040,
             40041,
             50040,
@@ -4654,7 +4654,7 @@ mod test {
         let server_microblocks_cell = RefCell::new(vec![]);
 
         test_rpc(
-            "test_rpc_confirmed_microblocks",
+            stdext::function_name!(),
             40042,
             40043,
             50042,
@@ -4768,7 +4768,7 @@ mod test {
         let server_microblocks_cell = RefCell::new(vec![]);
 
         test_rpc(
-            "test_rpc_unconfirmed_microblocks",
+            stdext::function_name!(),
             40050,
             40051,
             50050,
@@ -4837,7 +4837,7 @@ mod test {
         let last_mblock = RefCell::new(BlockHeaderHash([0u8; 32]));
 
         test_rpc(
-            "test_rpc_unconfirmed_transaction",
+            stdext::function_name!(),
             40052,
             40053,
             50052,
@@ -4915,7 +4915,7 @@ mod test {
     #[ignore]
     fn test_rpc_missing_getblock() {
         test_rpc(
-            "test_rpc_missing_getblock",
+            stdext::function_name!(),
             40060,
             40061,
             50060,
@@ -4957,7 +4957,7 @@ mod test {
     #[ignore]
     fn test_rpc_missing_index_getmicroblocks() {
         test_rpc(
-            "test_rpc_missing_index_getmicroblocks",
+            stdext::function_name!(),
             40070,
             40071,
             50070,
@@ -4999,7 +4999,7 @@ mod test {
     #[ignore]
     fn test_rpc_missing_confirmed_getmicroblocks() {
         test_rpc(
-            "test_rpc_missing_confirmed_getmicroblocks",
+            stdext::function_name!(),
             40072,
             40073,
             50072,
@@ -5043,7 +5043,7 @@ mod test {
         let server_microblocks_cell = RefCell::new(vec![]);
 
         test_rpc(
-            "test_rpc_missing_unconfirmed_microblocks",
+            stdext::function_name!(),
             40080,
             40081,
             50080,
@@ -5107,7 +5107,7 @@ mod test {
         // The contract source we are querying for exists in the anchored state, so we expect the
         // query to succeed.
         test_rpc(
-            "test_rpc_get_contract_src",
+            stdext::function_name!(),
             40090,
             40091,
             50090,
@@ -5155,7 +5155,7 @@ mod test {
         // The contract source we are querying for only exists in the unconfirmed state, so we
         // expect the query to fail.
         test_rpc(
-            "test_rpc_get_contract_src_unconfirmed_with_canonical_tip",
+            stdext::function_name!(),
             40100,
             40101,
             50100,
@@ -5202,7 +5202,7 @@ mod test {
         // The contract source we are querying for exists in the unconfirmed state, so we expect
         // the query to succeed.
         test_rpc(
-            "test_rpc_get_contract_src_with_unconfirmed_tip",
+            stdext::function_name!(),
             40102,
             40103,
             50102,
@@ -5256,7 +5256,7 @@ mod test {
         // The contract source we are querying for exists in the unconfirmed state, so we expect
         // the query to succeed.
         test_rpc(
-            "test_rpc_get_contract_src_use_latest_tip",
+            stdext::function_name!(),
             40104,
             40105,
             50104,
@@ -5299,7 +5299,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_account() {
         test_rpc(
-            "test_rpc_get_account",
+            stdext::function_name!(),
             40110,
             40111,
             50110,
@@ -5347,7 +5347,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_account_use_latest_tip() {
         test_rpc(
-            "test_rpc_get_account_use_latest_tip",
+            stdext::function_name!(),
             40112,
             40113,
             50112,
@@ -5396,7 +5396,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_account_use_latest_tip_no_microblocks() {
         test_rpc(
-            "test_rpc_get_account",
+            stdext::function_name!(),
             40114,
             40115,
             50114,
@@ -5441,7 +5441,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_account_unconfirmed() {
         test_rpc(
-            "test_rpc_get_account_unconfirmed",
+            stdext::function_name!(),
             40120,
             40121,
             50120,
@@ -5493,7 +5493,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_data_var() {
         test_rpc(
-            "test_rpc_get_data_var",
+            stdext::function_name!(),
             40122,
             40123,
             50122,
@@ -5540,7 +5540,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_data_var_unconfirmed() {
         test_rpc(
-            "test_rpc_get_data_var_unconfirmed",
+            stdext::function_name!(),
             40124,
             40125,
             50124,
@@ -5594,7 +5594,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_data_var_nonexistant() {
         test_rpc(
-            "test_rpc_get_data_var_nonexistant",
+            stdext::function_name!(),
             40125,
             40126,
             50125,
@@ -5641,7 +5641,7 @@ mod test {
         // In this test, we don't set any tip parameters, and we expect that querying for map data
         // against the canonical Stacks tip will succeed.
         test_rpc(
-            "test_rpc_get_map_entry",
+            stdext::function_name!(),
             40130,
             40131,
             50130,
@@ -5703,7 +5703,7 @@ mod test {
         // In this test, we set `tip_req` to UseLatestUnconfirmedTip, and we expect that querying for map data
         // against the unconfirmed state will succeed.
         test_rpc(
-            "test_rpc_get_map_entry_unconfirmed",
+            stdext::function_name!(),
             40140,
             40141,
             50140,
@@ -5769,7 +5769,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_map_entry_use_latest_tip() {
         test_rpc(
-            "test_rpc_get_map_entry_use_latest_tip",
+            stdext::function_name!(),
             40142,
             40143,
             50142,
@@ -5831,7 +5831,7 @@ mod test {
         // In this test, we don't set any tip parameters, and we expect that querying
         // against the canonical Stacks tip will succeed.
         test_rpc(
-            "test_rpc_get_contract_abi",
+            stdext::function_name!(),
             40150,
             40151,
             50150,
@@ -5876,7 +5876,7 @@ mod test {
         // In this test, we set `tip_req` to UseLatestUnconfirmedTip, and we expect that querying
         // against the unconfirmed state will succeed.
         test_rpc(
-            "test_rpc_get_contract_abi_unconfirmed",
+            stdext::function_name!(),
             40152,
             40153,
             50152,
@@ -5922,7 +5922,7 @@ mod test {
     #[ignore]
     fn test_rpc_get_contract_abi_use_latest_tip() {
         test_rpc(
-            "test_rpc_get_contract_abi_use_latest_tip",
+            stdext::function_name!(),
             40154,
             40155,
             50154,
@@ -5964,7 +5964,7 @@ mod test {
         // In this test, we don't set any tip parameters, and we expect that querying
         // against the canonical Stacks tip will succeed.
         test_rpc(
-            "test_rpc_call_read_only",
+            stdext::function_name!(),
             40170,
             40171,
             50170,
@@ -6017,7 +6017,7 @@ mod test {
         // In this test, we set `tip_req` to UseLatestUnconfirmedTip, and we expect that querying
         // against the unconfirmed state will succeed.
         test_rpc(
-            "test_rpc_call_read_only_use_latest_tip",
+            stdext::function_name!(),
             40172,
             40173,
             50172,
@@ -6070,7 +6070,7 @@ mod test {
     #[ignore]
     fn test_rpc_call_read_only_unconfirmed() {
         test_rpc(
-            "test_rpc_call_read_only_unconfirmed",
+            stdext::function_name!(),
             40180,
             40181,
             50180,
@@ -6130,7 +6130,7 @@ mod test {
     #[ignore]
     fn test_rpc_getattachmentsinv_limit_reached() {
         test_rpc(
-            "test_rpc_getattachmentsinv",
+            stdext::function_name!(),
             40190,
             40191,
             50190,
@@ -6169,7 +6169,7 @@ mod test {
     #[ignore]
     fn test_rpc_mempool_query_txtags() {
         test_rpc(
-            "test_rpc_mempool_query_txtags",
+            stdext::function_name!(),
             40813,
             40814,
             50813,
@@ -6208,7 +6208,7 @@ mod test {
     #[ignore]
     fn test_rpc_mempool_query_bloom() {
         test_rpc(
-            "test_rpc_mempool_query_bloom",
+            stdext::function_name!(),
             40815,
             40816,
             50815,

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -885,7 +885,7 @@ mod test {
     #[test]
     fn test_http_getinfo() {
         test_http_server(
-            "test_http_getinfo",
+            stdext::function_name!(),
             51000,
             51001,
             ConnectionOptions::default(),
@@ -915,7 +915,7 @@ mod test {
     #[ignore]
     fn test_http_10_threads_getinfo() {
         test_http_server(
-            "test_http_10_threads_getinfo",
+            stdext::function_name!(),
             51010,
             51011,
             ConnectionOptions::default(),
@@ -944,7 +944,7 @@ mod test {
     #[test]
     fn test_http_getblock() {
         test_http_server(
-            "test_http_getblock",
+            stdext::function_name!(),
             51020,
             51021,
             ConnectionOptions::default(),
@@ -1008,7 +1008,7 @@ mod test {
     #[ignore]
     fn test_http_10_threads_getblock() {
         test_http_server(
-            "test_http_getblock",
+            stdext::function_name!(),
             51030,
             51031,
             ConnectionOptions::default(),
@@ -1079,7 +1079,7 @@ mod test {
         let have_error = RefCell::new(false);
 
         test_http_server(
-            "test_http_too_many_clients",
+            stdext::function_name!(),
             51040,
             51041,
             conn_opts,
@@ -1135,7 +1135,7 @@ mod test {
         conn_opts.timeout = 3; // kill a connection after 3 seconds of idling
 
         test_http_server(
-            "test_http_slow_client",
+            stdext::function_name!(),
             51050,
             51051,
             conn_opts,
@@ -1169,7 +1169,7 @@ mod test {
     fn test_http_endless_data_client() {
         let conn_opts = ConnectionOptions::default();
         test_http_server(
-            "test_http_endless_data_client",
+            stdext::function_name!(),
             51060,
             51061,
             conn_opts,
@@ -1242,7 +1242,7 @@ mod test {
     #[test]
     fn test_http_400() {
         test_http_server(
-            "test_http_400",
+            stdext::function_name!(),
             51070,
             51071,
             ConnectionOptions::default(),
@@ -1269,7 +1269,7 @@ mod test {
     #[test]
     fn test_http_404() {
         test_http_server(
-            "test_http_404",
+            stdext::function_name!(),
             51072,
             51073,
             ConnectionOptions::default(),
@@ -1301,7 +1301,7 @@ mod test {
         conn_opts.connect_timeout = 10;
 
         let num_events = test_http_server(
-            "test_http_no_connecting_event_id_leak",
+            stdext::function_name!(),
             51082,
             51083,
             conn_opts,
@@ -1341,7 +1341,7 @@ mod test {
         // doesn't do anything; just runs a server for 10 minutes
         let conn_opts = ConnectionOptions::default();
         test_http_server(
-            "test_http_noop",
+            stdext::function_name!(),
             51080,
             51081,
             conn_opts,


### PR DESCRIPTION
This PR does three things:
1. Introducing `stdext` as a dev dependency.
2. Replacing hard-coded test names with `stdext::function_name!()`[^1].
3. A minor change in `TestPeer::new_with_observer()` : Replace `::` with `-` in ContractName construction.

[^1]: This gives us the fully qualified function names. e.g. the function `test_pox_lockup_contract` is now identified as `blockstack_lib::chainstate::stacks::boot::test::test_pox_lockup_contract`.
