### PR TITLE
fix: resolve regressions in Clarity1 type-checking

### DIFF
--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -921,7 +921,7 @@ impl TypeSignature {
                         CallableSubtype::Trait(_) => {
                             all_principals = false;
                         }
-                        _ => (),
+                        CallableSubtype::Principal(_) => (),
                     }
                 }
                 if all_principals {


### PR DESCRIPTION
Fixes: #3426