### PR TITLE
chore: expose some of the hash functions as public

### DIFF
--- a/stacks-common/src/util/hash.rs
+++ b/stacks-common/src/util/hash.rs
@@ -169,7 +169,7 @@ pub const DOUBLE_SHA256_ENCODED_SIZE: u32 = 32;
 
 #[derive(Debug, PartialEq, Clone)]
 #[repr(C)]
-enum MerklePathOrder {
+pub enum MerklePathOrder {
     Left = 0x02,
     Right = 0x03,
 }
@@ -373,7 +373,7 @@ impl DoubleSha256 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MerkleTree<H: MerkleHashFunc> {
     // nodes[0] is the list of leaves
     // nodes[-1][0] is the root
@@ -382,8 +382,8 @@ pub struct MerkleTree<H: MerkleHashFunc> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MerklePathPoint<H: MerkleHashFunc> {
-    order: MerklePathOrder,
-    hash: H,
+    pub order: MerklePathOrder,
+    pub hash: H,
 }
 
 pub type MerklePath<H> = Vec<MerklePathPoint<H>>;
@@ -399,6 +399,10 @@ impl<H> MerkleTree<H>
 where
     H: MerkleHashFunc + Clone + PartialEq + fmt::Debug,
 {
+    pub fn empty() -> MerkleTree<H> {
+        MerkleTree { nodes: vec![] }
+    }
+
     pub fn new(data: &Vec<Vec<u8>>) -> MerkleTree<H> {
         if data.len() == 0 {
             return MerkleTree { nodes: vec![] };
@@ -447,12 +451,12 @@ where
     }
 
     /// Get the leaf hash
-    fn get_leaf_hash(leaf_data: &[u8]) -> H {
+    pub fn get_leaf_hash(leaf_data: &[u8]) -> H {
         H::from_tagged_data(MERKLE_PATH_LEAF_TAG, leaf_data)
     }
 
     /// Get a non-leaf hash
-    fn get_node_hash(left: &H, right: &H) -> H {
+    pub fn get_node_hash(left: &H, right: &H) -> H {
         let mut buf = vec![];
         buf.extend_from_slice(left.bits());
         buf.extend_from_slice(right.bits());


### PR DESCRIPTION
These minor changes are helpful for other users of stacks-common, specifically, subnets.