### PR TITLE
feat: add `vm_error` to analysis failure receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - The transaction receipts for smart contract publish transactions now indicate
   a result of `(err none)` if the top-level code of the smart contract contained
-  runtime error. Fixes issue #3154.
+  runtime error and include details about the erro in the `vm_error` field of
+  the receipt. Fixes issues #3154, #3328.
 
 ## [2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 - The transaction receipts for smart contract publish transactions now indicate
   a result of `(err none)` if the top-level code of the smart contract contained
-  runtime error and include details about the erro in the `vm_error` field of
+  runtime error and include details about the error in the `vm_error` field of
   the receipt. Fixes issues #3154, #3328.
 
 ## [2.1]


### PR DESCRIPTION
### Description

### Applicable issues
- fixes #3328

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
