### PR TITLE
fix: revert all regex changes in the v1 parser

### DIFF
--- a/clarity/src/vm/ast/parser/v1.rs
+++ b/clarity/src/vm/ast/parser/v1.rs
@@ -1320,9 +1320,11 @@ mod test {
     #[test]
     fn test_long_contract_name() {
         let long_contract_name = "(define-private (transfer (id uint) (receiver principal)) (contract-call? 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.megapont-robot-expansion-nftSPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S.guests-hosted-stacks-parrots transfer id tx-sender receiver))";
-        assert!(match ast::parser::v1::parse(long_contract_name).unwrap_err().err {
-            ParseErrors::SeparatorExpected(_) => true,
-            _ => false,
-        });
+        assert!(
+            match ast::parser::v1::parse(long_contract_name).unwrap_err().err {
+                ParseErrors::SeparatorExpected(_) => true,
+                _ => false,
+            }
+        );
     }
 }

--- a/clarity/src/vm/ast/parser/v1.rs
+++ b/clarity/src/vm/ast/parser/v1.rs
@@ -17,9 +17,7 @@
 use crate::vm::ast::errors::{ParseError, ParseErrors, ParseResult};
 use crate::vm::errors::{InterpreterResult as Result, RuntimeErrorType};
 use crate::vm::representations::{
-    ClarityName, ContractName, PreSymbolicExpression, PreSymbolicExpressionType,
-    CONTRACT_MAX_NAME_LENGTH, CONTRACT_MIN_NAME_LENGTH, CONTRACT_NAME_REGEX_STRING,
-    CONTRACT_PRINCIPAL_REGEX_STRING, MAX_STRING_LEN, STANDARD_PRINCIPAL_REGEX_STRING,
+    ClarityName, ContractName, PreSymbolicExpression, PreSymbolicExpressionType, MAX_STRING_LEN,
 };
 use crate::vm::types::{PrincipalData, QualifiedContractIdentifier, TraitIdentifier, Value};
 use regex::{Captures, Regex};
@@ -30,6 +28,9 @@ use std::convert::TryInto;
 
 use crate::vm::ast::stack_depth_checker::AST_CALL_STACK_DEPTH_BUFFER;
 use crate::vm::MAX_CALL_STACK_DEPTH;
+
+pub const CONTRACT_MIN_NAME_LENGTH: usize = 1;
+pub const CONTRACT_MAX_NAME_LENGTH: usize = 40;
 
 pub enum LexItem {
     LeftParen,
@@ -109,7 +110,22 @@ fn get_lines_at(input: &str) -> Vec<usize> {
 }
 
 lazy_static! {
-    pub static ref CLARITY_NAME_REGEX_STRING: String =
+    pub static ref STANDARD_PRINCIPAL_REGEX: String =
+        "[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}".into();
+    pub static ref CONTRACT_NAME_REGEX: String = format!(
+        r#"([a-zA-Z](([a-zA-Z0-9]|[-_])){{{},{}}})"#,
+        CONTRACT_MIN_NAME_LENGTH - 1,
+        CONTRACT_MAX_NAME_LENGTH - 1
+    );
+    pub static ref CONTRACT_PRINCIPAL_REGEX: String = format!(
+        r#"{}(\.){}"#,
+        *STANDARD_PRINCIPAL_REGEX, *CONTRACT_NAME_REGEX
+    );
+    pub static ref PRINCIPAL_DATA_REGEX: String = format!(
+        "({})|({})",
+        *STANDARD_PRINCIPAL_REGEX, *CONTRACT_PRINCIPAL_REGEX
+    );
+    pub static ref CLARITY_NAME_REGEX: String =
         format!(r#"([[:word:]]|[-!?+<>=/*]){{1,{}}}"#, MAX_STRING_LEN);
 
     static ref lex_matchers: Vec<LexMatcher> = vec![
@@ -140,31 +156,31 @@ lazy_static! {
         LexMatcher::new(
             &format!(
                 r#"'(?P<value>{}(\.)([[:alnum:]]|[-]){{1,{}}})"#,
-                *CONTRACT_PRINCIPAL_REGEX_STRING, MAX_STRING_LEN
+                *CONTRACT_PRINCIPAL_REGEX, MAX_STRING_LEN
             ),
             TokenType::FullyQualifiedFieldIdentifierLiteral,
         ),
         LexMatcher::new(
             &format!(
                 r#"(?P<value>(\.){}(\.)([[:alnum:]]|[-]){{1,{}}})"#,
-                *CONTRACT_NAME_REGEX_STRING, MAX_STRING_LEN
+                *CONTRACT_NAME_REGEX, MAX_STRING_LEN
             ),
             TokenType::SugaredFieldIdentifierLiteral,
         ),
         LexMatcher::new(
-            &format!(r#"'(?P<value>{})"#, *CONTRACT_PRINCIPAL_REGEX_STRING),
+            &format!(r#"'(?P<value>{})"#, *CONTRACT_PRINCIPAL_REGEX),
             TokenType::FullyQualifiedContractIdentifierLiteral,
         ),
         LexMatcher::new(
-            &format!(r#"(?P<value>(\.){})"#, *CONTRACT_NAME_REGEX_STRING),
+            &format!(r#"(?P<value>(\.){})"#, *CONTRACT_NAME_REGEX),
             TokenType::SugaredContractIdentifierLiteral,
         ),
         LexMatcher::new(
-            &format!("'(?P<value>{})", *STANDARD_PRINCIPAL_REGEX_STRING),
+            &format!("'(?P<value>{})", *STANDARD_PRINCIPAL_REGEX),
             TokenType::PrincipalLiteral,
         ),
         LexMatcher::new(
-            &format!("(?P<value>{})", *CLARITY_NAME_REGEX_STRING),
+            &format!("(?P<value>{})", *CLARITY_NAME_REGEX),
             TokenType::Variable,
         ),
     ];
@@ -1298,6 +1314,15 @@ mod test {
             x => {
                 panic!("Got {:?}", &x);
             }
+        });
+    }
+
+    #[test]
+    fn test_long_contract_name() {
+        let long_contract_name = "(define-private (transfer (id uint) (receiver principal)) (contract-call? 'SP3D6PV2ACBPEKYJTCMH7HEN02KP87QSP8KTEH335.megapont-robot-expansion-nftSPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S.guests-hosted-stacks-parrots transfer id tx-sender receiver))";
+        assert!(match ast::parser::v1::parse(long_contract_name).unwrap_err().err {
+            ParseErrors::SeparatorExpected(_) => true,
+            _ => false,
         });
     }
 }

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -73,7 +73,7 @@ use crate::net::MAX_HEADERS;
 use crate::net::MAX_MICROBLOCKS_UNCONFIRMED;
 use crate::net::{CallReadOnlyRequestBody, TipRequest};
 use crate::net::{GetAttachmentResponse, GetAttachmentsInvResponse, PostTransactionRequestBody};
-use clarity::vm::ast::parser::v1::CLARITY_NAME_REGEX_STRING;
+use clarity::vm::ast::parser::v1::CLARITY_NAME_REGEX;
 use clarity::vm::types::{StandardPrincipalData, TraitIdentifier};
 use clarity::vm::{
     representations::{
@@ -124,17 +124,17 @@ lazy_static! {
     .unwrap();
     static ref PATH_GET_DATA_VAR: Regex = Regex::new(&format!(
         "^/v2/data_var/(?P<address>{})/(?P<contract>{})/(?P<varname>{})$",
-        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX_STRING
+        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX
     ))
     .unwrap();
     static ref PATH_GET_MAP_ENTRY: Regex = Regex::new(&format!(
         "^/v2/map_entry/(?P<address>{})/(?P<contract>{})/(?P<map>{})$",
-        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX_STRING
+        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX
     ))
     .unwrap();
     static ref PATH_POST_CALL_READ_ONLY: Regex = Regex::new(&format!(
         "^/v2/contracts/call-read/(?P<address>{})/(?P<contract>{})/(?P<function>{})$",
-        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX_STRING
+        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX
     ))
     .unwrap();
     static ref PATH_GET_CONTRACT_SRC: Regex = Regex::new(&format!(
@@ -144,7 +144,7 @@ lazy_static! {
     .unwrap();
     static ref PATH_GET_IS_TRAIT_IMPLEMENTED: Regex = Regex::new(&format!(
         "^/v2/traits/(?P<address>{})/(?P<contract>{})/(?P<traitContractAddr>{})/(?P<traitContractName>{})/(?P<traitName>{})$",
-        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX_STRING
+        *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *STANDARD_PRINCIPAL_REGEX_STRING, *CONTRACT_NAME_REGEX_STRING, *CLARITY_NAME_REGEX
     ))
     .unwrap();
     static ref PATH_GET_CONTRACT_ABI: Regex = Regex::new(&format!(


### PR DESCRIPTION
With the addition of the v2 parser, some of the regex expressions were
moved up to representations.rs so that they could be shared and reused.
This has proven to be a problem, because the strange behavior of the v1
parser was not preserved (e.g. allowing long contract names in
contract-call parameters, but not in contracts).

Fixes: #3470