### PR TITLE
Fix: reduce chain-liveness poll frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - Handle the case where a bitcoin node returns zero headers (#3588)
 - The default value for `always_use_affirmation_maps` is now set to `false`,
   instead of `true`.  This was preventing testnet nodes from reaching the chain
-tip with the default configuration.
+  tip with the default configuration.
+- Reduce default poll time of the `chain-liveness` thread which reduces the
+  possibility that a miner thread will get interrupted (#3610).
 
 ## [2.1]
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -665,6 +665,9 @@ impl Config {
                     // chainstate fault_injection activation for hide_blocks.
                     // you can't set this in the config file.
                     fault_injection_hide_blocks: false,
+                    chain_liveness_poll_time_secs: node
+                        .chain_liveness_poll_time_secs
+                        .unwrap_or(default_node_config.chain_liveness_poll_time_secs),
                 };
                 (node_config, node.bootstrap_node, node.deny_nodes)
             }
@@ -1450,6 +1453,9 @@ pub struct NodeConfig {
     // fault injection for hiding blocks.
     // not part of the config file.
     pub fault_injection_hide_blocks: bool,
+    /// At most, how often should the chain-liveness thread
+    ///  wake up the chains-coordinator. Defaults to 300s (5 min).
+    pub chain_liveness_poll_time_secs: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -1727,6 +1733,7 @@ impl NodeConfig {
             always_use_affirmation_maps: false,
             require_affirmed_anchor_blocks: true,
             fault_injection_hide_blocks: false,
+            chain_liveness_poll_time_secs: 300,
         }
     }
 
@@ -1928,6 +1935,9 @@ pub struct NodeConfigFile {
     pub use_test_genesis_chainstate: Option<bool>,
     pub always_use_affirmation_maps: Option<bool>,
     pub require_affirmed_anchor_blocks: Option<bool>,
+    /// At most, how often should the chain-liveness thread
+    ///  wake up the chains-coordinator. Defaults to 300s (5 min).
+    pub chain_liveness_poll_time_secs: Option<u64>,
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -629,7 +629,7 @@ impl RunLoop {
         last_stacks_pox_reorg_recover_time: &mut u128,
     ) {
         let delay = cmp::max(
-            1,
+            config.node.chain_liveness_poll_time_secs,
             cmp::max(
                 config.miner.first_attempt_time_ms,
                 config.miner.subsequent_attempt_time_ms,
@@ -724,7 +724,9 @@ impl RunLoop {
                 &stacks_tip_affirmation_map, &heaviest_affirmation_map
             );
 
-            // do it anyway since it's harmless
+            // announce a new stacks block to force the chains coordinator
+            //  to wake up anyways. this isn't free, so we have to make sure
+            //  the chain-liveness thread doesn't wake up too often
             globals.coord().announce_new_stacks_block();
         }
 
@@ -747,7 +749,7 @@ impl RunLoop {
         last_announce_time: &mut u128,
     ) {
         let delay = cmp::max(
-            1,
+            config.node.chain_liveness_poll_time_secs,
             cmp::max(
                 config.miner.first_attempt_time_ms,
                 config.miner.subsequent_attempt_time_ms,


### PR DESCRIPTION
### Description

This PR reduces the chain-liveness poll frequency. This was driving the issues facing Hiro's testnet miner yesterday.
