### PR TITLE
Fix: more hardcoded test names

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ $ cargo build
 $ cargo test testnet  -- --test-threads=1
 ```
 
+**Run all unit tests in parallel using [nextest](https://nexte.st/):**
+
+_Warning, this typically takes a few minutes_
+```bash
+$ cargo nextest run
+```
+
 ## Run the testnet
 
 You can observe the state machine in action locally by running:

--- a/src/chainstate/stacks/db/accounts.rs
+++ b/src/chainstate/stacks/db/accounts.rs
@@ -1366,7 +1366,7 @@ mod test {
 
     #[test]
     fn get_tip_ancestor() {
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "get_tip_ancestor_test");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let miner_1 =
             StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
@@ -1440,8 +1440,7 @@ mod test {
 
     #[test]
     fn load_store_miner_payment_schedule() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "load_store_miner_payment_schedule");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let miner_1 =
             StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();
@@ -1505,11 +1504,7 @@ mod test {
 
     #[test]
     fn load_store_miner_payment_schedule_pay_contract() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "load_store_miner_payment_schedule_pay_contract",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let miner_1 =
             StacksAddress::from_string(&"SP1A2K3ENNA6QQ7G8DVJXM24T6QMBDVS7D0TRTAR5".to_string())
                 .unwrap();

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -12045,8 +12045,7 @@ pub mod test {
     /// there are empty sortitions.
     #[test]
     fn test_get_stacking_and_transfer_and_delegate_burn_ops_v210() {
-        let mut peer_config =
-            TestPeerConfig::new("test_stacking_and_transfer_burn_ops_v210", 21315, 21316);
+        let mut peer_config = TestPeerConfig::new(function_name!(), 21315, 21316);
         let num_blocks = 10;
 
         let privk = StacksPrivateKey::from_hex(
@@ -12360,11 +12359,7 @@ pub mod test {
     /// between when they are mined and when the next Stacks block is mined.
     #[test]
     fn test_get_stacking_and_transfer_and_delegate_burn_ops_v210_expiration() {
-        let mut peer_config = TestPeerConfig::new(
-            "test_stacking_and_transfer_burn_ops_v210_expiration",
-            21317,
-            21318,
-        );
+        let mut peer_config = TestPeerConfig::new(function_name!(), 21317, 21318);
         let num_blocks = 20;
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -7981,8 +7981,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_block_load_store_empty() {
-        let chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_block_load_store_empty");
+        let chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let path = StacksChainState::get_block_path(
             &chainstate.blocks_path,
@@ -8026,8 +8025,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_block_load_store() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_block_load_store");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -8188,11 +8186,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_block_load_store_accept() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_block_load_store_accept",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -8243,11 +8237,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_block_load_store_reject() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_block_load_store_reject",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -8298,8 +8288,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_load_store_microblock_stream() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_load_store_microblock_stream");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -8359,11 +8348,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_microblock_stream_load_store_confirm_all() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_microblock_stream_load_store_confirm_all",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -8584,11 +8569,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_microblock_stream_load_store_partial_confirm() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_microblock_stream_load_store_partial_confirm",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -8846,11 +8827,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_microblock_stream_load_continuous_streams() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_microblock_stream_load_continuous_streams",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -9296,11 +9273,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_block_load_store_accept_attachable() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_block_load_store_accept_attachable",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -9436,11 +9409,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_block_load_store_accept_attachable_reversed() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stx_db_staging_block_load_store_accept_attachable_r",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -9577,11 +9546,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_block_load_store_accept_attachable_fork() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stx_db_staging_block_load_store_accept_attachable_f",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -9763,11 +9728,7 @@ pub mod test {
     #[test]
     fn stacks_db_staging_microblocks_multiple_descendants() {
         // multiple anchored blocks build off of different microblock parents
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_microblocks_multiple_descendants",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -9903,8 +9864,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_staging_blocks_orphaned() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_staging_blocks_orphaned");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -10074,8 +10034,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_drop_staging_microblocks() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_drop_staging_microblocks_1");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -10166,8 +10125,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_has_blocks_and_microblocks() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_has_blocks_and_microblocks");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -10510,7 +10468,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_stream_blocks() {
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "stacks_db_stream_blocks");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -10590,7 +10548,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_stream_headers() {
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "stacks_db_stream_headers");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -10843,8 +10801,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_stream_staging_microblocks() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_stream_staging_microblocks");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -10962,8 +10919,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_stream_confirmed_microblocks() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_stream_confirmed_microblocks");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -11075,8 +11031,7 @@ pub mod test {
 
     #[test]
     fn stacks_db_get_blocks_inventory() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_get_blocks_inventory");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let mut blocks: Vec<StacksBlock> = vec![];
         let mut privks = vec![];
@@ -11719,8 +11674,7 @@ pub mod test {
     #[test]
     fn stacks_db_staging_microblocks_fork() {
         // multiple anchored blocks build off of a forked microblock stream
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "stacks_db_staging_microblocks_fork");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )
@@ -11880,11 +11834,7 @@ pub mod test {
     fn stacks_db_staging_microblocks_multiple_forks() {
         // multiple anchored blocks build off of a microblock stream that gets forked multiple
         // times
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "stacks_db_staging_microblocks_multiple_fork",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         let privk = StacksPrivateKey::from_hex(
             "eb05c83546fdd2c79f10f5ad5434a90dd28f7e3acb7c092157aa1bc3656b012c01",
         )

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -2577,7 +2577,7 @@ pub mod test {
 
     #[test]
     fn test_instantiate_chainstate() {
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "instantiate-chainstate");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // verify that the boot code is there
         let mut conn = chainstate.block_begin(
@@ -2653,7 +2653,7 @@ pub mod test {
             })),
         };
 
-        let path = chainstate_path("genesis-consistency-chainstate-test");
+        let path = chainstate_path(function_name!());
         match fs::metadata(&path) {
             Ok(_) => {
                 fs::remove_dir_all(&path).unwrap();
@@ -2743,7 +2743,7 @@ pub mod test {
             })),
         };
 
-        let path = chainstate_path("genesis-consistency-chainstate");
+        let path = chainstate_path(function_name!());
         match fs::metadata(&path) {
             Ok(_) => {
                 fs::remove_dir_all(&path).unwrap();

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -1446,8 +1446,7 @@ pub mod test {
 
     #[test]
     fn process_token_transfer_stx_transaction() {
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-token-transfer-stx-transaction");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -1580,11 +1579,7 @@ pub mod test {
 
     #[test]
     fn process_token_transfer_stx_transaction_invalid() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "process-token-transfer-stx-transaction-invalid",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -1784,11 +1779,7 @@ pub mod test {
 
     #[test]
     fn process_token_transfer_stx_sponsored_transaction() {
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "process-token-transfer-stx-sponsored-transaction",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk_origin = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -1894,8 +1885,7 @@ pub mod test {
         (define-public (set-bar (x int) (y int))
           (begin (var-set bar (/ x y)) (ok (var-get bar))))";
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-smart-contract-transaction");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -1977,11 +1967,7 @@ pub mod test {
         (define-public (set-bar (x int) (y int))
           (begin (var-set bar (/ x y)) (ok (var-get bar))))";
 
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "process-smart-contract-transaction-invalid",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -2091,11 +2077,7 @@ pub mod test {
           (begin (var-set bar (/ x y)) (ok (var-get bar))))
         (begin (set-bar 1 0) (ok 1))";
 
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "process-smart-contract-transaction-runtime-error",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -2184,8 +2166,7 @@ pub mod test {
         (define-public (set-bar (x int) (y int))
           (begin (var-set bar (/ x y)) (ok (var-get bar))))";
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-smart-contract-sponsored-tx");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk_origin = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -2280,7 +2261,7 @@ pub mod test {
         (define-public (set-bar (x int) (y int))
           (begin (var-set bar (/ x y)) (ok (var-get bar))))";
 
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "process-contract-cc-tx");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // contract instantiation
         let privk = StacksPrivateKey::from_hex(
@@ -2414,7 +2395,7 @@ pub mod test {
         (define-data-var savedContract principal tx-sender)
         (define-public (save (contract principal)) (ok (var-set savedContract contract)))";
 
-        let mut chainstate = instantiate_chainstate(false, 0x80000000, "process-contract-cc-tx");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // contract instantiation
         let privk = StacksPrivateKey::from_hex(
@@ -2558,11 +2539,7 @@ pub mod test {
           (begin (var-set bar (/ x y)) (ok (var-get bar))))
         (define-public (return-error) (err 1))";
 
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "process-smart-contract-call-runtime-error",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // contract instantiation
         let privk = StacksPrivateKey::from_hex(
@@ -2683,8 +2660,7 @@ pub mod test {
     fn process_smart_contract_user_aborts_2257() {
         let contract = "(asserts! false (err 1))";
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-smart-contract-user-aborts");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // contract instantiation
         let privk = StacksPrivateKey::from_hex(
@@ -2745,8 +2721,7 @@ pub mod test {
         (define-public (set-bar (x int) (y int))
           (begin (var-set bar (/ x y)) (ok (var-get bar))))";
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-contract-cc-invalid");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // contract instantiation
         let privk = StacksPrivateKey::from_hex(
@@ -2973,8 +2948,7 @@ pub mod test {
         (define-public (set-bar (x int) (y int))
           (begin (var-set bar (/ x y)) (ok (var-get bar))))";
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-contract-cc-sponsored");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         // contract instantiation
         let privk = StacksPrivateKey::from_hex(
@@ -3582,8 +3556,7 @@ pub mod test {
             nonce += 1;
         }
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-post-conditions-tokens");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         for (dbi, burn_db) in ALL_BURN_DBS.iter().enumerate() {
             // make sure costs-3 is instantiated, so as-contract works in 2.1
@@ -4306,8 +4279,7 @@ pub mod test {
             recv_nonce += 1;
         }
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "process-post-conditions-tokens-deny");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         for (dbi, burn_db) in ALL_BURN_DBS.iter().enumerate() {
             // make sure costs-3 is installed so as-contract will work in epoch 2.1
@@ -4684,11 +4656,7 @@ pub mod test {
         signer.sign_origin(&privk_origin).unwrap();
         let contract_call_tx = signer.get_tx().unwrap();
 
-        let mut chainstate = instantiate_chainstate(
-            false,
-            0x80000000,
-            "process-post-conditions-tokens-deny-2097",
-        );
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
         for (dbi, burn_db) in ALL_BURN_DBS.iter().enumerate() {
             let mut conn = chainstate.block_begin(
                 burn_db,
@@ -7766,12 +7734,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "process-smart-contract-fee_check",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let mut tx_contract_create = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -7958,12 +7922,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "process-poison-microblock",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let block_privk = StacksPrivateKey::from_hex(
             "2f90f1b148207a110aa58d1b998510407420d7a8065d4fdfc0bbe22c5d9f1c6a01",
@@ -8079,12 +8039,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "process-poison-microblock-invalid-transaction",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let block_privk = StacksPrivateKey::from_hex(
             "2f90f1b148207a110aa58d1b998510407420d7a8065d4fdfc0bbe22c5d9f1c6a01",
@@ -8169,12 +8125,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "process-poison-microblock-multiple-same-block",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let block_privk = StacksPrivateKey::from_hex(
             "2f90f1b148207a110aa58d1b998510407420d7a8065d4fdfc0bbe22c5d9f1c6a01",
@@ -8409,8 +8361,7 @@ pub mod test {
             }
         }
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "test_get_tx_clarity_version_v205");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -8604,8 +8555,7 @@ pub mod test {
             }
         }
 
-        let mut chainstate =
-            instantiate_chainstate(false, 0x80000000, "test_get_tx_clarity_version_v210");
+        let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
 
         let privk = StacksPrivateKey::from_hex(
             "6d430bb91222408e7706c9001cfaeb91b08c2be6d5ac95779ab52c6b431950e001",
@@ -8743,7 +8693,7 @@ pub mod test {
         let balances = vec![(addr.clone(), 1000000000)];
 
         let mut chainstate =
-            instantiate_chainstate_with_balances(false, 0x80000000, "process_fee_gating", balances);
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let mut tx_contract_create = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -8916,12 +8866,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "process_fee_gating_sponsored",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let mut tx_contract_create = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -9124,12 +9070,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "test_checkerrors_at_runtime",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let mut tx_runtime_checkerror_trait = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -9644,12 +9586,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "test_checkerrors_at_runtime",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let mut tx_foo_trait = StacksTransaction::new(
             TransactionVersion::Testnet,
@@ -10020,12 +9958,8 @@ pub mod test {
 
         let balances = vec![(addr.clone(), 1000000000)];
 
-        let mut chainstate = instantiate_chainstate_with_balances(
-            false,
-            0x80000000,
-            "test_checkerrors_at_runtime",
-            balances,
-        );
+        let mut chainstate =
+            instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), balances);
 
         let mut tx_foo_trait = StacksTransaction::new(
             TransactionVersion::Testnet,

--- a/src/chainstate/stacks/tests/block_construction.rs
+++ b/src/chainstate/stacks/tests/block_construction.rs
@@ -175,11 +175,7 @@ fn test_build_anchored_blocks_stx_transfers_single() {
     )
     .unwrap();
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_stx_transfers_single",
-        2002,
-        2003,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2002, 2003);
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
     let mut peer = TestPeer::new(peer_config);
@@ -313,11 +309,7 @@ fn test_build_anchored_blocks_empty_with_builder_timeout() {
     )
     .unwrap();
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_empty_with_builder_timeout",
-        2022,
-        2023,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2022, 2023);
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
     let mut peer = TestPeer::new(peer_config);
@@ -615,11 +607,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch() {
     )
     .unwrap();
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_connected_by_microblocks_across_epoch",
-        2016,
-        2017,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2016, 2017);
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
     let epochs = vec![
@@ -853,11 +841,7 @@ fn test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid() {
     )
     .unwrap();
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_connected_by_microblocks_across_epoch_invalid",
-        2018,
-        2019,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2018, 2019);
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
     let epochs = vec![
@@ -1566,11 +1550,7 @@ fn test_build_anchored_blocks_multiple_chaintips() {
 
     // make a blank chainstate and mempool so we can mine empty blocks
     //  without punishing the correspondingly "too expensive" transactions
-    let blank_chainstate = instantiate_chainstate(
-        false,
-        1,
-        "test_build_anchored_blocks_multiple_chaintips_blank",
-    );
+    let blank_chainstate = instantiate_chainstate(false, 1, function_name!());
     let mut blank_mempool = MemPoolDB::open_test(false, 1, &blank_chainstate.root_path).unwrap();
 
     let first_stacks_block_height = {
@@ -1845,11 +1825,7 @@ fn test_build_anchored_blocks_too_expensive_transactions() {
         balances.push((addr.to_account_principal(), 100000000));
     }
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_too_expensive_transactions",
-        2013,
-        2014,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2013, 2014);
     peer_config.initial_balances = balances;
 
     let mut peer = TestPeer::new(peer_config);
@@ -2209,11 +2185,7 @@ fn test_build_anchored_blocks_bad_nonces() {
         balances.push((addr.to_account_principal(), 100000000));
     }
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_too_expensive_transactions",
-        2012,
-        2013,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2012, 2013);
     peer_config.initial_balances = balances;
 
     let mut peer = TestPeer::new(peer_config);
@@ -2757,11 +2729,7 @@ fn test_build_microblock_stream_forks_with_descendants() {
         balances.push((addr.to_account_principal(), initial_balance));
     }
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_microblock_stream_forks_with_descendants",
-        2014,
-        2015,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2014, 2015);
     peer_config.initial_balances = balances;
 
     let mut peer = TestPeer::new(peer_config);
@@ -4263,11 +4231,7 @@ fn test_fee_order_mismatch_nonce_order() {
     )
     .unwrap();
 
-    let mut peer_config = TestPeerConfig::new(
-        "test_build_anchored_blocks_stx_transfers_single",
-        2002,
-        2003,
-    );
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2002, 2003);
     peer_config.initial_balances = vec![(addr.to_account_principal(), 1000000000)];
 
     let mut peer = TestPeer::new(peer_config);

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -2313,7 +2313,7 @@ fn test_find_next_missing_transactions() {
     assert_eq!(txs.len(), 0);
     assert!(next_page_opt.is_some());
 
-    let mut empty_bloom_conn = setup_bloom_counter("find_next_missing_txs_empty");
+    let mut empty_bloom_conn = setup_bloom_counter(function_name!());
     let mut empty_tx = tx_begin_immediate(&mut empty_bloom_conn).unwrap();
     let hasher = BloomNodeHasher::new(&[0u8; 32]);
     let empty_bloom = BloomCounter::new(

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -95,8 +95,8 @@ const SK_3: &'static str = "cb95ddd0fe18ec57f4f3533b95ae564b3f1ae063dbf75b46334b
 
 #[test]
 fn mempool_db_init() {
-    let _chainstate = instantiate_chainstate(false, 0x80000000, "mempool_db_init");
-    let chainstate_path = chainstate_path("mempool_db_init");
+    let _chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let _mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 }
 
@@ -179,7 +179,7 @@ pub fn make_block(
 #[test]
 fn mempool_walk_over_fork() {
     let mut chainstate =
-        instantiate_chainstate_with_balances(false, 0x80000000, "mempool_walk_over_fork", vec![]);
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
 
     // genesis -> b_1* -> b_2*
     //               \-> b_3 -> b_4
@@ -203,7 +203,7 @@ fn mempool_walk_over_fork() {
     let b_3 = make_block(&mut chainstate, ConsensusHash([0x3; 20]), &b_1, 3, 2);
     let b_4 = make_block(&mut chainstate, ConsensusHash([0x4; 20]), &b_3, 4, 3);
 
-    let chainstate_path = chainstate_path("mempool_walk_over_fork");
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let mut all_txs = codec_all_transactions(
@@ -597,13 +597,9 @@ fn mempool_walk_over_fork() {
 /// This test verifies that all transactions are visited, regardless of the
 /// setting for `consider_no_estimate_tx_prob`.
 fn test_iterate_candidates_consider_no_estimate_tx_prob() {
-    let mut chainstate = instantiate_chainstate_with_balances(
-        false,
-        0x80000000,
-        "test_iterate_candidates_consider_no_estimate_tx_prob",
-        vec![],
-    );
-    let chainstate_path = chainstate_path("test_iterate_candidates_consider_no_estimate_tx_prob");
+    let mut chainstate =
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
     let b_1 = make_block(
         &mut chainstate,
@@ -797,13 +793,9 @@ fn test_iterate_candidates_consider_no_estimate_tx_prob() {
 /// This test verifies that when a transaction is skipped, other transactions
 /// from the same address with higher nonces are not considered for inclusion in a block.
 fn test_iterate_candidates_skipped_transaction() {
-    let mut chainstate = instantiate_chainstate_with_balances(
-        false,
-        0x80000000,
-        "test_iterate_candidates_skipped_transaction",
-        vec![],
-    );
-    let chainstate_path = chainstate_path("test_iterate_candidates_skipped_transaction");
+    let mut chainstate =
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
     let b_1 = make_block(
         &mut chainstate,
@@ -914,13 +906,9 @@ fn test_iterate_candidates_skipped_transaction() {
 /// This test verifies that when a transaction reports a processing error, other transactions
 /// from the same address with higher nonces are not considered for inclusion in a block.
 fn test_iterate_candidates_processing_error_transaction() {
-    let mut chainstate = instantiate_chainstate_with_balances(
-        false,
-        0x80000000,
-        "test_iterate_candidates_processing_error_transaction",
-        vec![],
-    );
-    let chainstate_path = chainstate_path("test_iterate_candidates_processing_error_transaction");
+    let mut chainstate =
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
     let b_1 = make_block(
         &mut chainstate,
@@ -1033,13 +1021,9 @@ fn test_iterate_candidates_processing_error_transaction() {
 /// This test verifies that when a transaction is skipped, other transactions
 /// from the same address with higher nonces are not considered for inclusion in a block.
 fn test_iterate_candidates_problematic_transaction() {
-    let mut chainstate = instantiate_chainstate_with_balances(
-        false,
-        0x80000000,
-        "test_iterate_candidates_problematic_transaction",
-        vec![],
-    );
-    let chainstate_path = chainstate_path("test_iterate_candidates_problematic_transaction");
+    let mut chainstate =
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
     let b_1 = make_block(
         &mut chainstate,
@@ -1152,13 +1136,9 @@ fn test_iterate_candidates_problematic_transaction() {
 /// This test verifies that all transactions are visited, and nonce cache on disk updated, even if
 /// there's a concurrent write-lock on the mempool DB.
 fn test_iterate_candidates_concurrent_write_lock() {
-    let mut chainstate = instantiate_chainstate_with_balances(
-        false,
-        0x80000000,
-        "test_iterate_candidates_concurrent_write_lock",
-        vec![],
-    );
-    let chainstate_path = chainstate_path("test_iterate_candidates_concurrent_write_lock");
+    let mut chainstate =
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
     let b_1 = make_block(
         &mut chainstate,
@@ -1312,12 +1292,8 @@ fn test_iterate_candidates_concurrent_write_lock() {
 
 #[test]
 fn mempool_do_not_replace_tx() {
-    let mut chainstate = instantiate_chainstate_with_balances(
-        false,
-        0x80000000,
-        "mempool_do_not_replace_tx",
-        vec![],
-    );
+    let mut chainstate =
+        instantiate_chainstate_with_balances(false, 0x80000000, function_name!(), vec![]);
 
     // genesis -> b_1 -> b_2
     //      \-> b_3
@@ -1335,7 +1311,7 @@ fn mempool_do_not_replace_tx() {
     let b_2 = make_block(&mut chainstate, ConsensusHash([0x2; 20]), &b_1, 2, 2);
     let b_3 = make_block(&mut chainstate, ConsensusHash([0x3; 20]), &b_1, 1, 1);
 
-    let chainstate_path = chainstate_path("mempool_do_not_replace_tx");
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let mut txs = codec_all_transactions(
@@ -1430,9 +1406,8 @@ fn mempool_do_not_replace_tx() {
 
 #[test]
 fn mempool_db_load_store_replace_tx() {
-    let mut chainstate =
-        instantiate_chainstate(false, 0x80000000, "mempool_db_load_store_replace_tx");
-    let chainstate_path = chainstate_path("mempool_db_load_store_replace_tx");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let mut txs = codec_all_transactions(
@@ -1672,8 +1647,8 @@ fn mempool_db_load_store_replace_tx() {
 
 #[test]
 fn mempool_db_test_rbf() {
-    let mut chainstate = instantiate_chainstate(false, 0x80000000, "mempool_db_test_rbf");
-    let chainstate_path = chainstate_path("mempool_db_test_rbf");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     // create initial transaction
@@ -1819,8 +1794,8 @@ fn mempool_db_test_rbf() {
 
 #[test]
 fn test_add_txs_bloom_filter() {
-    let mut chainstate = instantiate_chainstate(false, 0x80000000, "mempool_add_txs_bloom_filter");
-    let chainstate_path = chainstate_path("mempool_add_txs_bloom_filter");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {
@@ -1927,8 +1902,8 @@ fn test_add_txs_bloom_filter() {
 
 #[test]
 fn test_txtags() {
-    let mut chainstate = instantiate_chainstate(false, 0x80000000, "mempool_txtags");
-    let chainstate_path = chainstate_path("mempool_txtags");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {
@@ -2026,8 +2001,8 @@ fn test_txtags() {
 #[test]
 #[ignore]
 fn test_make_mempool_sync_data() {
-    let mut chainstate = instantiate_chainstate(false, 0x80000000, "make_mempool_sync_data");
-    let chainstate_path = chainstate_path("make_mempool_sync_data");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {
@@ -2204,9 +2179,8 @@ fn test_make_mempool_sync_data() {
 
 #[test]
 fn test_find_next_missing_transactions() {
-    let mut chainstate =
-        instantiate_chainstate(false, 0x80000000, "find_next_missing_transactions");
-    let chainstate_path = chainstate_path("find_next_missing_transactions");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {
@@ -2475,8 +2449,8 @@ fn test_find_next_missing_transactions() {
 
 #[test]
 fn test_stream_txs() {
-    let mut chainstate = instantiate_chainstate(false, 0x80000000, "test_stream_txs");
-    let chainstate_path = chainstate_path("test_stream_txs");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {
@@ -2821,9 +2795,8 @@ fn test_decode_tx_stream() {
 
 #[test]
 fn test_drop_and_blacklist_txs_by_time() {
-    let mut chainstate =
-        instantiate_chainstate(false, 0x80000000, "test_drop_and_blacklist_txs_by_time");
-    let chainstate_path = chainstate_path("test_drop_and_blacklist_txs_by_time");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {
@@ -2941,9 +2914,8 @@ fn test_drop_and_blacklist_txs_by_time() {
 
 #[test]
 fn test_drop_and_blacklist_txs_by_size() {
-    let mut chainstate =
-        instantiate_chainstate(false, 0x80000000, "test_drop_and_blacklist_txs_by_size");
-    let chainstate_path = chainstate_path("test_drop_and_blacklist_txs_by_size");
+    let mut chainstate = instantiate_chainstate(false, 0x80000000, function_name!());
+    let chainstate_path = chainstate_path(function_name!());
     let mut mempool = MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
 
     let addr = StacksAddress {

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -5328,8 +5328,7 @@ pub mod test {
 
     #[test]
     fn test_block_pay_to_contract_gated_at_v210() {
-        let mut peer_config =
-            TestPeerConfig::new("test_block_pay_to_contract_gated_at_v210", 4246, 4247);
+        let mut peer_config = TestPeerConfig::new(function_name!(), 4246, 4247);
         let epochs = vec![
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch10,
@@ -5490,11 +5489,7 @@ pub mod test {
 
     #[test]
     fn test_block_versioned_smart_contract_gated_at_v210() {
-        let mut peer_config = TestPeerConfig::new(
-            "test_block_versioned_smart_contract_gated_at_v210",
-            4248,
-            4249,
-        );
+        let mut peer_config = TestPeerConfig::new(function_name!(), 4248, 4249);
 
         let initial_balances = vec![(
             PrincipalData::from(peer_config.spending_account.origin_address().unwrap()),
@@ -5671,11 +5666,7 @@ pub mod test {
 
     #[test]
     fn test_block_versioned_smart_contract_mempool_rejection_until_v210() {
-        let mut peer_config = TestPeerConfig::new(
-            "test_block_versioned_smart_contract_mempool_rejection_until_v210",
-            4250,
-            4251,
-        );
+        let mut peer_config = TestPeerConfig::new(function_name!(), 4250, 4251);
 
         let initial_balances = vec![(
             PrincipalData::from(peer_config.spending_account.origin_address().unwrap()),

--- a/src/util_lib/bloom.rs
+++ b/src/util_lib/bloom.rs
@@ -680,7 +680,7 @@ pub mod test {
         let num_items = 8192;
         let err_rate = 0.001;
 
-        let mut db = setup_bloom_counter("has_all_inserted_items_with_error_rate");
+        let mut db = setup_bloom_counter(function_name!());
         let hasher = BloomNodeHasher::new(&[0u8; 32]);
 
         let bf = {
@@ -720,7 +720,7 @@ pub mod test {
         let num_items = 8192;
         let err_rate = 0.001;
 
-        let mut db = setup_bloom_counter("counter_is_invertible");
+        let mut db = setup_bloom_counter(function_name!());
 
         let hasher = BloomNodeHasher::new(&[0u8; 32]);
 
@@ -787,7 +787,7 @@ pub mod test {
         let num_items = 8192;
         let err_rate = 0.001;
 
-        let mut db = setup_bloom_counter("counter_is_invertible_over_iterations");
+        let mut db = setup_bloom_counter(function_name!());
 
         let hasher = BloomNodeHasher::new(&[0u8; 32]);
 
@@ -980,7 +980,7 @@ pub mod test {
         let num_items = 8192;
         let err_rate = 0.001;
 
-        let mut db = setup_bloom_counter("has_all_inserted_items_with_error_rate");
+        let mut db = setup_bloom_counter(function_name!());
 
         let hasher = BloomNodeHasher::new(&[0u8; 32]);
 


### PR DESCRIPTION
I stumbled upon some more tests with concurrency issues, with the same old root cause of copy-pasted hard-coded test names. Took the opportunity to spread the usage of our `function_name!()` macro.