### PR TITLE
chore: enable manual start of btc integration test workflow 

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -2,8 +2,10 @@ name: stacks-bitcoin-integration-tests
 
 # Only run when:
 #   - PRs are opened
+#   - the workflow is started from the UI
 on:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: stacks-bitcoin-integration-tests-${{ github.ref }}

--- a/.idea/stacks-blockchain.iml
+++ b/.idea/stacks-blockchain.iml
@@ -10,6 +10,7 @@
       <sourceFolder url="file://$MODULE_DIR$/stx-genesis/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testnet/puppet-chain/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testnet/stacks-node/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/contrib/tools/relay-server/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/.idea/stacks-blockchain.iml
+++ b/.idea/stacks-blockchain.iml
@@ -10,7 +10,6 @@
       <sourceFolder url="file://$MODULE_DIR$/stx-genesis/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testnet/puppet-chain/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testnet/stacks-node/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/contrib/tools/relay-server/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,12 @@ Each Rust file should contain a `mod test {}` definition, in which unit tests
 should be supplied for the file's methods.  Unit tests should cover a maximal
 amount of code paths.
 
+### GitHub Workflows and Actions 
+We run our CI pipeline using GitHub workflows. The main workflows are CI (at `.github/workflows/ci.yml`), 
+and stacks-bitcoin-integration-tests (at `.github/workflows/bitcoin-tests.yml`). These 
+workflows can be manually triggered on the Actions tab in the GitHub UI on any branch. 
+
+
 ## Contributing Conventions
 
 ### Simplicity of implementation


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Updated the `stacks-bitcoin-integration-tests` workflow file to allow running the workflow through the GitHub UI. This can be helpful if a workflow was manually stopped for any reason.  
