### PR TITLE
fix: always_use_affirmation_maps defaults to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 ### Fixed
 
 - Handle the case where a bitcoin node returns zero headers (#3588)
+- The default value for `always_use_affirmation_maps` is now set to `false`,
+  instead of `true`.  This was preventing testnet nodes from reaching the chain
+tip with the default configuration.
 
 ## [2.1]
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1729,7 +1729,7 @@ impl NodeConfig {
             marf_defer_hashing: true,
             pox_sync_sample_secs: 30,
             use_test_genesis_chainstate: None,
-            always_use_affirmation_maps: true,
+            always_use_affirmation_maps: false,
             require_affirmed_anchor_blocks: true,
             fault_injection_hide_blocks: false,
         }


### PR DESCRIPTION
Testnet nodes currently do not sync with the default config.  This is because at reward cycle 360, the 2.05 PoX anchor block rules differ from the 2.1 rules -- 2.05 believes that there is an anchor block, while 2.1 does not.

A while back, we added a config option `always_use_affirmation_maps` which forced the node to use the 2.1 rules all the time.  This was meant to allow us to stress-test #2707.  The value for this config option defaults to `true`, meaning that the node uses the 2.1 rules by default in epoch 2.05.  While this isn't a problem on mainnet, it prevents nodes from syncing on testnet due to the above.

This PR switches this config option's default value to `false`.