### PR TITLE
Feat/synthetic print delegate stx

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -47,6 +47,7 @@ jobs:
           - tests::neon_integrations::bitcoind_integration_test
           - tests::neon_integrations::liquid_ustx_integration
           - tests::neon_integrations::stx_transfer_btc_integration_test
+          - tests::neon_integrations::stx_delegate_btc_integration_test
           - tests::neon_integrations::bitcoind_forking_test
           - tests::neon_integrations::should_fix_2771
           - tests::neon_integrations::pox_integration_test

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -3548,6 +3548,10 @@ fn test_delegate_stx_btc_ops() {
                 &second_del,
             );
 
+            if ix == 10 {
+
+            }
+
             // Check that the effects of the delegate stx op sent when ix==10
             // are materialized for ix=11... (we check that the
             // changes endure for the following blocks)
@@ -3582,6 +3586,8 @@ fn test_delegate_stx_btc_ops() {
                     "The second delegation should not be active"
                 );
             }
+
+
         }
     }
 

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -3548,10 +3548,6 @@ fn test_delegate_stx_btc_ops() {
                 &second_del,
             );
 
-            if ix == 10 {
-
-            }
-
             // Check that the effects of the delegate stx op sent when ix==10
             // are materialized for ix=11... (we check that the
             // changes endure for the following blocks)
@@ -3586,8 +3582,6 @@ fn test_delegate_stx_btc_ops() {
                     "The second delegation should not be active"
                 );
             }
-
-
         }
     }
 

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -1555,7 +1555,11 @@ fn delegate_stack_increase() {
         "(err 18)"
     );
 
-    let delegate_stx_tx = &alice_txs.get(&success_alice_delegation).unwrap().clone().events[0];
+    let delegate_stx_tx = &alice_txs
+        .get(&success_alice_delegation)
+        .unwrap()
+        .clone()
+        .events[0];
     let delegate_stx_op_data = HashMap::from([
         ("pox-addr", Value::none()),
         ("amount-ustx", Value::UInt(10230000000000)),

--- a/src/chainstate/stacks/boot/pox_2_tests.rs
+++ b/src/chainstate/stacks/boot/pox_2_tests.rs
@@ -1339,6 +1339,7 @@ fn delegate_stack_increase() {
     let tip = get_tip(peer.sortdb.as_ref());
 
     // submit delegation tx
+    let success_alice_delegation = alice_nonce;
     let alice_delegation_1 = make_pox_2_contract_call(
         &alice,
         alice_nonce,
@@ -1553,6 +1554,33 @@ fn delegate_stack_increase() {
         &bob_txs[&fail_invalid_amount].result.to_string(),
         "(err 18)"
     );
+
+    let delegate_stx_tx = &alice_txs.get(&success_alice_delegation).unwrap().clone().events[0];
+    let delegate_stx_op_data = HashMap::from([
+        ("pox-addr", Value::none()),
+        ("amount-ustx", Value::UInt(10230000000000)),
+        ("unlock-burn-height", Value::none()),
+        (
+            "delegate-to",
+            Value::Principal(
+                StacksAddress::from_string("ST1GCB6NH3XR67VT4R5PKVJ2PYXNVQ4AYQATXNP4P")
+                    .unwrap()
+                    .to_account_principal(),
+            ),
+        ),
+    ]);
+    let common_data = PoxPrintFields {
+        op_name: "delegate-stx".to_string(),
+        stacker: Value::Principal(
+            StacksAddress::from_string("ST2Q1B4S2DY2Y96KYNZTVCCZZD1V9AGWCS5MFXM4C")
+                .unwrap()
+                .to_account_principal(),
+        ),
+        balance: Value::UInt(10240000000000),
+        locked: Value::UInt(0),
+        burnchain_unlock_height: Value::UInt(0),
+    };
+    check_pox_print_event(delegate_stx_tx, common_data, delegate_stx_op_data);
 
     // Check that the call to `delegate-stack-increase` has a well-formed print event.
     let delegate_stack_increase_tx = &bob_txs.get(&4).unwrap().clone().events[0];

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5866,9 +5866,9 @@ impl StacksChainState {
     /// in the block, and a `PreCommitClarityBlock` struct.
     ///
     /// The `StacksEpochReceipts` contains the list of transaction
-    /// receipts for both the preceeding microblock stream that the
-    /// block confirms, as well as the transaction receipts for the
-    /// anchored block's transactions. Finally, it returns the
+    /// receipts for the preceeding microblock stream that the
+    /// block confirms, the anchored block's transactions, and the
+    /// btc wire transactions. Finally, it returns the
     /// execution costs for the microblock stream and for the anchored
     /// block (separately).
     ///

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -12131,7 +12131,10 @@ pub mod test {
             .collect();
         init_balances.push((addr.to_account_principal(), initial_balance));
         peer_config.initial_balances = init_balances;
-        peer_config.epochs = Some(StacksEpoch::unit_test_2_1(0));
+        let mut epochs = StacksEpoch::unit_test_2_1(0);
+        let num_epochs = epochs.len();
+        epochs[num_epochs - 1].block_limit.runtime = 10_000_000;
+        peer_config.epochs = Some(epochs);
         peer_config.burnchain.pox_constants.v1_unlock_height = 26;
 
         let mut peer = TestPeer::new(peer_config);

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -257,7 +257,9 @@ fn handle_pox_v1_api_contract_call(
 /// - for delegate stacking functions, it's the first argument
 fn get_stacker(sender: &PrincipalData, function_name: &str, args: &[Value]) -> Value {
     match function_name {
-        "stack-stx" | "stack-increase" | "stack-extend" | "delegate-stx" => Value::Principal(sender.clone()),
+        "stack-stx" | "stack-increase" | "stack-extend" | "delegate-stx" => {
+            Value::Principal(sender.clone())
+        }
         _ => args[0].clone(),
     }
 }
@@ -558,7 +560,7 @@ fn create_event_info_data_code(function_name: &str, args: &[Value]) -> String {
                 until_burn_height = &args[2],
                 pox_addr = &args[3],
             )
-        },
+        }
         _ => format!("{{ data: {{ unimplemented: true }} }}"),
     }
 }
@@ -585,7 +587,8 @@ fn synthesize_pox_2_event_info(
         | "stack-extend"
         | "delegate-stack-extend"
         | "stack-increase"
-        | "delegate-stack-increase" => Some(create_event_info_stack_or_delegate_code(
+        | "delegate-stack-increase"
+        | "delegate-stx" => Some(create_event_info_stack_or_delegate_code(
             sender,
             function_name,
             args,
@@ -593,7 +596,6 @@ fn synthesize_pox_2_event_info(
         "stack-aggregation-commit"
         | "stack-aggregation-commit-indexed"
         | "stack-aggregation-increase" => Some(create_event_info_aggregation_code(function_name)),
-        "delegate-stx" => Some(create_event_info_stack_or_delegate_code(sender, function_name, args)),
         _ => None,
     };
 

--- a/src/clarity_vm/special.rs
+++ b/src/clarity_vm/special.rs
@@ -692,7 +692,7 @@ fn synthesize_pox_2_event_info(
                 e
             })?;
 
-        info!(
+        test_debug!(
             "Synthesized PoX-2 event info for '{}''s call to '{}': {:?}",
             sender,
             function_name,

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -38,7 +38,10 @@ use stacks::burnchains::{
 };
 use stacks::burnchains::{Burnchain, BurnchainParameters};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
-use stacks::chainstate::burn::operations::{BlockstackOperationType, DelegateStxOp, LeaderBlockCommitOp, LeaderKeyRegisterOp, PreStxOp, TransferStxOp, UserBurnSupportOp};
+use stacks::chainstate::burn::operations::{
+    BlockstackOperationType, DelegateStxOp, LeaderBlockCommitOp, LeaderKeyRegisterOp, PreStxOp,
+    TransferStxOp, UserBurnSupportOp,
+};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 #[cfg(test)]
 use stacks::chainstate::stacks::address::PoxAddress;
@@ -825,6 +828,17 @@ impl BitcoinRegtestController {
         &mut self,
         _epoch_id: StacksEpochId,
         _payload: TransferStxOp,
+        _signer: &mut BurnchainOpSigner,
+        _utxo: Option<UTXO>,
+    ) -> Option<Transaction> {
+        unimplemented!()
+    }
+
+    #[cfg(not(test))]
+    fn build_delegate_stacks_tx(
+        &mut self,
+        _epoch_id: StacksEpochId,
+        _payload: DelegateStxOp,
         _signer: &mut BurnchainOpSigner,
         _utxo: Option<UTXO>,
     ) -> Option<Transaction> {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -16,7 +16,7 @@ use rusqlite::types::ToSql;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::Txid;
-use stacks::chainstate::burn::operations::{BlockstackOperationType, PreStxOp, TransferStxOp};
+use stacks::chainstate::burn::operations::{BlockstackOperationType, DelegateStxOp, PreStxOp, TransferStxOp};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::clarity_cli::vm_execute as execute;
 use stacks::codec::StacksMessageCodec;
@@ -956,6 +956,7 @@ pub fn get_balance<F: std::fmt::Display>(http_origin: &str, account: &F) -> u128
 #[derive(Debug)]
 pub struct Account {
     pub balance: u128,
+    pub locked: u128,
     pub nonce: u64,
 }
 
@@ -971,6 +972,7 @@ pub fn get_account<F: std::fmt::Display>(http_origin: &str, account: &F) -> Acco
     info!("Account response: {:#?}", res);
     Account {
         balance: u128::from_str_radix(&res.balance[2..], 16).unwrap(),
+        locked: u128::from_str_radix(&res.locked[2..], 16).unwrap(),
         nonce: res.nonce,
     }
 }
@@ -1682,6 +1684,274 @@ fn stx_transfer_btc_integration_test() {
     assert_eq!(get_balance(&http_origin, &recipient_addr), 200_000);
     assert_eq!(get_balance(&http_origin, &spender_2_addr), 300);
 
+    channel.stop_chains_coordinator();
+}
+
+#[test]
+#[ignore]
+fn stx_delegate_btc_integration_test() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let spender_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+    let spender_stx_addr: StacksAddress = to_addr(&spender_sk);
+    let spender_addr: PrincipalData = spender_stx_addr.clone().into();
+    let _spender_btc_addr = BitcoinAddress::from_bytes_legacy(
+        BitcoinNetworkType::Regtest,
+        LegacyBitcoinAddressType::PublicKeyHash,
+        &spender_stx_addr.bytes.0,
+    )
+        .unwrap();
+
+    let spender_2_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
+    let spender_2_stx_addr: StacksAddress = to_addr(&spender_2_sk);
+    let spender_2_addr: PrincipalData = spender_2_stx_addr.clone().into();
+    let pox_pubkey = Secp256k1PublicKey::from_hex(
+        "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
+    )
+        .unwrap();
+    let pox_pubkey_hash = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let (mut conf, _miner_account) = neon_integration_test_conf();
+
+    conf.initial_balances.push(InitialBalance {
+        address: spender_addr.clone(),
+        amount: 100300,
+    });
+
+    conf.initial_balances.push(InitialBalance {
+        address: spender_2_addr.clone(),
+        amount: 100300,
+    });
+
+    // force mainnet limits in 2.05 for this test
+    conf.burnchain.epochs = Some(vec![
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch20,
+            start_height: 0,
+            end_height: 1,
+            block_limit: BLOCK_LIMIT_MAINNET_20.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_0,
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch2_05,
+            start_height: 1,
+            end_height: 2,
+            block_limit: BLOCK_LIMIT_MAINNET_205.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_05,
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch21,
+            start_height: 2,
+            end_height: 9223372036854775807,
+            block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_1,
+        },
+    ]);
+    conf.burnchain.pox_2_activation = Some(3);
+
+    test_observer::spawn();
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    // reward cycle length = 5, so 3 reward cycle slots + 2 prepare-phase burns
+    let reward_cycle_len = 5;
+    let prepare_phase_len = 2;
+    let pox_constants = PoxConstants::new(
+        reward_cycle_len,
+        prepare_phase_len,
+        2,
+        5,
+        15,
+        (16 * reward_cycle_len - 1).into(),
+        (17 * reward_cycle_len).into(),
+        u32::MAX,
+    );
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(), None, Some(burnchain_config.clone()), None
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    test_observer::clear();
+
+    // Mine a few more blocks so that Epoch 2.1 (and thus pox-2) can take effect.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let pox_info = get_pox_info(&http_origin);
+    info!("pox info after startup: {:?}", pox_info);
+    assert_eq!(pox_info.contract_id, format!("{}", boot_code_id("pox-2", false)));
+
+    // let's query the spender's account:
+    assert_eq!(get_balance(&http_origin, &spender_addr), 100300);
+
+    // okay, let's send a pre-stx op.
+    let pre_stx_op = PreStxOp {
+        output: spender_stx_addr.clone(),
+        // to be filled in
+        txid: Txid([0u8; 32]),
+        vtxindex: 0,
+        block_height: 0,
+        burn_header_hash: BurnchainHeaderHash([0u8; 32]),
+    };
+
+    let mut miner_signer = Keychain::default(conf.node.seed.clone()).generate_op_signer();
+
+    assert!(
+        btc_regtest_controller
+            .submit_operation(
+                StacksEpochId::Epoch21,
+                BlockstackOperationType::PreStx(pre_stx_op),
+                &mut miner_signer,
+                1
+            )
+            .is_some(),
+        "Pre-stx operation should submit successfully"
+    );
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    // let's fire off our delegate op.
+    let recipient_sk = StacksPrivateKey::new();
+    let recipient_addr = to_addr(&recipient_sk);
+    let del_stx_op = DelegateStxOp {
+        sender: spender_stx_addr.clone(),
+        delegate_to: recipient_addr.clone(),
+        reward_addr: None,
+        delegated_ustx: 100_000,
+        // to be filled in
+        txid: Txid([0u8; 32]),
+        vtxindex: 0,
+        block_height: 0,
+        burn_header_hash: BurnchainHeaderHash([0u8; 32]),
+        until_burn_height: None,
+    };
+
+    let mut spender_signer = BurnchainOpSigner::new(spender_sk.clone(), false);
+
+    assert!(
+        btc_regtest_controller
+            .submit_operation(
+                StacksEpochId::Epoch21,
+                BlockstackOperationType::DelegateStx(del_stx_op),
+                &mut spender_signer,
+                1
+            )
+            .is_some(),
+        "Delegate operation should submit successfully"
+    );
+    // should be elected in the same block as the transfer, so balances should be unchanged.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    assert_eq!(get_balance(&http_origin, &spender_addr), 100300);
+    assert_eq!(get_balance(&http_origin, &recipient_addr), 0);
+
+    // this block should process the delegation, after which the balaces should be unchanged
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    assert_eq!(get_balance(&http_origin, &spender_addr), 100300);
+    assert_eq!(get_balance(&http_origin, &recipient_addr), 0);
+
+    let tx = make_contract_call(
+        &spender_2_sk,
+        0,
+        262,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox-2",
+        "stack-stx",
+        &[
+            Value::UInt(500),
+            execute(
+                &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash),
+                ClarityVersion::Clarity2,
+            )
+                .unwrap()
+                .unwrap(),
+            Value::UInt(10),
+            Value::UInt(6),
+        ],
+    );
+
+    // okay, let's push that stacking transaction!
+    submit_tx(&http_origin, &tx);
+
+    let pox_info = get_pox_info(&http_origin);
+    // now let's mine until the next reward cycle starts ...
+    // while sort_height < ((pox_info.current_cycle.id as u32 * pox_constants.reward_cycle_length) + 1).into() {
+    //     next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    //     sort_height = channel.get_sortitions_processed();
+    //     eprintln!("Sort height: {}", sort_height);
+    // }
+
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let account = get_account(&http_origin, &spender_stx_addr);
+    assert_eq!(account.locked, 500);
+
+
+    let blocks = test_observer::get_blocks();
+    for block in blocks.iter() {
+        let events = block.get("events").unwrap().as_array().unwrap();
+        for event in events.iter() {
+            let event_type = event.get("type").unwrap().as_str().unwrap();
+            if event_type == "contract_event" {
+                let contract_event = event.get("contract_event").unwrap().as_object().unwrap();
+                let sub_type = contract_event.get("topic").unwrap().as_str().unwrap();
+                assert_eq!(sub_type, "print");
+
+                let name_field = &contract_event["value"]["Response"]["data"]["Tuple"]["data_map"]["name"];
+                let name_data = name_field["Sequence"]["String"]["ASCII"]["data"].as_array().unwrap();
+                let ascii_vec = name_data.iter().map(|num| num.as_u64().unwrap() as u8).collect();
+                let name = String::from_utf8(ascii_vec).unwrap();
+                assert_eq!(name, "delegate-stx");
+            }
+        }
+    }
+
+    test_observer::clear();
     channel.stop_chains_coordinator();
 }
 
@@ -5536,7 +5806,7 @@ fn pox_integration_test() {
         15,
         (16 * reward_cycle_len - 1).into(),
         (17 * reward_cycle_len).into(),
-        u32::max_value(),
+        u32::MAX,
     );
     burnchain_config.pox_constants = pox_constants.clone();
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -16,7 +16,9 @@ use rusqlite::types::ToSql;
 use stacks::burnchains::bitcoin::address::{BitcoinAddress, LegacyBitcoinAddressType};
 use stacks::burnchains::bitcoin::BitcoinNetworkType;
 use stacks::burnchains::Txid;
-use stacks::chainstate::burn::operations::{BlockstackOperationType, DelegateStxOp, PreStxOp, TransferStxOp};
+use stacks::chainstate::burn::operations::{
+    BlockstackOperationType, DelegateStxOp, PreStxOp, TransferStxOp,
+};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::clarity_cli::vm_execute as execute;
 use stacks::codec::StacksMessageCodec;
@@ -1703,7 +1705,7 @@ fn stx_delegate_btc_integration_test() {
     let pox_pubkey = Secp256k1PublicKey::from_hex(
         "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
     )
-        .unwrap();
+    .unwrap();
     let pox_pubkey_hash = bytes_to_hex(
         &Hash160::from_node_public_key(&pox_pubkey)
             .to_bytes()
@@ -1777,7 +1779,10 @@ fn stx_delegate_btc_integration_test() {
     burnchain_config.pox_constants = pox_constants.clone();
 
     let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
-        conf.clone(), None, Some(burnchain_config.clone()), None
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
     );
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
@@ -1882,8 +1887,8 @@ fn stx_delegate_btc_integration_test() {
                 &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash),
                 ClarityVersion::Clarity2,
             )
-                .unwrap()
-                .unwrap(),
+            .unwrap()
+            .unwrap(),
             Value::UInt(sort_height as u128),
             Value::UInt(6),
         ],
@@ -1919,9 +1924,15 @@ fn stx_delegate_btc_integration_test() {
 
                 // Ensure that the function name is as expected
                 // This verifies that there were print events for delegate-stack-stx and delegate-stx
-                let name_field = &contract_event["value"]["Response"]["data"]["Tuple"]["data_map"]["name"];
-                let name_data = name_field["Sequence"]["String"]["ASCII"]["data"].as_array().unwrap();
-                let ascii_vec = name_data.iter().map(|num| num.as_u64().unwrap() as u8).collect();
+                let name_field =
+                    &contract_event["value"]["Response"]["data"]["Tuple"]["data_map"]["name"];
+                let name_data = name_field["Sequence"]["String"]["ASCII"]["data"]
+                    .as_array()
+                    .unwrap();
+                let ascii_vec = name_data
+                    .iter()
+                    .map(|num| num.as_u64().unwrap() as u8)
+                    .collect();
                 let name = String::from_utf8(ascii_vec).unwrap();
                 if name == "delegate-stack-stx" {
                     delegate_stack_stx_found = true;


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
This PR adds a synthetic print event to the `delegate-stx` function in the `pox-2` contract. It does so by means of the special contract handler (defined in `special.rs`). 

This PR adds 2 tests:
- a test in `pox_2_tests.rs` that called `delegate-stx` through a normal stacks transaction
- a test in `neon_integrations.rs` that sends a btc wire DelegateStx tx, and verifies (a) that the delegation was successful, and (b) that a synthetic print event was emitted. 

### Applicable issues
- fixes #3465

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [x] New integration test(s) added to `bitcoin-tests.yml`
