### PR TITLE
[testing] Add integration test to verify that v1 unlock height and epoch 2.1 work as expected

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -95,6 +95,7 @@ jobs:
           - tests::epoch_21::test_pox_reorg_flap_reward_cycles
           - tests::epoch_21::test_pox_missing_five_anchor_blocks
           - tests::epoch_21::test_sortition_divergence_pre_21
+          - tests::epoch_21::test_v1_unlock_height_with_current_stackers
           - tests::neon_integrations::bad_microblock_pubkey
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -96,6 +96,7 @@ jobs:
           - tests::epoch_21::test_pox_missing_five_anchor_blocks
           - tests::epoch_21::test_sortition_divergence_pre_21
           - tests::epoch_21::test_v1_unlock_height_with_current_stackers
+          - tests::epoch_21::test_v1_unlock_height_with_delay_and_current_stackers
           - tests::neon_integrations::bad_microblock_pubkey
     steps:
       - uses: actions/checkout@v2

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -485,19 +485,6 @@ impl Config {
                 "FATAL: v1 unlock height is at a reward cycle boundary\nburnchain: {:?}",
                 burnchain
             );
-        } else if epoch21_rc == v1_unlock_rc {
-            // if v1_unlock_height and epoch_21 are in the same reward cycle, then epoch_21 must be
-            // instantiated before the prepare phase.  This is because pox-2 must exist in the
-            // PoX anchor block for the subsequent reward cycle.
-            //
-            // Ideally, the epoch_21 start height would be at the very beginning of the reward
-            // cycle, but this is not a hard requirement.  However, it is highly recommended to
-            // de-risk the chance that the anchor block is picked before the block in which pox-2
-            // is instantiated.
-            assert!(!burnchain.is_in_prepare_phase(epoch21.start_height));
-            if !burnchain.is_reward_cycle_start(epoch21.start_height) {
-                warn!("DANGEROUS CONFIG: Epoch 2.1 starts at {}, which is _NOT_ the beginning of the reward cycle.", epoch21.start_height);
-            }
         }
     }
 

--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -4936,3 +4936,291 @@ fn test_v1_unlock_height_with_current_stackers() {
     test_observer::clear();
     channel.stop_chains_coordinator();
 }
+
+#[test]
+#[ignore]
+/// Verify that it is acceptable to launch PoX-2 at the end of a reward cycle, and set v1 unlock
+/// height to be at the start of the subsequent reward cycle.
+///
+/// Verify that PoX-1 stackers continue to receive PoX payouts after v1 unlock height, and that
+/// PoX-2 stackers only begin receiving rewards at the start of the reward cycle following the one
+/// that contains v1 unlock height.
+///
+/// Verify that both of the above work even if miners do not mine in the same block as the PoX-2
+/// start height or v1 unlock height (e.g. suppose there's a delay).
+fn test_v1_unlock_height_with_delay_and_current_stackers() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let reward_cycle_len = 10;
+    let prepare_phase_len = 3;
+    let epoch_2_05 = 215;
+    let epoch_2_1 = 230;
+    let v1_unlock_height = 231;
+
+    let stacked = 100_000_000_000 * (core::MICROSTACKS_PER_STACKS as u64);
+
+    let spender_sk = StacksPrivateKey::new();
+    let spender_addr: PrincipalData = to_addr(&spender_sk).into();
+    let mut initial_balances = vec![];
+
+    initial_balances.push(InitialBalance {
+        address: spender_addr.clone(),
+        amount: stacked + 100_000,
+    });
+
+    let pox_pubkey_1 = Secp256k1PublicKey::from_hex(
+        "02f006a09b59979e2cb8449f58076152af6b124aa29b948a3714b8d5f15aa94ede",
+    )
+    .unwrap();
+    let pox_pubkey_hash_1 = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey_1)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let pox_pubkey_2 = Secp256k1PublicKey::from_hex(
+        "03cd91307e16c10428dd0120d0a4d37f14d4e0097b3b2ea1651d7bd0fb109cd44b",
+    )
+    .unwrap();
+    let pox_pubkey_hash_2 = bytes_to_hex(
+        &Hash160::from_node_public_key(&pox_pubkey_2)
+            .to_bytes()
+            .to_vec(),
+    );
+
+    let (mut conf, _) = neon_integration_test_conf();
+
+    // we'll manually post a forked stream to the node
+    conf.node.mine_microblocks = false;
+    conf.burnchain.max_rbf = 1000000;
+    conf.node.wait_time_for_microblocks = 0;
+    conf.node.microblock_frequency = 1_000;
+    conf.miner.first_attempt_time_ms = 2_000;
+    conf.miner.subsequent_attempt_time_ms = 5_000;
+    conf.node.wait_time_for_blocks = 1_000;
+    conf.miner.wait_for_block_download = false;
+
+    conf.miner.min_tx_fee = 1;
+    conf.miner.first_attempt_time_ms = i64::max_value() as u64;
+    conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
+
+    test_observer::spawn();
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+    conf.initial_balances.append(&mut initial_balances);
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = epoch_2_05;
+    epochs[2].start_height = epoch_2_05;
+    epochs[2].end_height = epoch_2_1;
+    epochs[3].start_height = epoch_2_1;
+    conf.burnchain.epochs = Some(epochs);
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let pox_constants = PoxConstants::new(
+        reward_cycle_len,
+        prepare_phase_len,
+        4 * prepare_phase_len / 5,
+        5,
+        15,
+        u64::max_value() - 2,
+        u64::max_value() - 1,
+        v1_unlock_height as u32,
+    );
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let runloop_burnchain = burnchain_config.clone();
+
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    thread::spawn(move || run_loop.start(Some(runloop_burnchain), 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // push us to block 205
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // stack right away
+    let sort_height = channel.get_sortitions_processed();
+    let pox_addr_tuple_1 = execute(
+        &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash_1,),
+        ClarityVersion::Clarity2,
+    )
+    .unwrap()
+    .unwrap();
+    let tx = make_contract_call(
+        &spender_sk,
+        0,
+        3000,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox",
+        "stack-stx",
+        &[
+            Value::UInt(stacked.into()),
+            pox_addr_tuple_1.clone(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(12),
+        ],
+    );
+
+    info!("Submit 2.05 stacking tx to {:?}", &http_origin);
+    submit_tx(&http_origin, &tx);
+
+    // wait until just before epoch 2.1
+    loop {
+        let tip_info = get_chain_info(&conf);
+        if tip_info.burn_block_height >= epoch_2_1 - 2 {
+            break;
+        }
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    // skip a couple sortitions
+    btc_regtest_controller.bootstrap_chain(4);
+    sleep_ms(5000);
+
+    let sort_height = channel.get_sortitions_processed();
+    assert!(sort_height > epoch_2_1);
+    assert!(sort_height > v1_unlock_height);
+
+    // *now* advance to 2.1
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    info!("Test passed processing 2.1");
+
+    let sort_height = channel.get_sortitions_processed();
+    let pox_addr_tuple_2 = execute(
+        &format!("{{ hashbytes: 0x{}, version: 0x00 }}", pox_pubkey_hash_2,),
+        ClarityVersion::Clarity2,
+    )
+    .unwrap()
+    .unwrap();
+    let tx = make_contract_call(
+        &spender_sk,
+        1,
+        3000,
+        &StacksAddress::from_string("ST000000000000000000002AMW42H").unwrap(),
+        "pox-2",
+        "stack-stx",
+        &[
+            Value::UInt(stacked.into()),
+            pox_addr_tuple_2.clone(),
+            Value::UInt(sort_height as u128),
+            Value::UInt(12),
+        ],
+    );
+
+    info!("Submit 2.1 stacking tx to {:?}", &http_origin);
+    submit_tx(&http_origin, &tx);
+
+    // that it can mine _at all_ is a success criterion
+    let mut last_block_height = get_chain_info(&conf).burn_block_height;
+    for _i in 0..20 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+        let tip_info = get_chain_info(&conf);
+        if tip_info.burn_block_height > last_block_height {
+            last_block_height = tip_info.burn_block_height;
+        } else {
+            panic!("FATAL: failed to mine");
+        }
+    }
+
+    let tip_info = get_chain_info(&conf);
+    let tip = StacksBlockId::new(&tip_info.stacks_tip_consensus_hash, &tip_info.stacks_tip);
+
+    let (mut chainstate, _) = StacksChainState::open(
+        false,
+        conf.burnchain.chain_id,
+        &conf.get_chainstate_path_str(),
+        None,
+    )
+    .unwrap();
+    let sortdb = btc_regtest_controller.sortdb_mut();
+
+    for height in 211..tip_info.burn_block_height {
+        let iconn = sortdb.index_conn();
+        let pox_addrs = chainstate
+            .clarity_eval_read_only(
+                &iconn,
+                &tip,
+                &boot_code_id("pox-2", false),
+                &format!("(get-burn-block-info? pox-addrs u{})", height),
+            )
+            .expect_optional()
+            .unwrap()
+            .expect_tuple()
+            .get_owned("addrs")
+            .unwrap()
+            .expect_list();
+
+        debug!("Test burnchain height {}", height);
+        if !burnchain_config.is_in_prepare_phase(height) {
+            let mut have_expected_payout = false;
+            if height < epoch_2_1 + (reward_cycle_len as u64) {
+                if pox_addrs.len() > 0 {
+                    assert_eq!(pox_addrs.len(), 2);
+                    for addr_tuple in pox_addrs {
+                        // can either pay to pox tuple 1, or burn
+                        assert_ne!(addr_tuple, pox_addr_tuple_2);
+                        if addr_tuple == pox_addr_tuple_1 {
+                            have_expected_payout = true;
+                        }
+                    }
+                }
+            } else {
+                if pox_addrs.len() > 0 {
+                    assert_eq!(pox_addrs.len(), 2);
+                    for addr_tuple in pox_addrs {
+                        // can either pay to pox tuple 2, or burn
+                        assert_ne!(addr_tuple, pox_addr_tuple_1);
+                        if addr_tuple == pox_addr_tuple_2 {
+                            have_expected_payout = true;
+                        }
+                    }
+                }
+            }
+            assert!(have_expected_payout);
+        }
+    }
+
+    test_observer::clear();
+    channel.stop_chains_coordinator();
+}


### PR DESCRIPTION
This PR doesn't add any new features.  It just increases test coverage by verifying that PoX 2 will activate if it is instantiated at the very end of a reward cycle, and the v1 unlock height passes at the very beginning of the next.