### PR TITLE
Feat/expr-comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 
 ## [Unreleased]
 
+### Added
+
+- When the Clarity library is built with feature flag `developer-mode`, comments
+  from the source code are now attached to the `SymbolicExpression` nodes. This
+  will be useful for tools that use the Clarity library to analyze and
+  manipulate Clarity source code, e.g. a formatter.
+
 ### Fixed
 
 - The transaction receipts for smart contract publish transactions now indicate

--- a/clarity/src/vm/ast/sugar_expander/mod.rs
+++ b/clarity/src/vm/ast/sugar_expander/mod.rs
@@ -663,7 +663,7 @@ mod test {
             make_pre_atom("bar", 4, 1, 4, 3),
         ];
         let foo = make_atom("foo", 1, 1, 1, 3);
-        let mut bar = make_atom("bar", 3, 1, 3, 3);
+        let mut bar = make_atom("bar", 4, 1, 4, 3);
         bar.pre_comments = vec![
             (
                 "this is a comment".to_string(),
@@ -710,7 +710,7 @@ mod test {
             make_pre_atom("bar", 5, 1, 5, 3),
         ];
         let foo = make_atom("foo", 1, 1, 1, 3);
-        let mut bar = make_atom("bar", 3, 1, 3, 3);
+        let mut bar = make_atom("bar", 5, 1, 5, 3);
         bar.pre_comments = vec![
             (
                 "this is a comment".to_string(),

--- a/clarity/src/vm/ast/sugar_expander/mod.rs
+++ b/clarity/src/vm/ast/sugar_expander/mod.rs
@@ -579,7 +579,7 @@ mod test {
         expander.run(&mut contract_ast).unwrap();
         assert_eq!(
             contract_ast.expressions, ast,
-            "`foo` should have the post-comment attached"
+            "`foo` should have the end-line comment attached"
         );
     }
 

--- a/clarity/src/vm/ast/sugar_expander/mod.rs
+++ b/clarity/src/vm/ast/sugar_expander/mod.rs
@@ -64,7 +64,8 @@ impl SugarExpander {
         pre_exprs_iter: PreExpressionsDrain,
         contract_ast: &mut ContractAST,
     ) -> ParseResult<Vec<SymbolicExpression>> {
-        let mut expressions = Vec::new();
+        let mut expressions: Vec<SymbolicExpression> = Vec::new();
+        let mut comments = Vec::new();
 
         for pre_expr in pre_exprs_iter {
             let mut expr = match pre_expr.pre_expr {
@@ -116,12 +117,43 @@ impl SugarExpander {
                         return Err(ParseErrors::TraitReferenceUnknown(name.to_string()).into());
                     }
                 }
-                PreSymbolicExpressionType::Comment(_)
-                | PreSymbolicExpressionType::Placeholder(_) => continue,
+                #[cfg(not(feature = "developer-mode"))]
+                PreSymbolicExpressionType::Comment(_) => continue,
+                #[cfg(feature = "developer-mode")]
+                PreSymbolicExpressionType::Comment(comment) => {
+                    if let Some(last_expr) = expressions.last_mut() {
+                        // If this comment is on the same line as the last expression attach it
+                        if last_expr.span.end_line == pre_expr.span.start_line {
+                            last_expr.end_line_comment = Some(comment);
+                        } else {
+                            // Else, attach it to the next expression
+                            comments.push((comment, pre_expr.span));
+                        }
+                    } else {
+                        comments.push((comment, pre_expr.span));
+                    }
+                    continue;
+                }
+                PreSymbolicExpressionType::Placeholder(_) => continue,
             };
             // expr.id will be set by the subsequent expression identifier pass.
             expr.span = pre_expr.span.clone();
+
+            #[cfg(feature = "developer-mode")]
+            // If there were comments above this expression, attach them.
+            if !comments.is_empty() {
+                expr.pre_comments = std::mem::replace(&mut comments, Vec::new());
+            }
+
             expressions.push(expr);
+        }
+
+        #[cfg(feature = "developer-mode")]
+        // If there were comments after the last expression, attach them.
+        if !comments.is_empty() {
+            if let Some(expr) = expressions.last_mut() {
+                expr.post_comments = comments;
+            }
         }
         Ok(expressions)
     }
@@ -132,8 +164,10 @@ mod test {
     use crate::vm::ast::errors::{ParseError, ParseErrors};
     use crate::vm::ast::sugar_expander::SugarExpander;
     use crate::vm::ast::types::ContractAST;
-    use crate::vm::representations::{ContractName, PreSymbolicExpression, SymbolicExpression};
-    use crate::vm::types::{PrincipalData, QualifiedContractIdentifier};
+    use crate::vm::representations::{
+        ContractName, PreSymbolicExpression, Span, SymbolicExpression,
+    };
+    use crate::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
     use crate::vm::{ast, Value};
 
     fn make_pre_atom(
@@ -192,6 +226,18 @@ mod test {
         end_column: u32,
     ) -> PreSymbolicExpression {
         let mut e = PreSymbolicExpression::sugared_contract_identifier(x);
+        e.set_span(start_line, start_column, end_line, end_column);
+        e
+    }
+
+    fn make_pre_comment(
+        comment: String,
+        start_line: u32,
+        start_column: u32,
+        end_line: u32,
+        end_column: u32,
+    ) -> PreSymbolicExpression {
+        let mut e = PreSymbolicExpression::comment(comment);
         e.set_span(start_line, start_column, end_line, end_column);
         e
     }
@@ -482,6 +528,7 @@ mod test {
             "Should match expected tuple symbolic expression"
         );
     }
+
     #[test]
     fn test_transform_sugared_contract_identifier() {
         let contract_name = "tokens".into();
@@ -507,6 +554,311 @@ mod test {
         assert_eq!(
             contract_ast.expressions, ast,
             "Should match expected symbolic expression"
+        );
+    }
+
+    #[test]
+    fn test_attach_end_line_comment() {
+        let pre_ast = vec![
+            make_pre_atom("foo", 1, 1, 1, 3),
+            make_pre_comment("this is a comment".to_string(), 1, 5, 1, 21),
+            make_pre_atom("bar", 2, 1, 2, 3),
+        ];
+        let mut foo = make_atom("foo", 1, 1, 1, 3);
+        foo.end_line_comment = Some("this is a comment".to_string());
+        let bar = make_atom("bar", 2, 1, 2, 3);
+        let ast = vec![foo, bar];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`foo` should have the post-comment attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_pre_comment() {
+        // Pre-comment at the top of the file
+        let pre_ast = vec![
+            make_pre_comment("this is a comment".to_string(), 1, 1, 1, 17),
+            make_pre_atom("foo", 2, 1, 2, 3),
+            make_pre_atom("bar", 3, 1, 3, 3),
+        ];
+        let mut foo = make_atom("foo", 2, 1, 2, 3);
+        foo.pre_comments = vec![(
+            "this is a comment".to_string(),
+            Span {
+                start_line: 1,
+                start_column: 1,
+                end_line: 1,
+                end_column: 17,
+            },
+        )];
+        let bar = make_atom("bar", 3, 1, 3, 3);
+        let ast = vec![foo, bar];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`foo` should have the pre-comment attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_pre_comment_second() {
+        // Pre-comment on the second expression
+        let pre_ast = vec![
+            make_pre_atom("foo", 1, 1, 1, 3),
+            make_pre_comment("this is a comment".to_string(), 2, 1, 2, 17),
+            make_pre_atom("bar", 3, 1, 3, 3),
+        ];
+        let foo = make_atom("foo", 1, 1, 1, 3);
+        let mut bar = make_atom("bar", 3, 1, 3, 3);
+        bar.pre_comments = vec![(
+            "this is a comment".to_string(),
+            Span {
+                start_line: 2,
+                start_column: 1,
+                end_line: 2,
+                end_column: 17,
+            },
+        )];
+        let ast = vec![foo, bar];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`bar` should have the pre-comment attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_pre_comments_multiple() {
+        // Multiple pre-comments
+        let pre_ast = vec![
+            make_pre_atom("foo", 1, 1, 1, 3),
+            make_pre_comment("this is a comment".to_string(), 2, 1, 2, 17),
+            make_pre_comment("this is another".to_string(), 3, 1, 3, 15),
+            make_pre_atom("bar", 4, 1, 4, 3),
+        ];
+        let foo = make_atom("foo", 1, 1, 1, 3);
+        let mut bar = make_atom("bar", 3, 1, 3, 3);
+        bar.pre_comments = vec![
+            (
+                "this is a comment".to_string(),
+                Span {
+                    start_line: 2,
+                    start_column: 1,
+                    end_line: 2,
+                    end_column: 17,
+                },
+            ),
+            (
+                "this is another".to_string(),
+                Span {
+                    start_line: 3,
+                    start_column: 1,
+                    end_line: 3,
+                    end_column: 15,
+                },
+            ),
+        ];
+        let ast = vec![foo, bar];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`bar` should have both pre-comments attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_pre_comments_newline() {
+        // Multiple pre-comments with a newline in between
+        let pre_ast = vec![
+            make_pre_atom("foo", 1, 1, 1, 3),
+            make_pre_comment("this is a comment".to_string(), 2, 1, 2, 17),
+            make_pre_comment("this is another".to_string(), 4, 1, 4, 15),
+            make_pre_atom("bar", 5, 1, 5, 3),
+        ];
+        let foo = make_atom("foo", 1, 1, 1, 3);
+        let mut bar = make_atom("bar", 3, 1, 3, 3);
+        bar.pre_comments = vec![
+            (
+                "this is a comment".to_string(),
+                Span {
+                    start_line: 2,
+                    start_column: 1,
+                    end_line: 2,
+                    end_column: 17,
+                },
+            ),
+            (
+                "this is another".to_string(),
+                Span {
+                    start_line: 4,
+                    start_column: 1,
+                    end_line: 4,
+                    end_column: 15,
+                },
+            ),
+        ];
+        let ast = vec![foo, bar];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`bar` should have both pre-comments attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_post_comment() {
+        // Post-comment at end of file
+        let pre_ast = vec![
+            make_pre_atom("foo", 1, 1, 1, 3),
+            make_pre_comment("this is a comment".to_string(), 2, 1, 2, 17),
+        ];
+        let mut foo = make_atom("foo", 1, 1, 1, 3);
+        foo.post_comments = vec![(
+            "this is a comment".to_string(),
+            Span {
+                start_line: 2,
+                start_column: 1,
+                end_line: 2,
+                end_column: 17,
+            },
+        )];
+        let ast = vec![foo];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`foo` should have post-comment attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_post_comments_multiple() {
+        // Multiple post-comments at end of file
+        let pre_ast = vec![
+            make_pre_atom("foo", 1, 1, 1, 3),
+            make_pre_comment("this is a comment".to_string(), 2, 1, 2, 17),
+            make_pre_comment("this is another".to_string(), 3, 1, 3, 15),
+        ];
+        let mut foo = make_atom("foo", 1, 1, 1, 3);
+        foo.post_comments = vec![
+            (
+                "this is a comment".to_string(),
+                Span {
+                    start_line: 2,
+                    start_column: 1,
+                    end_line: 2,
+                    end_column: 17,
+                },
+            ),
+            (
+                "this is another".to_string(),
+                Span {
+                    start_line: 3,
+                    start_column: 1,
+                    end_line: 3,
+                    end_column: 15,
+                },
+            ),
+        ];
+        let ast = vec![foo];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`foo` should have both post-comments attached"
+        );
+    }
+
+    #[test]
+    fn test_attach_post_comment_inside_list() {
+        // Post-comment at end of list:
+        // (
+        //    foo
+        //    ;; this is a comment
+        // )
+        let pre_foo = make_pre_atom("foo", 2, 4, 2, 6);
+        let pre_comment = make_pre_comment("this is a comment".to_string(), 3, 4, 3, 20);
+        let pre_ast = vec![make_pre_list(1, 1, 4, 1, Box::new([pre_foo, pre_comment]))];
+        let mut foo = make_atom("foo", 2, 4, 2, 6);
+        foo.post_comments = vec![(
+            "this is a comment".to_string(),
+            Span {
+                start_line: 3,
+                start_column: 4,
+                end_line: 3,
+                end_column: 20,
+            },
+        )];
+        let list = make_list(1, 1, 4, 1, Box::new([foo]));
+        let ast = vec![list];
+
+        let contract_id = QualifiedContractIdentifier::parse(
+            "S1G2081040G2081040G2081040G208105NK8PE5.test-comments",
+        )
+        .unwrap();
+        let mut contract_ast = ContractAST::new(contract_id.clone(), pre_ast);
+
+        let expander = SugarExpander::new(contract_id.issuer);
+        expander.run(&mut contract_ast).unwrap();
+        assert_eq!(
+            contract_ast.expressions, ast,
+            "`foo` should have post-comment attached"
         );
     }
 }

--- a/clarity/src/vm/representations.rs
+++ b/clarity/src/vm/representations.rs
@@ -427,6 +427,13 @@ pub struct SymbolicExpression {
 
     #[cfg(feature = "developer-mode")]
     pub span: Span,
+
+    #[cfg(feature = "developer-mode")]
+    pub pre_comments: Vec<(String, Span)>,
+    #[cfg(feature = "developer-mode")]
+    pub end_line_comment: Option<String>,
+    #[cfg(feature = "developer-mode")]
+    pub post_comments: Vec<(String, Span)>,
 }
 
 impl SymbolicExpression {
@@ -434,8 +441,11 @@ impl SymbolicExpression {
     fn cons() -> SymbolicExpression {
         SymbolicExpression {
             id: 0,
-            span: Span::zero(),
             expr: SymbolicExpressionType::AtomValue(Value::Bool(false)),
+            span: Span::zero(),
+            pre_comments: vec![],
+            end_line_comment: None,
+            post_comments: vec![],
         }
     }
     #[cfg(not(feature = "developer-mode"))]


### PR DESCRIPTION
### Description

Comments are only enabled with feature, `developer-mode`. This will be
useful for tools that want to manipulate Clarity source code, like a
formatter for example.

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
