### PR TITLE
fix: handle `TraitReferenceType` in 2.1

### DIFF
--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -602,8 +602,8 @@ pub fn clarity2_trait_check_trait_compliance<T: CostTracker>(
 fn clarity2_inner_type_check_type<T: CostTracker>(
     db: &mut AnalysisDatabase,
     contract_context: Option<&ContractContext>,
-    actual_type: &TypeSignature,
-    expected_type: &TypeSignature,
+    actual_in: &TypeSignature,
+    expected_in: &TypeSignature,
     depth: u8,
     tracker: &mut T,
 ) -> TypeResult {
@@ -611,8 +611,12 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
         return Err(CheckErrors::TypeSignatureTooDeep.into());
     }
 
+    // Canonicalize the types for 2.1
+    let actual_type = actual_in.canonicalize(&StacksEpochId::Epoch21);
+    let expected_type = expected_in.canonicalize(&StacksEpochId::Epoch21);
+
     // Recurse into values to check embedded traits properly
-    match (actual_type, expected_type) {
+    match (&actual_type, &expected_type) {
         (
             TypeSignature::OptionalType(atom_inner_type),
             TypeSignature::OptionalType(expected_inner_type),
@@ -693,7 +697,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                             expected_type.clone(),
                             actual_type.clone(),
                         )
-                        .into())
+                        .into());
                     }
                 }
             }
@@ -701,12 +705,6 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
         (
             TypeSignature::CallableType(CallableSubtype::Trait(atom_trait_id)),
             TypeSignature::CallableType(CallableSubtype::Trait(expected_trait_id)),
-        )
-        | (
-            TypeSignature::CallableType(CallableSubtype::Trait(atom_trait_id)),
-            // In 2.1, TraitReferenceType may show up as an expected type if it
-            // came from a trait deployed before 2.1.
-            TypeSignature::TraitReferenceType(expected_trait_id),
         ) => {
             if atom_trait_id != expected_trait_id {
                 let atom_trait =
@@ -727,12 +725,6 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
         (
             TypeSignature::CallableType(CallableSubtype::Principal(contract_identifier)),
             TypeSignature::CallableType(CallableSubtype::Trait(expected_trait_id)),
-        )
-        | (
-            TypeSignature::CallableType(CallableSubtype::Principal(contract_identifier)),
-            // In 2.1, TraitReferenceType may show up as an expected type if it
-            // came from a trait deployed before 2.1.
-            TypeSignature::TraitReferenceType(expected_trait_id),
         ) => {
             let contract_to_check = match db.load_contract(&contract_identifier) {
                 Some(contract) => {
@@ -766,7 +758,7 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
                     db,
                     contract_context,
                     &TypeSignature::CallableType(subtype.clone()),
-                    expected_type,
+                    &expected_type,
                     depth + 1,
                     tracker,
                 )?;
@@ -1231,18 +1223,13 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         &mut self,
         expr: &SymbolicExpression,
         context: &TypingContext,
-        expected_type: &TypeSignature,
+        expected: &TypeSignature,
     ) -> TypeResult {
-        match (&expr.expr, expected_type) {
+        let expected_type = expected.canonicalize(&StacksEpochId::Epoch21);
+        match (&expr.expr, &expected_type) {
             (
                 LiteralValue(Value::Principal(PrincipalData::Contract(ref contract_identifier))),
                 TypeSignature::CallableType(CallableSubtype::Trait(trait_identifier)),
-            )
-            | (
-                LiteralValue(Value::Principal(PrincipalData::Contract(ref contract_identifier))),
-                // In 2.1, TraitReferenceType may show up as an expected type if it
-                // came from a trait deployed before 2.1.
-                TypeSignature::TraitReferenceType(trait_identifier),
             ) => {
                 let contract_to_check = self
                     .db
@@ -1274,11 +1261,10 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         }
 
         let actual_type = self.type_check(expr, context)?;
-        analysis_typecheck_cost(self, expected_type, &actual_type)?;
+        analysis_typecheck_cost(self, &expected_type, &actual_type)?;
 
         if !expected_type.admits_type(&StacksEpochId::Epoch21, &actual_type)? {
-            let mut err: CheckError =
-                CheckErrors::TypeError(expected_type.clone(), actual_type).into();
+            let mut err: CheckError = CheckErrors::TypeError(expected_type, actual_type).into();
             err.set_expression(expr);
             Err(err)
         } else {

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -612,8 +612,8 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
     }
 
     // Canonicalize the types for 2.1
-    let actual_type = actual_in.canonicalize(&StacksEpochId::Epoch21);
-    let expected_type = expected_in.canonicalize(&StacksEpochId::Epoch21);
+    let actual_type = actual_in.canonicalize_simple_type(&StacksEpochId::Epoch21);
+    let expected_type = expected_in.canonicalize_simple_type(&StacksEpochId::Epoch21);
 
     // Recurse into values to check embedded traits properly
     match (&actual_type, &expected_type) {
@@ -1225,7 +1225,7 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
         context: &TypingContext,
         expected: &TypeSignature,
     ) -> TypeResult {
-        let expected_type = expected.canonicalize(&StacksEpochId::Epoch21);
+        let expected_type = expected.canonicalize_simple_type(&StacksEpochId::Epoch21);
         match (&expr.expr, &expected_type) {
             (
                 LiteralValue(Value::Principal(PrincipalData::Contract(ref contract_identifier))),

--- a/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/mod.rs
@@ -701,6 +701,12 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
         (
             TypeSignature::CallableType(CallableSubtype::Trait(atom_trait_id)),
             TypeSignature::CallableType(CallableSubtype::Trait(expected_trait_id)),
+        )
+        | (
+            TypeSignature::CallableType(CallableSubtype::Trait(atom_trait_id)),
+            // In 2.1, TraitReferenceType may show up as an expected type if it
+            // came from a trait deployed before 2.1.
+            TypeSignature::TraitReferenceType(expected_trait_id),
         ) => {
             if atom_trait_id != expected_trait_id {
                 let atom_trait =
@@ -721,6 +727,12 @@ fn clarity2_inner_type_check_type<T: CostTracker>(
         (
             TypeSignature::CallableType(CallableSubtype::Principal(contract_identifier)),
             TypeSignature::CallableType(CallableSubtype::Trait(expected_trait_id)),
+        )
+        | (
+            TypeSignature::CallableType(CallableSubtype::Principal(contract_identifier)),
+            // In 2.1, TraitReferenceType may show up as an expected type if it
+            // came from a trait deployed before 2.1.
+            TypeSignature::TraitReferenceType(expected_trait_id),
         ) => {
             let contract_to_check = match db.load_contract(&contract_identifier) {
                 Some(contract) => {
@@ -1225,6 +1237,12 @@ impl<'a, 'b> TypeChecker<'a, 'b> {
             (
                 LiteralValue(Value::Principal(PrincipalData::Contract(ref contract_identifier))),
                 TypeSignature::CallableType(CallableSubtype::Trait(trait_identifier)),
+            )
+            | (
+                LiteralValue(Value::Principal(PrincipalData::Contract(ref contract_identifier))),
+                // In 2.1, TraitReferenceType may show up as an expected type if it
+                // came from a trait deployed before 2.1.
+                TypeSignature::TraitReferenceType(trait_identifier),
             ) => {
                 let contract_to_check = self
                     .db

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -3543,8 +3543,8 @@ fn clarity_trait_experiments_cross_epochs(
         load_versioned(
             db,
             "use-compute",
-            ClarityVersion::Clarity1,
-            StacksEpochId::Epoch2_05,
+            version,
+            epoch,
         )?;
         call_versioned(
             db,
@@ -3552,7 +3552,7 @@ fn clarity_trait_experiments_cross_epochs(
             "do-it",
             ".impl-compute .impl-math-trait u1",
             version,
-            epoch,
+            StacksEpochId::Epoch21,
         )
     });
     match result {

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -3540,12 +3540,7 @@ fn clarity_trait_experiments_cross_epochs(
             ClarityVersion::Clarity1,
             StacksEpochId::Epoch2_05,
         )?;
-        load_versioned(
-            db,
-            "use-compute",
-            version,
-            epoch,
-        )?;
+        load_versioned(db, "use-compute", version, epoch)?;
         call_versioned(
             db,
             "use-compute",

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts/compute.clar
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts/compute.clar
@@ -1,0 +1,5 @@
+(use-trait math-trait .math-trait.math)
+
+(define-trait compute-trait (
+  (compute (<math-trait> uint) (response uint uint))
+))

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts/impl-compute.clar
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts/impl-compute.clar
@@ -1,0 +1,6 @@
+(impl-trait .compute.compute-trait)
+(use-trait math-trait .math-trait.math)
+
+(define-public (compute (m <math-trait>) (arg uint))
+  (contract-call? m add arg u1)
+)

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts/use-compute.clar
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts/use-compute.clar
@@ -1,0 +1,6 @@
+(use-trait compute-trait .compute.compute-trait)
+(use-trait math-trait .math-trait.math)
+
+(define-public (do-it (computer <compute-trait>) (math-contract <math-trait>) (x uint))
+  (contract-call? computer compute math-contract x)
+)

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -645,6 +645,22 @@ impl TypeSignature {
         }
     }
 
+    /// Canonicalize the type. This method will replace any types from previous
+    /// epochs with the appropriate types for the current epoch.
+    pub fn canonicalize(&self, epoch: &StacksEpochId) -> TypeSignature {
+        match epoch {
+            StacksEpochId::Epoch21 => self.canonicalize_v2_1(),
+            _ => self.clone(),
+        }
+    }
+
+    pub fn canonicalize_v2_1(&self) -> TypeSignature {
+        match self {
+            TraitReferenceType(trait_id) => CallableType(CallableSubtype::Trait(trait_id.clone())),
+            _ => self.clone(),
+        }
+    }
+
     /// Concretize the type. The input to this method may include
     /// `ListUnionType` and the `CallableType` variant for a `principal.
     /// This method turns these "temporary" types into actual types.

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -641,9 +641,6 @@ impl TypeSignature {
                 }
             }
             NoType => Err(CheckErrors::CouldNotDetermineType),
-            TraitReferenceType(_) => {
-                unreachable!("TraitReferenceType should not be used in epoch v2.1")
-            }
             _ => Ok(&other == self),
         }
     }

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -645,16 +645,18 @@ impl TypeSignature {
         }
     }
 
-    /// Canonicalize the type. This method will replace any types from previous
-    /// epochs with the appropriate types for the current epoch.
-    pub fn canonicalize(&self, epoch: &StacksEpochId) -> TypeSignature {
+    /// Canonicalize a simple type. This method will replace any simple types
+    /// from previous epochs with the appropriate types for the current epoch.
+    /// Note that complex types (`optional`, `list`, `response`, `tuple`) should
+    /// be recursed by the caller.
+    pub fn canonicalize_simple_type(&self, epoch: &StacksEpochId) -> TypeSignature {
         match epoch {
-            StacksEpochId::Epoch21 => self.canonicalize_v2_1(),
+            StacksEpochId::Epoch21 => self.canonicalize_simple_type_v2_1(),
             _ => self.clone(),
         }
     }
 
-    pub fn canonicalize_v2_1(&self) -> TypeSignature {
+    pub fn canonicalize_simple_type_v2_1(&self) -> TypeSignature {
         match self {
             TraitReferenceType(trait_id) => CallableType(CallableSubtype::Trait(trait_id.clone())),
             _ => self.clone(),


### PR DESCRIPTION
### Description

A trait processed during epoch 2.05 which contains a trait type for one
of its parameters will have a `TraitReferenceType` in its function
signature. This behavior changed when we split off the updated
type-checker and continued to run the old one in 2.05, but this one case
was not modified accordingly.

Fixes: #3489

### Applicable issues
- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
