### PR TITLE
feat: add epoch to abi RPC endpoint

### DIFF
--- a/clarity/src/vm/analysis/arithmetic_checker/tests.rs
+++ b/clarity/src/vm/analysis/arithmetic_checker/tests.rs
@@ -59,6 +59,7 @@ fn arithmetic_check(
         contract_identifier,
         expressions,
         LimitedCostTracker::new_free(),
+        epoch,
         version,
     );
 

--- a/clarity/src/vm/analysis/contract_interface_builder/mod.rs
+++ b/clarity/src/vm/analysis/contract_interface_builder/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use stacks_common::types::StacksEpochId;
+
 use crate::vm::analysis::types::ContractAnalysis;
 use crate::vm::types::signatures::CallableSubtype;
 use crate::vm::types::{
@@ -25,7 +27,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::vm::ClarityVersion;
 
 pub fn build_contract_interface(contract_analysis: &ContractAnalysis) -> ContractInterface {
-    let mut contract_interface = ContractInterface::new(contract_analysis.clarity_version.clone());
+    let mut contract_interface = ContractInterface::new(
+        contract_analysis.epoch.clone(),
+        contract_analysis.clarity_version.clone(),
+    );
 
     let ContractAnalysis {
         private_function_types,
@@ -36,6 +41,7 @@ pub fn build_contract_interface(contract_analysis: &ContractAnalysis) -> Contrac
         map_types,
         fungible_tokens,
         non_fungible_tokens,
+        epoch: _,
         clarity_version: _,
         defined_traits: _,
         implemented_traits: _,
@@ -365,17 +371,19 @@ pub struct ContractInterface {
     pub maps: Vec<ContractInterfaceMap>,
     pub fungible_tokens: Vec<ContractInterfaceFungibleTokens>,
     pub non_fungible_tokens: Vec<ContractInterfaceNonFungibleTokens>,
+    pub epoch: StacksEpochId,
     pub clarity_version: ClarityVersion,
 }
 
 impl ContractInterface {
-    pub fn new(clarity_version: ClarityVersion) -> Self {
+    pub fn new(epoch: StacksEpochId, clarity_version: ClarityVersion) -> Self {
         Self {
             functions: Vec::new(),
             variables: Vec::new(),
             maps: Vec::new(),
             fungible_tokens: Vec::new(),
             non_fungible_tokens: Vec::new(),
+            epoch,
             clarity_version,
         }
     }

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -128,6 +128,7 @@ pub fn run_analysis(
         contract_identifier.clone(),
         expressions.to_vec(),
         cost_tracker,
+        epoch,
         version,
     );
     let result = analysis_db.execute(|db| {

--- a/clarity/src/vm/analysis/type_checker/v2_05/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_05/tests/contracts.rs
@@ -171,6 +171,7 @@ fn test_names_tokens_contracts_interface() {
         serde_json::from_str(&test_contract_json_str).unwrap();
 
     let test_contract_json_expected: serde_json::Value = serde_json::from_str(r#"{
+        "epoch": "Epoch2_05",
         "clarity_version": "Clarity1",
         "functions": [
             { "name": "f00",

--- a/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
+++ b/clarity/src/vm/analysis/type_checker/v2_1/tests/contracts.rs
@@ -436,6 +436,7 @@ fn test_names_tokens_contracts_interface() {
         ],
         "fungible_tokens": [],
         "non_fungible_tokens": [],
+        "epoch": "Epoch21",
         "clarity_version": "Clarity2"
     }"#).unwrap();
 

--- a/clarity/src/vm/analysis/types.rs
+++ b/clarity/src/vm/analysis/types.rs
@@ -54,6 +54,7 @@ pub struct ContractAnalysis {
     pub implemented_traits: BTreeSet<TraitIdentifier>,
     pub contract_interface: Option<ContractInterface>,
     pub is_cost_contract_eligible: bool,
+    pub epoch: StacksEpochId,
     pub clarity_version: ClarityVersion,
     #[serde(skip)]
     pub expressions: Vec<SymbolicExpression>,
@@ -68,6 +69,7 @@ impl ContractAnalysis {
         contract_identifier: QualifiedContractIdentifier,
         expressions: Vec<SymbolicExpression>,
         cost_track: LimitedCostTracker,
+        epoch: StacksEpochId,
         clarity_version: ClarityVersion,
     ) -> ContractAnalysis {
         ContractAnalysis {
@@ -87,6 +89,7 @@ impl ContractAnalysis {
             non_fungible_tokens: BTreeMap::new(),
             cost_track: Some(cost_track),
             is_cost_contract_eligible: false,
+            epoch,
             clarity_version,
         }
     }

--- a/clarity/src/vm/analysis/types.rs
+++ b/clarity/src/vm/analysis/types.rs
@@ -284,6 +284,7 @@ mod test {
             QualifiedContractIdentifier::local("foo").unwrap(),
             vec![],
             LimitedCostTracker::new_free(),
+            StacksEpochId::Epoch20,
             ClarityVersion::Clarity1,
         );
         let trait_id = TraitIdentifier::new(


### PR DESCRIPTION
It can be useful for clients to know during which epoch a contract was
published. This was a specific request from the Clarinet team.