### PR TITLE
Feat/3596

### DIFF
--- a/testnet/stacks-node/src/tests/epoch_21.rs
+++ b/testnet/stacks-node/src/tests/epoch_21.rs
@@ -4711,7 +4711,7 @@ fn trait_invocation_cross_epoch() {
 
     test_observer::spawn();
 
-    let (mut conf, miner_account) = neon_integration_test_conf();
+    let (mut conf, _) = neon_integration_test_conf();
     let mut initial_balances = vec![InitialBalance {
         address: spender_addr.clone(),
         amount: 200_000_000,
@@ -4727,8 +4727,6 @@ fn trait_invocation_cross_epoch() {
     epochs[2].end_height = epoch_2_1;
     epochs[3].start_height = epoch_2_1;
     conf.burnchain.epochs = Some(epochs);
-
-    let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -67,6 +67,7 @@ use stacks::{
 };
 
 use crate::{
+    burnchains::bitcoin_regtest_controller::BitcoinRPCRequest,
     burnchains::bitcoin_regtest_controller::UTXO, config::EventKeyType,
     config::EventObserverConfig, config::InitialBalance, neon, operations::BurnchainOpSigner,
     syncctl::PoxSyncWatchdogComms, BitcoinRegtestController, BurnchainController, Config,
@@ -10193,6 +10194,70 @@ fn push_boot_receipts() {
         .expect("Expected events key to be an array in mined block event");
 
     assert_eq!(events.len(), 26);
+}
+
+/// Verify that we can operate with a custom wallet name
+#[test]
+#[ignore]
+fn run_with_custom_wallet() {
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let (mut conf, _) = neon_integration_test_conf();
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    // custom wallet
+    conf.burnchain.wallet_name = "test_with_custom_wallet".to_string();
+
+    test_observer::spawn();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::new(conf.clone(), None);
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // Give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // First block wakes up the run loop.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // Second block will hold our VRF registration.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // Third block will be the first mined Stacks block.
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // verify that the event observer got its boot receipts.
+    // If we get this far, then it also means that mining and block-production worked.
+    let blocks = test_observer::get_blocks();
+    assert!(blocks.len() > 1);
+
+    // bitcoin node knows of this wallet
+    let wallets = BitcoinRPCRequest::list_wallets(&conf).unwrap();
+    let mut found = false;
+    for w in wallets {
+        if w == conf.burnchain.wallet_name {
+            found = true;
+        }
+    }
+    assert!(found);
 }
 
 /// Make a contract that takes a parameterized amount of runtime


### PR DESCRIPTION
This PR addresses #3596 by enabling using a custom existing `bitcoind` wallet name when mining, instead of the default one ("") created by Stacks when it boots up for the first time.  This is pertinent for the `listunspent` and `importaddress` RPC calls that the node makes (h/t @MaksimalistT for bringing this up).

To use this feature, you will need to add 'wallet_name' to the '[burnchain]' section as follows:

```
[burnchain]
wallet_name = "name-of-your-wallet"
```

I have tested this with bitcoin 0.22.99.0.