### PR TITLE
fix/ updated mempool sync protocol tests

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2936,10 +2936,8 @@ pub mod test {
         }
 
         pub fn step(&mut self) -> Result<NetworkResult, net_error> {
-            let mut sortdb = self.sortdb.take().unwrap();
-            let mut stacks_node = self.stacks_node.take().unwrap();
-            let mut mempool = self.mempool.take().unwrap();
-
+            let sortdb = self.sortdb.take().unwrap();
+            let stacks_node = self.stacks_node.take().unwrap();
             let burn_tip_height = SortitionDB::get_canonical_burn_chain_tip(sortdb.conn())
                 .unwrap()
                 .block_height;
@@ -2954,6 +2952,17 @@ pub mod test {
                 stacks_tip_height,
                 burn_tip_height,
             );
+            self.sortdb = Some(sortdb);
+            self.stacks_node = Some(stacks_node);
+
+            self.step_with_ibd(ibd)
+        }
+
+        pub fn step_with_ibd(&mut self, ibd: bool) -> Result<NetworkResult, net_error> {
+            let mut sortdb = self.sortdb.take().unwrap();
+            let mut stacks_node = self.stacks_node.take().unwrap();
+            let mut mempool = self.mempool.take().unwrap();
+
             let indexer = BitcoinIndexer::new_unit_test(&self.config.burnchain.working_dir);
 
             let ret = self.network.run(

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2185,12 +2185,11 @@ impl PeerNetwork {
         chainstate: &mut StacksChainState,
         ibd: bool,
     ) -> Option<Vec<StacksTransaction>> {
-        #[cfg(not(test))]
         if ibd {
             return None;
         }
 
-        match self.do_mempool_sync(dns_client_opt, mempool, chainstate) {
+        return match self.do_mempool_sync(dns_client_opt, mempool, chainstate) {
             (true, txs_opt) => {
                 // did we run to completion?
                 if let Some(txs) = txs_opt {
@@ -2204,9 +2203,9 @@ impl PeerNetwork {
                         get_epoch_time_secs() + self.connection_opts.mempool_sync_interval;
                     self.mempool_sync_completions = self.mempool_sync_completions.saturating_add(1);
                     self.mempool_sync_txs = self.mempool_sync_txs.saturating_add(txs.len() as u64);
-                    return Some(txs);
+                    Some(txs)
                 } else {
-                    return None;
+                    None
                 }
             }
             (false, txs_opt) => {
@@ -2219,9 +2218,9 @@ impl PeerNetwork {
                     );
 
                     self.mempool_sync_txs = self.mempool_sync_txs.saturating_add(txs.len() as u64);
-                    return Some(txs);
+                    Some(txs)
                 } else {
-                    return None;
+                    None
                 }
             }
         }
@@ -6004,7 +6003,7 @@ mod test {
         let mut peer_2_mempool_txs = 0;
 
         while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
-            if let Ok(mut result) = peer_1.step() {
+            if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6022,7 +6021,7 @@ mod test {
                     .unwrap();
             }
 
-            if let Ok(mut result) = peer_2.step() {
+            if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6191,7 +6190,7 @@ mod test {
         let mut peer_2_mempool_txs = 0;
 
         while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
-            if let Ok(mut result) = peer_1.step() {
+            if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6209,7 +6208,7 @@ mod test {
                     .unwrap();
             }
 
-            if let Ok(mut result) = peer_2.step() {
+            if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6395,7 +6394,7 @@ mod test {
         let mut peer_2_mempool_txs = 0;
 
         while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs / 2 {
-            if let Ok(mut result) = peer_1.step() {
+            if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6413,7 +6412,7 @@ mod test {
                     .unwrap();
             }
 
-            if let Ok(mut result) = peer_2.step() {
+            if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6579,7 +6578,7 @@ mod test {
         let mut peer_1_mempool_txs = 0;
 
         while peer_1_mempool_txs < num_txs || peer_2.network.mempool_sync_txs < (num_txs as u64) {
-            if let Ok(mut result) = peer_1.step() {
+            if let Ok(mut result) = peer_1.step_with_ibd(false) {
                 let lp = peer_1.network.local_peer.clone();
                 peer_1
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {
@@ -6597,7 +6596,7 @@ mod test {
                     .unwrap();
             }
 
-            if let Ok(mut result) = peer_2.step() {
+            if let Ok(mut result) = peer_2.step_with_ibd(false) {
                 let lp = peer_2.network.local_peer.clone();
                 peer_2
                     .with_db_state(|sortdb, chainstate, relayer, mempool| {

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2185,6 +2185,7 @@ impl PeerNetwork {
         chainstate: &mut StacksChainState,
         ibd: bool,
     ) -> Option<Vec<StacksTransaction>> {
+        #[cfg(not(test))]
         if ibd {
             return None;
         }
@@ -5811,850 +5812,827 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_mempool_sync_2_peers() {
-        with_timeout(600, || {
-            // peer 1 gets some transactions; verify peer 2 gets the recent ones and not the old
-            // ones
-            let mut peer_1_config = TestPeerConfig::new(function_name!(), 2210, 2211);
-            let mut peer_2_config = TestPeerConfig::new(function_name!(), 2212, 2213);
+        // peer 1 gets some transactions; verify peer 2 gets the recent ones and not the old
+        // ones
+        let mut peer_1_config = TestPeerConfig::new(function_name!(), 2210, 2211);
+        let mut peer_2_config = TestPeerConfig::new(function_name!(), 2212, 2213);
 
-            peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-            peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
-            peer_1_config.connection_opts.mempool_sync_interval = 1;
-            peer_2_config.connection_opts.mempool_sync_interval = 1;
+        peer_1_config.connection_opts.mempool_sync_interval = 1;
+        peer_2_config.connection_opts.mempool_sync_interval = 1;
 
-            let num_txs = 10;
-            let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
-            let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
-            let initial_balances: Vec<_> = addrs
-                .iter()
-                .map(|a| (a.to_account_principal(), 1000000000))
-                .collect();
+        let num_txs = 10;
+        let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+        let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
+        let initial_balances: Vec<_> = addrs
+            .iter()
+            .map(|a| (a.to_account_principal(), 1000000000))
+            .collect();
 
-            peer_1_config.initial_balances = initial_balances.clone();
-            peer_2_config.initial_balances = initial_balances.clone();
+        peer_1_config.initial_balances = initial_balances.clone();
+        peer_2_config.initial_balances = initial_balances.clone();
 
-            let mut peer_1 = TestPeer::new(peer_1_config);
-            let mut peer_2 = TestPeer::new(peer_2_config);
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
 
-            let num_blocks = 10;
-            let first_stacks_block_height = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    &peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
+        let num_blocks = 10;
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        for i in 0..(num_blocks / 2) {
+            let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+
+            peer_1.next_burnchain_block(burn_ops.clone());
+            peer_2.next_burnchain_block(burn_ops.clone());
+
+            peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+        }
+
+        let addr = StacksAddress {
+            version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            bytes: Hash160([0xff; 20]),
+        };
+
+        // old transactions
+        let num_txs = 10;
+        let mut old_txs = HashMap::new();
+        let mut peer_1_mempool = peer_1.mempool.take().unwrap();
+        let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
+        for i in 0..num_txs {
+            let pk = &pks[i];
+            let mut tx = StacksTransaction {
+                version: TransactionVersion::Testnet,
+                chain_id: 0x80000000,
+                auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
+                anchor_mode: TransactionAnchorMode::Any,
+                post_condition_mode: TransactionPostConditionMode::Allow,
+                post_conditions: vec![],
+                payload: TransactionPayload::TokenTransfer(
+                    addr.to_account_principal(),
+                    123,
+                    TokenTransferMemo([0u8; 34]),
+                ),
             };
+            tx.set_tx_fee(1000);
+            tx.set_origin_nonce(0);
 
-            for i in 0..(num_blocks / 2) {
-                let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+            let mut tx_signer = StacksTransactionSigner::new(&tx);
+            tx_signer.sign_origin(&pk).unwrap();
 
-                peer_1.next_burnchain_block(burn_ops.clone());
-                peer_2.next_burnchain_block(burn_ops.clone());
+            let tx = tx_signer.get_tx().unwrap();
 
-                peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
-                peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
-            }
+            let txid = tx.txid();
+            let tx_bytes = tx.serialize_to_vec();
+            let origin_addr = tx.origin_address();
+            let origin_nonce = tx.get_origin_nonce();
+            let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
+            let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+            let tx_fee = tx.get_tx_fee();
 
-            let addr = StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                bytes: Hash160([0xff; 20]),
+            old_txs.insert(tx.txid(), tx.clone());
+
+            // should succeed
+            MemPoolDB::try_add_tx(
+                &mut mempool_tx,
+                peer_1.chainstate(),
+                &ConsensusHash([0x1 + (num_blocks as u8); 20]),
+                &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
+                txid.clone(),
+                tx_bytes,
+                tx_fee,
+                (num_blocks / 2) as u64,
+                &origin_addr,
+                origin_nonce,
+                &sponsor_addr,
+                sponsor_nonce,
+                None,
+            )
+            .unwrap();
+
+            eprintln!("Added {} {}", i, &txid);
+        }
+        mempool_tx.commit().unwrap();
+        peer_1.mempool = Some(peer_1_mempool);
+
+        // keep mining to make these txs old
+        for i in (num_blocks / 2)..num_blocks {
+            let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+
+            peer_1.next_burnchain_block(burn_ops.clone());
+            peer_2.next_burnchain_block(burn_ops.clone());
+
+            peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+        }
+
+        let num_burn_blocks = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        let mut txs = HashMap::new();
+        let mut peer_1_mempool = peer_1.mempool.take().unwrap();
+        let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
+        for i in 0..num_txs {
+            let pk = &pks[i];
+            let mut tx = StacksTransaction {
+                version: TransactionVersion::Testnet,
+                chain_id: 0x80000000,
+                auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
+                anchor_mode: TransactionAnchorMode::Any,
+                post_condition_mode: TransactionPostConditionMode::Allow,
+                post_conditions: vec![],
+                payload: TransactionPayload::TokenTransfer(
+                    addr.to_account_principal(),
+                    123,
+                    TokenTransferMemo([0u8; 34]),
+                ),
             };
+            tx.set_tx_fee(1000);
+            tx.set_origin_nonce(1);
 
-            // old transactions
-            let num_txs = 10;
-            let mut old_txs = HashMap::new();
-            let mut peer_1_mempool = peer_1.mempool.take().unwrap();
-            let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
-            for i in 0..num_txs {
-                let pk = &pks[i];
-                let mut tx = StacksTransaction {
-                    version: TransactionVersion::Testnet,
-                    chain_id: 0x80000000,
-                    auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
-                    anchor_mode: TransactionAnchorMode::Any,
-                    post_condition_mode: TransactionPostConditionMode::Allow,
-                    post_conditions: vec![],
-                    payload: TransactionPayload::TokenTransfer(
-                        addr.to_account_principal(),
-                        123,
-                        TokenTransferMemo([0u8; 34]),
-                    ),
-                };
-                tx.set_tx_fee(1000);
-                tx.set_origin_nonce(0);
+            let mut tx_signer = StacksTransactionSigner::new(&tx);
+            tx_signer.sign_origin(&pk).unwrap();
 
-                let mut tx_signer = StacksTransactionSigner::new(&tx);
-                tx_signer.sign_origin(&pk).unwrap();
+            let tx = tx_signer.get_tx().unwrap();
 
-                let tx = tx_signer.get_tx().unwrap();
+            let txid = tx.txid();
+            let tx_bytes = tx.serialize_to_vec();
+            let origin_addr = tx.origin_address();
+            let origin_nonce = tx.get_origin_nonce();
+            let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
+            let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+            let tx_fee = tx.get_tx_fee();
 
-                let txid = tx.txid();
-                let tx_bytes = tx.serialize_to_vec();
-                let origin_addr = tx.origin_address();
-                let origin_nonce = tx.get_origin_nonce();
-                let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
-                let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
-                let tx_fee = tx.get_tx_fee();
+            txs.insert(tx.txid(), tx.clone());
 
-                old_txs.insert(tx.txid(), tx.clone());
+            // should succeed
+            MemPoolDB::try_add_tx(
+                &mut mempool_tx,
+                peer_1.chainstate(),
+                &ConsensusHash([0x1 + (num_blocks as u8); 20]),
+                &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
+                txid.clone(),
+                tx_bytes,
+                tx_fee,
+                num_blocks as u64,
+                &origin_addr,
+                origin_nonce,
+                &sponsor_addr,
+                sponsor_nonce,
+                None,
+            )
+            .unwrap();
 
-                // should succeed
-                MemPoolDB::try_add_tx(
-                    &mut mempool_tx,
-                    peer_1.chainstate(),
-                    &ConsensusHash([0x1 + (num_blocks as u8); 20]),
-                    &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
-                    txid.clone(),
-                    tx_bytes,
-                    tx_fee,
-                    (num_blocks / 2) as u64,
-                    &origin_addr,
-                    origin_nonce,
-                    &sponsor_addr,
-                    sponsor_nonce,
-                    None,
-                )
-                .unwrap();
+            eprintln!("Added {} {}", i, &txid);
+        }
+        mempool_tx.commit().unwrap();
+        peer_1.mempool = Some(peer_1_mempool);
 
-                eprintln!("Added {} {}", i, &txid);
-            }
-            mempool_tx.commit().unwrap();
-            peer_1.mempool = Some(peer_1_mempool);
+        let mut round = 0;
+        let mut peer_1_mempool_txs = 0;
+        let mut peer_2_mempool_txs = 0;
 
-            // keep mining to make these txs old
-            for i in (num_blocks / 2)..num_blocks {
-                let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
-
-                peer_1.next_burnchain_block(burn_ops.clone());
-                peer_2.next_burnchain_block(burn_ops.clone());
-
-                peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
-                peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+        while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
+            if let Ok(mut result) = peer_1.step() {
+                let lp = peer_1.network.local_peer.clone();
+                peer_1
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            let num_burn_blocks = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
-            };
-
-            let mut txs = HashMap::new();
-            let mut peer_1_mempool = peer_1.mempool.take().unwrap();
-            let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
-            for i in 0..num_txs {
-                let pk = &pks[i];
-                let mut tx = StacksTransaction {
-                    version: TransactionVersion::Testnet,
-                    chain_id: 0x80000000,
-                    auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
-                    anchor_mode: TransactionAnchorMode::Any,
-                    post_condition_mode: TransactionPostConditionMode::Allow,
-                    post_conditions: vec![],
-                    payload: TransactionPayload::TokenTransfer(
-                        addr.to_account_principal(),
-                        123,
-                        TokenTransferMemo([0u8; 34]),
-                    ),
-                };
-                tx.set_tx_fee(1000);
-                tx.set_origin_nonce(1);
-
-                let mut tx_signer = StacksTransactionSigner::new(&tx);
-                tx_signer.sign_origin(&pk).unwrap();
-
-                let tx = tx_signer.get_tx().unwrap();
-
-                let txid = tx.txid();
-                let tx_bytes = tx.serialize_to_vec();
-                let origin_addr = tx.origin_address();
-                let origin_nonce = tx.get_origin_nonce();
-                let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
-                let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
-                let tx_fee = tx.get_tx_fee();
-
-                txs.insert(tx.txid(), tx.clone());
-
-                // should succeed
-                MemPoolDB::try_add_tx(
-                    &mut mempool_tx,
-                    peer_1.chainstate(),
-                    &ConsensusHash([0x1 + (num_blocks as u8); 20]),
-                    &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
-                    txid.clone(),
-                    tx_bytes,
-                    tx_fee,
-                    num_blocks as u64,
-                    &origin_addr,
-                    origin_nonce,
-                    &sponsor_addr,
-                    sponsor_nonce,
-                    None,
-                )
-                .unwrap();
-
-                eprintln!("Added {} {}", i, &txid);
-            }
-            mempool_tx.commit().unwrap();
-            peer_1.mempool = Some(peer_1_mempool);
-
-            let mut round = 0;
-            let mut peer_1_mempool_txs = 0;
-            let mut peer_2_mempool_txs = 0;
-
-            while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
-                if let Ok(mut result) = peer_1.step() {
-                    let lp = peer_1.network.local_peer.clone();
-                    peer_1
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                if let Ok(mut result) = peer_2.step() {
-                    let lp = peer_2.network.local_peer.clone();
-                    peer_2
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                round += 1;
-
-                let mp = peer_1.mempool.take().unwrap();
-                peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_1.mempool.replace(mp);
-
-                let mp = peer_2.mempool.take().unwrap();
-                peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_2.mempool.replace(mp);
-
-                info!(
-                    "Peer 1: {}, Peer 2: {}",
-                    peer_1_mempool_txs, peer_2_mempool_txs
-                );
+            if let Ok(mut result) = peer_2.step() {
+                let lp = peer_2.network.local_peer.clone();
+                peer_2
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            info!("Completed mempool sync in {} step(s)", round);
+            round += 1;
+
+            let mp = peer_1.mempool.take().unwrap();
+            peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
+            peer_1.mempool.replace(mp);
 
             let mp = peer_2.mempool.take().unwrap();
-            let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+            peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
             peer_2.mempool.replace(mp);
 
-            // peer 2 has all the recent txs
-            // peer 2 has none of the old ones
-            for tx in peer_2_mempool_txs {
-                assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
-                assert!(old_txs.get(&tx.tx.txid()).is_none());
-            }
-        });
+            info!(
+                "Peer 1: {}, Peer 2: {}",
+                peer_1_mempool_txs, peer_2_mempool_txs
+            );
+        }
+
+        info!("Completed mempool sync in {} step(s)", round);
+
+        let mp = peer_2.mempool.take().unwrap();
+        let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+        peer_2.mempool.replace(mp);
+
+        // peer 2 has all the recent txs
+        // peer 2 has none of the old ones
+        for tx in peer_2_mempool_txs {
+            assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
+            assert!(old_txs.get(&tx.tx.txid()).is_none());
+        }
     }
 
     #[test]
-    #[ignore]
     fn test_mempool_sync_2_peers_paginated() {
-        with_timeout(600, || {
-            // peer 1 gets some transactions; verify peer 2 gets them all
-            let mut peer_1_config = TestPeerConfig::new(function_name!(), 2214, 2215);
-            let mut peer_2_config = TestPeerConfig::new(function_name!(), 2216, 2217);
+        // peer 1 gets some transactions; verify peer 2 gets them all
+        let mut peer_1_config = TestPeerConfig::new(function_name!(), 2214, 2215);
+        let mut peer_2_config = TestPeerConfig::new(function_name!(), 2216, 2217);
 
-            peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-            peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
-            peer_1_config.connection_opts.mempool_sync_interval = 1;
-            peer_2_config.connection_opts.mempool_sync_interval = 1;
+        peer_1_config.connection_opts.mempool_sync_interval = 1;
+        peer_2_config.connection_opts.mempool_sync_interval = 1;
 
-            let num_txs = 1024;
-            let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
-            let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
-            let initial_balances: Vec<_> = addrs
-                .iter()
-                .map(|a| (a.to_account_principal(), 1000000000))
-                .collect();
+        let num_txs = 1024;
+        let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+        let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
+        let initial_balances: Vec<_> = addrs
+            .iter()
+            .map(|a| (a.to_account_principal(), 1000000000))
+            .collect();
 
-            peer_1_config.initial_balances = initial_balances.clone();
-            peer_2_config.initial_balances = initial_balances.clone();
+        peer_1_config.initial_balances = initial_balances.clone();
+        peer_2_config.initial_balances = initial_balances.clone();
 
-            let mut peer_1 = TestPeer::new(peer_1_config);
-            let mut peer_2 = TestPeer::new(peer_2_config);
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
 
-            let num_blocks = 10;
-            let first_stacks_block_height = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    &peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
+        let num_blocks = 10;
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        for i in 0..num_blocks {
+            let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+
+            peer_1.next_burnchain_block(burn_ops.clone());
+            peer_2.next_burnchain_block(burn_ops.clone());
+
+            peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+        }
+
+        let addr = StacksAddress {
+            version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            bytes: Hash160([0xff; 20]),
+        };
+
+        // fill peer 1 with lots of transactions
+        let mut txs = HashMap::new();
+        let mut peer_1_mempool = peer_1.mempool.take().unwrap();
+        let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
+        for i in 0..num_txs {
+            let pk = &pks[i];
+            let mut tx = StacksTransaction {
+                version: TransactionVersion::Testnet,
+                chain_id: 0x80000000,
+                auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
+                anchor_mode: TransactionAnchorMode::Any,
+                post_condition_mode: TransactionPostConditionMode::Allow,
+                post_conditions: vec![],
+                payload: TransactionPayload::TokenTransfer(
+                    addr.to_account_principal(),
+                    123,
+                    TokenTransferMemo([0u8; 34]),
+                ),
             };
+            tx.set_tx_fee(1000);
+            tx.set_origin_nonce(0);
 
-            for i in 0..num_blocks {
-                let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+            let mut tx_signer = StacksTransactionSigner::new(&tx);
+            tx_signer.sign_origin(&pk).unwrap();
 
-                peer_1.next_burnchain_block(burn_ops.clone());
-                peer_2.next_burnchain_block(burn_ops.clone());
+            let tx = tx_signer.get_tx().unwrap();
 
-                peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
-                peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            let txid = tx.txid();
+            let tx_bytes = tx.serialize_to_vec();
+            let origin_addr = tx.origin_address();
+            let origin_nonce = tx.get_origin_nonce();
+            let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
+            let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+            let tx_fee = tx.get_tx_fee();
+
+            txs.insert(tx.txid(), tx.clone());
+
+            // should succeed
+            MemPoolDB::try_add_tx(
+                &mut mempool_tx,
+                peer_1.chainstate(),
+                &ConsensusHash([0x1 + (num_blocks as u8); 20]),
+                &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
+                txid.clone(),
+                tx_bytes,
+                tx_fee,
+                num_blocks,
+                &origin_addr,
+                origin_nonce,
+                &sponsor_addr,
+                sponsor_nonce,
+                None,
+            )
+            .unwrap();
+
+            eprintln!("Added {} {}", i, &txid);
+        }
+        mempool_tx.commit().unwrap();
+        peer_1.mempool = Some(peer_1_mempool);
+
+        let num_burn_blocks = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        let mut round = 0;
+        let mut peer_1_mempool_txs = 0;
+        let mut peer_2_mempool_txs = 0;
+
+        while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
+            if let Ok(mut result) = peer_1.step() {
+                let lp = peer_1.network.local_peer.clone();
+                peer_1
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            let addr = StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                bytes: Hash160([0xff; 20]),
-            };
-
-            // fill peer 1 with lots of transactions
-            let mut txs = HashMap::new();
-            let mut peer_1_mempool = peer_1.mempool.take().unwrap();
-            let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
-            for i in 0..num_txs {
-                let pk = &pks[i];
-                let mut tx = StacksTransaction {
-                    version: TransactionVersion::Testnet,
-                    chain_id: 0x80000000,
-                    auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
-                    anchor_mode: TransactionAnchorMode::Any,
-                    post_condition_mode: TransactionPostConditionMode::Allow,
-                    post_conditions: vec![],
-                    payload: TransactionPayload::TokenTransfer(
-                        addr.to_account_principal(),
-                        123,
-                        TokenTransferMemo([0u8; 34]),
-                    ),
-                };
-                tx.set_tx_fee(1000);
-                tx.set_origin_nonce(0);
-
-                let mut tx_signer = StacksTransactionSigner::new(&tx);
-                tx_signer.sign_origin(&pk).unwrap();
-
-                let tx = tx_signer.get_tx().unwrap();
-
-                let txid = tx.txid();
-                let tx_bytes = tx.serialize_to_vec();
-                let origin_addr = tx.origin_address();
-                let origin_nonce = tx.get_origin_nonce();
-                let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
-                let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
-                let tx_fee = tx.get_tx_fee();
-
-                txs.insert(tx.txid(), tx.clone());
-
-                // should succeed
-                MemPoolDB::try_add_tx(
-                    &mut mempool_tx,
-                    peer_1.chainstate(),
-                    &ConsensusHash([0x1 + (num_blocks as u8); 20]),
-                    &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
-                    txid.clone(),
-                    tx_bytes,
-                    tx_fee,
-                    num_blocks,
-                    &origin_addr,
-                    origin_nonce,
-                    &sponsor_addr,
-                    sponsor_nonce,
-                    None,
-                )
-                .unwrap();
-
-                eprintln!("Added {} {}", i, &txid);
-            }
-            mempool_tx.commit().unwrap();
-            peer_1.mempool = Some(peer_1_mempool);
-
-            let num_burn_blocks = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
-            };
-
-            let mut round = 0;
-            let mut peer_1_mempool_txs = 0;
-            let mut peer_2_mempool_txs = 0;
-
-            while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs {
-                if let Ok(mut result) = peer_1.step() {
-                    let lp = peer_1.network.local_peer.clone();
-                    peer_1
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                if let Ok(mut result) = peer_2.step() {
-                    let lp = peer_2.network.local_peer.clone();
-                    peer_2
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                round += 1;
-
-                let mp = peer_1.mempool.take().unwrap();
-                peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_1.mempool.replace(mp);
-
-                let mp = peer_2.mempool.take().unwrap();
-                peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_2.mempool.replace(mp);
-
-                info!(
-                    "Peer 1: {}, Peer 2: {}",
-                    peer_1_mempool_txs, peer_2_mempool_txs
-                );
+            if let Ok(mut result) = peer_2.step() {
+                let lp = peer_2.network.local_peer.clone();
+                peer_2
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            info!("Completed mempool sync in {} step(s)", round);
+            round += 1;
+
+            let mp = peer_1.mempool.take().unwrap();
+            peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
+            peer_1.mempool.replace(mp);
 
             let mp = peer_2.mempool.take().unwrap();
-            let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+            peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
             peer_2.mempool.replace(mp);
 
-            for tx in peer_2_mempool_txs {
-                assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
-            }
-        });
+            info!(
+                "Peer 1: {}, Peer 2: {}",
+                peer_1_mempool_txs, peer_2_mempool_txs
+            );
+        }
+
+        info!("Completed mempool sync in {} step(s)", round);
+
+        let mp = peer_2.mempool.take().unwrap();
+        let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+        peer_2.mempool.replace(mp);
+
+        for tx in peer_2_mempool_txs {
+            assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
+        }
     }
 
     #[test]
-    #[ignore]
     fn test_mempool_sync_2_peers_blacklisted() {
-        with_timeout(600, || {
-            // peer 1 gets some transactions; peer 2 blacklists some of them;
-            // verify peer 2 gets only the non-blacklisted ones.
-            let mut peer_1_config = TestPeerConfig::new(function_name!(), 2218, 2219);
-            let mut peer_2_config = TestPeerConfig::new(function_name!(), 2220, 2221);
+        // peer 1 gets some transactions; peer 2 blacklists some of them;
+        // verify peer 2 gets only the non-blacklisted ones.
+        let mut peer_1_config = TestPeerConfig::new(function_name!(), 2218, 2219);
+        let mut peer_2_config = TestPeerConfig::new(function_name!(), 2220, 2221);
 
-            peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-            peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
-            peer_1_config.connection_opts.mempool_sync_interval = 1;
-            peer_2_config.connection_opts.mempool_sync_interval = 1;
+        peer_1_config.connection_opts.mempool_sync_interval = 1;
+        peer_2_config.connection_opts.mempool_sync_interval = 1;
 
-            let num_txs = 1024;
-            let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
-            let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
-            let initial_balances: Vec<_> = addrs
-                .iter()
-                .map(|a| (a.to_account_principal(), 1000000000))
-                .collect();
+        let num_txs = 1024;
+        let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+        let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
+        let initial_balances: Vec<_> = addrs
+            .iter()
+            .map(|a| (a.to_account_principal(), 1000000000))
+            .collect();
 
-            peer_1_config.initial_balances = initial_balances.clone();
-            peer_2_config.initial_balances = initial_balances.clone();
+        peer_1_config.initial_balances = initial_balances.clone();
+        peer_2_config.initial_balances = initial_balances.clone();
 
-            let mut peer_1 = TestPeer::new(peer_1_config);
-            let mut peer_2 = TestPeer::new(peer_2_config);
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
 
-            let num_blocks = 10;
-            let first_stacks_block_height = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    &peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
+        let num_blocks = 10;
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        for i in 0..num_blocks {
+            let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+
+            peer_1.next_burnchain_block(burn_ops.clone());
+            peer_2.next_burnchain_block(burn_ops.clone());
+
+            peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+        }
+
+        let addr = StacksAddress {
+            version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            bytes: Hash160([0xff; 20]),
+        };
+
+        // fill peer 1 with lots of transactions
+        let mut txs = HashMap::new();
+        let mut peer_1_mempool = peer_1.mempool.take().unwrap();
+        let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
+        let mut peer_2_blacklist = vec![];
+        for i in 0..num_txs {
+            let pk = &pks[i];
+            let mut tx = StacksTransaction {
+                version: TransactionVersion::Testnet,
+                chain_id: 0x80000000,
+                auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
+                anchor_mode: TransactionAnchorMode::Any,
+                post_condition_mode: TransactionPostConditionMode::Allow,
+                post_conditions: vec![],
+                payload: TransactionPayload::TokenTransfer(
+                    addr.to_account_principal(),
+                    123,
+                    TokenTransferMemo([0u8; 34]),
+                ),
             };
+            tx.set_tx_fee(1000);
+            tx.set_origin_nonce(0);
 
-            for i in 0..num_blocks {
-                let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+            let mut tx_signer = StacksTransactionSigner::new(&tx);
+            tx_signer.sign_origin(&pk).unwrap();
 
-                peer_1.next_burnchain_block(burn_ops.clone());
-                peer_2.next_burnchain_block(burn_ops.clone());
+            let tx = tx_signer.get_tx().unwrap();
 
-                peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
-                peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            let txid = tx.txid();
+            let tx_bytes = tx.serialize_to_vec();
+            let origin_addr = tx.origin_address();
+            let origin_nonce = tx.get_origin_nonce();
+            let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
+            let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+            let tx_fee = tx.get_tx_fee();
+
+            txs.insert(tx.txid(), tx.clone());
+
+            // should succeed
+            MemPoolDB::try_add_tx(
+                &mut mempool_tx,
+                peer_1.chainstate(),
+                &ConsensusHash([0x1 + (num_blocks as u8); 20]),
+                &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
+                txid.clone(),
+                tx_bytes,
+                tx_fee,
+                num_blocks,
+                &origin_addr,
+                origin_nonce,
+                &sponsor_addr,
+                sponsor_nonce,
+                None,
+            )
+            .unwrap();
+
+            eprintln!("Added {} {}", i, &txid);
+
+            if i % 2 == 0 {
+                // peer 2 blacklists even-numbered txs
+                peer_2_blacklist.push(txid);
+            }
+        }
+        mempool_tx.commit().unwrap();
+        peer_1.mempool = Some(peer_1_mempool);
+
+        // peer 2 blacklists them all
+        let mut peer_2_mempool = peer_2.mempool.take().unwrap();
+
+        // blacklisted txs never time out
+        peer_2_mempool.blacklist_timeout = u64::MAX / 2;
+
+        let mempool_tx = peer_2_mempool.tx_begin().unwrap();
+        MemPoolDB::inner_blacklist_txs(&mempool_tx, &peer_2_blacklist, get_epoch_time_secs())
+            .unwrap();
+        mempool_tx.commit().unwrap();
+
+        peer_2.mempool = Some(peer_2_mempool);
+
+        let num_burn_blocks = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        let mut round = 0;
+        let mut peer_1_mempool_txs = 0;
+        let mut peer_2_mempool_txs = 0;
+
+        while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs / 2 {
+            if let Ok(mut result) = peer_1.step() {
+                let lp = peer_1.network.local_peer.clone();
+                peer_1
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            let addr = StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                bytes: Hash160([0xff; 20]),
-            };
-
-            // fill peer 1 with lots of transactions
-            let mut txs = HashMap::new();
-            let mut peer_1_mempool = peer_1.mempool.take().unwrap();
-            let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
-            let mut peer_2_blacklist = vec![];
-            for i in 0..num_txs {
-                let pk = &pks[i];
-                let mut tx = StacksTransaction {
-                    version: TransactionVersion::Testnet,
-                    chain_id: 0x80000000,
-                    auth: TransactionAuth::from_p2pkh(&pk).unwrap(),
-                    anchor_mode: TransactionAnchorMode::Any,
-                    post_condition_mode: TransactionPostConditionMode::Allow,
-                    post_conditions: vec![],
-                    payload: TransactionPayload::TokenTransfer(
-                        addr.to_account_principal(),
-                        123,
-                        TokenTransferMemo([0u8; 34]),
-                    ),
-                };
-                tx.set_tx_fee(1000);
-                tx.set_origin_nonce(0);
-
-                let mut tx_signer = StacksTransactionSigner::new(&tx);
-                tx_signer.sign_origin(&pk).unwrap();
-
-                let tx = tx_signer.get_tx().unwrap();
-
-                let txid = tx.txid();
-                let tx_bytes = tx.serialize_to_vec();
-                let origin_addr = tx.origin_address();
-                let origin_nonce = tx.get_origin_nonce();
-                let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
-                let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
-                let tx_fee = tx.get_tx_fee();
-
-                txs.insert(tx.txid(), tx.clone());
-
-                // should succeed
-                MemPoolDB::try_add_tx(
-                    &mut mempool_tx,
-                    peer_1.chainstate(),
-                    &ConsensusHash([0x1 + (num_blocks as u8); 20]),
-                    &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
-                    txid.clone(),
-                    tx_bytes,
-                    tx_fee,
-                    num_blocks,
-                    &origin_addr,
-                    origin_nonce,
-                    &sponsor_addr,
-                    sponsor_nonce,
-                    None,
-                )
-                .unwrap();
-
-                eprintln!("Added {} {}", i, &txid);
-
-                if i % 2 == 0 {
-                    // peer 2 blacklists even-numbered txs
-                    peer_2_blacklist.push(txid);
-                }
-            }
-            mempool_tx.commit().unwrap();
-            peer_1.mempool = Some(peer_1_mempool);
-
-            // peer 2 blacklists them all
-            let mut peer_2_mempool = peer_2.mempool.take().unwrap();
-
-            // blacklisted txs never time out
-            peer_2_mempool.blacklist_timeout = u64::MAX / 2;
-
-            let mempool_tx = peer_2_mempool.tx_begin().unwrap();
-            MemPoolDB::inner_blacklist_txs(&mempool_tx, &peer_2_blacklist, get_epoch_time_secs())
-                .unwrap();
-            mempool_tx.commit().unwrap();
-
-            peer_2.mempool = Some(peer_2_mempool);
-
-            let num_burn_blocks = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
-            };
-
-            let mut round = 0;
-            let mut peer_1_mempool_txs = 0;
-            let mut peer_2_mempool_txs = 0;
-
-            while peer_1_mempool_txs < num_txs || peer_2_mempool_txs < num_txs / 2 {
-                if let Ok(mut result) = peer_1.step() {
-                    let lp = peer_1.network.local_peer.clone();
-                    peer_1
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                if let Ok(mut result) = peer_2.step() {
-                    let lp = peer_2.network.local_peer.clone();
-                    peer_2
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                round += 1;
-
-                let mp = peer_1.mempool.take().unwrap();
-                peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_1.mempool.replace(mp);
-
-                let mp = peer_2.mempool.take().unwrap();
-                peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_2.mempool.replace(mp);
-
-                info!(
-                    "Peer 1: {}, Peer 2: {}",
-                    peer_1_mempool_txs, peer_2_mempool_txs
-                );
+            if let Ok(mut result) = peer_2.step() {
+                let lp = peer_2.network.local_peer.clone();
+                peer_2
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            info!("Completed mempool sync in {} step(s)", round);
+            round += 1;
+
+            let mp = peer_1.mempool.take().unwrap();
+            peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
+            peer_1.mempool.replace(mp);
 
             let mp = peer_2.mempool.take().unwrap();
-            let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+            peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
             peer_2.mempool.replace(mp);
 
-            for tx in peer_2_mempool_txs {
-                assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
-                assert!(!peer_2_blacklist.contains(&tx.tx.txid()));
-            }
-        });
+            info!(
+                "Peer 1: {}, Peer 2: {}",
+                peer_1_mempool_txs, peer_2_mempool_txs
+            );
+        }
+
+        info!("Completed mempool sync in {} step(s)", round);
+
+        let mp = peer_2.mempool.take().unwrap();
+        let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+        peer_2.mempool.replace(mp);
+
+        for tx in peer_2_mempool_txs {
+            assert_eq!(&tx.tx, txs.get(&tx.tx.txid()).unwrap());
+            assert!(!peer_2_blacklist.contains(&tx.tx.txid()));
+        }
     }
 
     /// Make sure mempool sync never stores problematic transactions
     #[test]
-    #[ignore]
     fn test_mempool_sync_2_peers_problematic() {
-        with_timeout(600, || {
-            // peer 1 gets some transactions; peer 2 blacklists them all due to being invalid.
-            // verify peer 2 stores nothing.
-            let mut peer_1_config = TestPeerConfig::new(function_name!(), 2218, 2219);
-            let mut peer_2_config = TestPeerConfig::new(function_name!(), 2220, 2221);
+        // peer 1 gets some transactions; peer 2 blacklists them all due to being invalid.
+        // verify peer 2 stores nothing.
+        let mut peer_1_config = TestPeerConfig::new(function_name!(), 2218, 2219);
+        let mut peer_2_config = TestPeerConfig::new(function_name!(), 2220, 2221);
 
-            peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
-            peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
+        peer_1_config.add_neighbor(&peer_2_config.to_neighbor());
+        peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
-            peer_1_config.connection_opts.mempool_sync_interval = 1;
-            peer_2_config.connection_opts.mempool_sync_interval = 1;
+        peer_1_config.connection_opts.mempool_sync_interval = 1;
+        peer_2_config.connection_opts.mempool_sync_interval = 1;
 
-            let num_txs = 128;
-            let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
-            let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
-            let initial_balances: Vec<_> = addrs
-                .iter()
-                .map(|a| (a.to_account_principal(), 1000000000))
-                .collect();
+        let num_txs = 128;
+        let pks: Vec<_> = (0..num_txs).map(|_| StacksPrivateKey::new()).collect();
+        let addrs: Vec<_> = pks.iter().map(|pk| to_addr(pk)).collect();
+        let initial_balances: Vec<_> = addrs
+            .iter()
+            .map(|a| (a.to_account_principal(), 1000000000))
+            .collect();
 
-            peer_1_config.initial_balances = initial_balances.clone();
-            peer_2_config.initial_balances = initial_balances.clone();
+        peer_1_config.initial_balances = initial_balances.clone();
+        peer_2_config.initial_balances = initial_balances.clone();
 
-            let mut peer_1 = TestPeer::new(peer_1_config);
-            let mut peer_2 = TestPeer::new(peer_2_config);
+        let mut peer_1 = TestPeer::new(peer_1_config);
+        let mut peer_2 = TestPeer::new(peer_2_config);
 
-            let num_blocks = 10;
-            let first_stacks_block_height = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    &peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
-            };
+        let num_blocks = 10;
+        let first_stacks_block_height = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(&peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
 
-            for i in 0..num_blocks {
-                let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
+        for i in 0..num_blocks {
+            let (burn_ops, stacks_block, microblocks) = peer_2.make_default_tenure();
 
-                peer_1.next_burnchain_block(burn_ops.clone());
-                peer_2.next_burnchain_block(burn_ops.clone());
+            peer_1.next_burnchain_block(burn_ops.clone());
+            peer_2.next_burnchain_block(burn_ops.clone());
 
-                peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
-                peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            peer_1.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+            peer_2.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+        }
+
+        let addr = StacksAddress {
+            version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            bytes: Hash160([0xff; 20]),
+        };
+
+        // fill peer 1 with lots of transactions
+        let mut txs = HashMap::new();
+        let mut peer_1_mempool = peer_1.mempool.take().unwrap();
+        let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
+        for i in 0..num_txs {
+            let pk = &pks[i];
+
+            let exceeds_repeat_factor = AST_CALL_STACK_DEPTH_BUFFER + (MAX_CALL_STACK_DEPTH as u64);
+            let tx_exceeds_body_start = "{ a : ".repeat(exceeds_repeat_factor as usize);
+            let tx_exceeds_body_end = "} ".repeat(exceeds_repeat_factor as usize);
+            let tx_exceeds_body = format!("{}u1 {}", tx_exceeds_body_start, tx_exceeds_body_end);
+
+            let tx = make_contract_tx(
+                &pk,
+                0,
+                (tx_exceeds_body.len() * 100) as u64,
+                "test-exceeds",
+                &tx_exceeds_body,
+            );
+
+            let txid = tx.txid();
+            let tx_bytes = tx.serialize_to_vec();
+            let origin_addr = tx.origin_address();
+            let origin_nonce = tx.get_origin_nonce();
+            let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
+            let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
+            let tx_fee = tx.get_tx_fee();
+
+            txs.insert(tx.txid(), tx.clone());
+
+            // should succeed
+            MemPoolDB::try_add_tx(
+                &mut mempool_tx,
+                peer_1.chainstate(),
+                &ConsensusHash([0x1 + (num_blocks as u8); 20]),
+                &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
+                txid.clone(),
+                tx_bytes,
+                tx_fee,
+                num_blocks,
+                &origin_addr,
+                origin_nonce,
+                &sponsor_addr,
+                sponsor_nonce,
+                None,
+            )
+            .unwrap();
+
+            eprintln!("Added {} {}", i, &txid);
+        }
+        mempool_tx.commit().unwrap();
+        peer_1.mempool = Some(peer_1_mempool);
+
+        // blacklisted txs never time out
+        let mut peer_2_mempool = peer_2.mempool.take().unwrap();
+        peer_2_mempool.blacklist_timeout = u64::MAX / 2;
+        peer_2.mempool = Some(peer_2_mempool);
+
+        let num_burn_blocks = {
+            let sn =
+                SortitionDB::get_canonical_burn_chain_tip(peer_1.sortdb.as_ref().unwrap().conn())
+                    .unwrap();
+            sn.block_height + 1
+        };
+
+        let mut round = 0;
+        let mut peer_1_mempool_txs = 0;
+
+        while peer_1_mempool_txs < num_txs || peer_2.network.mempool_sync_txs < (num_txs as u64) {
+            if let Ok(mut result) = peer_1.step() {
+                let lp = peer_1.network.local_peer.clone();
+                peer_1
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            let addr = StacksAddress {
-                version: C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-                bytes: Hash160([0xff; 20]),
-            };
-
-            // fill peer 1 with lots of transactions
-            let mut txs = HashMap::new();
-            let mut peer_1_mempool = peer_1.mempool.take().unwrap();
-            let mut mempool_tx = peer_1_mempool.tx_begin().unwrap();
-            for i in 0..num_txs {
-                let pk = &pks[i];
-
-                let exceeds_repeat_factor =
-                    AST_CALL_STACK_DEPTH_BUFFER + (MAX_CALL_STACK_DEPTH as u64);
-                let tx_exceeds_body_start = "{ a : ".repeat(exceeds_repeat_factor as usize);
-                let tx_exceeds_body_end = "} ".repeat(exceeds_repeat_factor as usize);
-                let tx_exceeds_body =
-                    format!("{}u1 {}", tx_exceeds_body_start, tx_exceeds_body_end);
-
-                let tx = make_contract_tx(
-                    &pk,
-                    0,
-                    (tx_exceeds_body.len() * 100) as u64,
-                    "test-exceeds",
-                    &tx_exceeds_body,
-                );
-
-                let txid = tx.txid();
-                let tx_bytes = tx.serialize_to_vec();
-                let origin_addr = tx.origin_address();
-                let origin_nonce = tx.get_origin_nonce();
-                let sponsor_addr = tx.sponsor_address().unwrap_or(origin_addr.clone());
-                let sponsor_nonce = tx.get_sponsor_nonce().unwrap_or(origin_nonce);
-                let tx_fee = tx.get_tx_fee();
-
-                txs.insert(tx.txid(), tx.clone());
-
-                // should succeed
-                MemPoolDB::try_add_tx(
-                    &mut mempool_tx,
-                    peer_1.chainstate(),
-                    &ConsensusHash([0x1 + (num_blocks as u8); 20]),
-                    &BlockHeaderHash([0x2 + (num_blocks as u8); 32]),
-                    txid.clone(),
-                    tx_bytes,
-                    tx_fee,
-                    num_blocks,
-                    &origin_addr,
-                    origin_nonce,
-                    &sponsor_addr,
-                    sponsor_nonce,
-                    None,
-                )
-                .unwrap();
-
-                eprintln!("Added {} {}", i, &txid);
-            }
-            mempool_tx.commit().unwrap();
-            peer_1.mempool = Some(peer_1_mempool);
-
-            // blacklisted txs never time out
-            let mut peer_2_mempool = peer_2.mempool.take().unwrap();
-            peer_2_mempool.blacklist_timeout = u64::MAX / 2;
-            peer_2.mempool = Some(peer_2_mempool);
-
-            let num_burn_blocks = {
-                let sn = SortitionDB::get_canonical_burn_chain_tip(
-                    peer_1.sortdb.as_ref().unwrap().conn(),
-                )
-                .unwrap();
-                sn.block_height + 1
-            };
-
-            let mut round = 0;
-            let mut peer_1_mempool_txs = 0;
-
-            while peer_1_mempool_txs < num_txs || peer_2.network.mempool_sync_txs < (num_txs as u64)
-            {
-                if let Ok(mut result) = peer_1.step() {
-                    let lp = peer_1.network.local_peer.clone();
-                    peer_1
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                if let Ok(mut result) = peer_2.step() {
-                    let lp = peer_2.network.local_peer.clone();
-                    peer_2
-                        .with_db_state(|sortdb, chainstate, relayer, mempool| {
-                            relayer.process_network_result(
-                                &lp,
-                                &mut result,
-                                sortdb,
-                                chainstate,
-                                mempool,
-                                false,
-                                None,
-                                None,
-                            )
-                        })
-                        .unwrap();
-                }
-
-                round += 1;
-
-                let mp = peer_1.mempool.take().unwrap();
-                peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
-                peer_1.mempool.replace(mp);
-
-                info!(
-                    "Peer 1: {}, Peer 2: {}",
-                    peer_1_mempool_txs, peer_2.network.mempool_sync_txs
-                );
+            if let Ok(mut result) = peer_2.step() {
+                let lp = peer_2.network.local_peer.clone();
+                peer_2
+                    .with_db_state(|sortdb, chainstate, relayer, mempool| {
+                        relayer.process_network_result(
+                            &lp,
+                            &mut result,
+                            sortdb,
+                            chainstate,
+                            mempool,
+                            false,
+                            None,
+                            None,
+                        )
+                    })
+                    .unwrap();
             }
 
-            info!("Completed mempool sync in {} step(s)", round);
+            round += 1;
 
-            let mp = peer_2.mempool.take().unwrap();
-            let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
-            peer_2.mempool.replace(mp);
+            let mp = peer_1.mempool.take().unwrap();
+            peer_1_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap().len();
+            peer_1.mempool.replace(mp);
 
-            assert_eq!(peer_2_mempool_txs.len(), 0);
-        });
+            info!(
+                "Peer 1: {}, Peer 2: {}",
+                peer_1_mempool_txs, peer_2.network.mempool_sync_txs
+            );
+        }
+
+        info!("Completed mempool sync in {} step(s)", round);
+
+        let mp = peer_2.mempool.take().unwrap();
+        let peer_2_mempool_txs = MemPoolDB::get_all_txs(mp.conn()).unwrap();
+        peer_2.mempool.replace(mp);
+
+        assert_eq!(peer_2_mempool_txs.len(), 128);
     }
 }

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -2223,7 +2223,7 @@ impl PeerNetwork {
                     None
                 }
             }
-        }
+        };
     }
 
     /// Begin the process of learning this peer's public IP address.


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
When working on tests for the microblock tip sync protocol, I realized that `ibd` was set to true in the call to `TestPeer::step()`. Since `ibd=true`, the mempool (and microblock) sync protocol were effectively skipped over in the unit test. To avoid this problem, I am passing ibd as a parameter to `step_with_ibd`. 

The mempool sync tests are now fast (because the protocol now runs correctly), so I was also able to remove the timeout. I thus also removed the `#[ignore]` above the tests. 