### PR TITLE
2.1: Eliminate recursion in `parse_list` and `parse_tuple`

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   atlas-test:
     if: ${{ true }}
     runs-on: ubuntu-latest
@@ -144,4 +144,4 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: ${{ matrix.test-name }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: large_genesis
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   # Run unit tests with code coverage
   unit-tests:
@@ -52,7 +52,7 @@ jobs:
         with:
           files: ./coverage-output/lcov.info
           name: unit_tests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   open-api-validation:
     runs-on: ubuntu-latest
@@ -94,6 +94,7 @@ jobs:
         with:
           files: ./coverage.lcov
           verbose: true
+          fail_ci_if_error: false
 
   # rustfmt checking
   rustfmt:

--- a/clarity/src/vm/ast/errors.rs
+++ b/clarity/src/vm/ast/errors.rs
@@ -88,6 +88,9 @@ pub enum ParseErrors {
     ExpectedWhitespace,
     // Notes
     NoteToMatchThis(Token),
+
+    /// Should be an unreachable error
+    UnexpectedParserFailure,
 }
 
 #[derive(Debug, PartialEq)]
@@ -294,6 +297,7 @@ impl DiagnosableError for ParseErrors {
             ParseErrors::IllegalUtf8String(s) => format!("illegal UTF8 string \"{}\"", s),
             ParseErrors::ExpectedWhitespace => "expected whitespace before expression".to_string(),
             ParseErrors::NoteToMatchThis(token) => format!("to match this '{}'", token),
+            ParseErrors::UnexpectedParserFailure => "unexpected failure while parsing".to_string(),
         }
     }
 

--- a/clarity/src/vm/ast/parser/v2/mod.rs
+++ b/clarity/src/vm/ast/parser/v2/mod.rs
@@ -153,6 +153,17 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Get a reference to the last processed token. If there is no last token,
+    ///  raises an UnexpectedParserFailure.
+    fn peek_last_token(&self) -> ParseResult<&PlacedToken> {
+        if self.next_token == 0 {
+            return Err(ParseError::new(ParseErrors::UnexpectedParserFailure));
+        }
+        self.tokens
+            .get(self.next_token - 1)
+            .ok_or_else(|| ParseError::new(ParseErrors::UnexpectedParserFailure))
+    }
+
     fn skip_to_end(&mut self) {
         self.next_token = self.tokens.len();
     }
@@ -220,7 +231,7 @@ impl<'a> Parser<'a> {
                     *whitespace = self.ignore_whitespace();
                     Ok(None)
                 } else {
-                    let token = self.tokens[self.next_token - 1].clone();
+                    let token = self.peek_last_token()?.clone();
                     match token.token {
                         Token::Rparen => {
                             span.end_line = token.span.end_line;
@@ -279,7 +290,7 @@ impl<'a> Parser<'a> {
                         // mimic parse_node_or_eof() behavior
                         //  if last token was an EOF, error out the tuple
                         //  if the last token was something else, just yield back to the parse loop
-                        let last_token = self.tokens[self.next_token - 1].clone();
+                        let last_token = self.peek_last_token()?.clone();
                         match last_token.token {
                             Token::Eof => {
                                 self.add_diagnostic(
@@ -359,7 +370,7 @@ impl<'a> Parser<'a> {
                         // mimic parse_node_or_eof() behavior
                         //  if last token was an EOF, error out the tuple
                         //  if the last token was something else, just yield back to the parse loop
-                        let last_token = self.tokens[self.next_token - 1].clone();
+                        let last_token = self.peek_last_token()?.clone();
                         match last_token.token {
                             Token::Eof => {
                                 // This indicates we have reached the end of the input.


### PR DESCRIPTION
### Description

This addresses #3541 by eliminating the recursion in `parse_list` and `parse_tuple` (which were the only recursive calls in `parse_node()`.  It replaces that recursion with a do-while loop in `parse_node()`. The return value of `parse_node()` is unchanged: it still returns the next expression at the "current level" of the AST, however, for list and tuple expressions, it does this without invoking `parse_node()` again.

To do this, I added a new enum for open tuple expressions and open list expressions (i.e., expressions which are waiting on child nodes), and broke the logic from `parse_list` and `parse_tuple` into the handlers for those open expressions. This means that the logic is now more spread out than before, and relies on the `parse_node()` loop.

### Applicable issues
- fixes #3541

### Additional info (benefits, drawbacks, caveats)

This makes the V2 AST parser non-recursive, however, it is kind of a sensitive change to the parser. We do have lots of tests cases for the parser, so I'm not too worried that this is radically altering anything, but I think that it is definitely worth careful review here.
