### PR TITLE
Fix: Incorporate unlocks in mempool admitter, #3623

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [2.1.0.0.2]
+
+This software update is a hotfix to resolve improper unlock handling
+in mempool admission. This release's chainstate directory is
+compatible with chainstate directories from 2.1.0.0.2.
+
+### Fixed
+
+- Fix mempool admission logic's improper handling of PoX unlocks. This would
+  cause users to get spurious `NotEnoughFunds` rejections when trying to submit
+  their transactions (#3623)
+
 ## [2.1.0.0.1]
 
 ### Fixed

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -6975,6 +6975,7 @@ impl StacksChainState {
     /// unconfirmed microblock stream trailing off of it.
     pub fn will_admit_mempool_tx(
         &mut self,
+        burn_state_db: &dyn BurnStateDB,
         current_consensus_hash: &ConsensusHash,
         current_block: &BlockHeaderHash,
         tx: &StacksTransaction,
@@ -7019,7 +7020,7 @@ impl StacksChainState {
 
         let current_tip =
             StacksChainState::get_parent_index_block(current_consensus_hash, current_block);
-        let res = match self.with_read_only_clarity_tx(&NULL_BURN_STATE_DB, &current_tip, |conn| {
+        let res = match self.with_read_only_clarity_tx(burn_state_db, &current_tip, |conn| {
             StacksChainState::can_include_tx(conn, &conf, has_microblock_pubk, tx, tx_size)
         }) {
             Some(r) => r,
@@ -7039,7 +7040,7 @@ impl StacksChainState {
                 {
                     debug!("Transaction {} is unminable in the confirmed chain tip due to nonce {} != {}; trying the unconfirmed chain tip",
                            &tx.txid(), mismatch_error.expected, mismatch_error.actual);
-                    self.with_read_only_unconfirmed_clarity_tx(&NULL_BURN_STATE_DB, |conn| {
+                    self.with_read_only_unconfirmed_clarity_tx(burn_state_db, |conn| {
                         StacksChainState::can_include_tx(
                             conn,
                             &conf,

--- a/src/chainstate/stacks/tests/block_construction.rs
+++ b/src/chainstate/stacks/tests/block_construction.rs
@@ -248,6 +248,7 @@ fn test_build_anchored_blocks_stx_transfers_single() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &stx_transfer,
@@ -382,6 +383,7 @@ fn test_build_anchored_blocks_empty_with_builder_timeout() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &stx_transfer,
@@ -516,6 +518,7 @@ fn test_build_anchored_blocks_stx_transfers_multi() {
                         mempool
                             .submit(
                                 chainstate,
+                                sortdb,
                                 &parent_consensus_hash,
                                 &parent_header_hash,
                                 &stx_transfer,
@@ -541,6 +544,7 @@ fn test_build_anchored_blocks_stx_transfers_multi() {
                         mempool
                             .submit(
                                 chainstate,
+                                sortdb,
                                 &parent_consensus_hash,
                                 &parent_header_hash,
                                 &stx_transfer,
@@ -1230,6 +1234,7 @@ fn test_build_anchored_blocks_incrementing_nonces() {
                 mempool
                     .submit(
                         chainstate,
+                        sortdb,
                         &parent_consensus_hash,
                         &parent_header_hash,
                         &tx,
@@ -1430,6 +1435,7 @@ fn test_build_anchored_blocks_skip_too_expensive() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &stx_transfer,
@@ -1451,6 +1457,7 @@ fn test_build_anchored_blocks_skip_too_expensive() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &contract_tx,
@@ -1471,6 +1478,7 @@ fn test_build_anchored_blocks_skip_too_expensive() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &stx_transfer,
@@ -1617,6 +1625,7 @@ fn test_build_anchored_blocks_multiple_chaintips() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &contract_tx,
@@ -1771,6 +1780,7 @@ fn test_build_anchored_blocks_empty_chaintips() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &contract_tx,
@@ -1901,6 +1911,7 @@ fn test_build_anchored_blocks_too_expensive_transactions() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             contract_tx_bytes,
@@ -1928,6 +1939,7 @@ fn test_build_anchored_blocks_too_expensive_transactions() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             contract_tx_bytes,
@@ -2262,6 +2274,7 @@ fn test_build_anchored_blocks_bad_nonces() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_tip_ch,
                             &parent_header_hash,
                             contract_tx_bytes,
@@ -2290,6 +2303,7 @@ fn test_build_anchored_blocks_bad_nonces() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_tip_ch,
                             &parent_header_hash,
                             contract_tx_bytes,
@@ -2326,6 +2340,7 @@ fn test_build_anchored_blocks_bad_nonces() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_tip_ch,
                             &parent_header_hash,
                             contract_tx_bytes,
@@ -2354,6 +2369,7 @@ fn test_build_anchored_blocks_bad_nonces() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_tip_ch,
                             &parent_header_hash,
                             contract_tx_bytes,
@@ -2599,6 +2615,7 @@ fn test_build_microblock_stream_forks() {
                             mempool
                                 .submit_raw(
                                     chainstate,
+                                    sortdb,
                                     &parent_consensus_hash,
                                     &parent_header_hash,
                                     tx_bytes,
@@ -2925,6 +2942,7 @@ fn test_build_microblock_stream_forks_with_descendants() {
                             mempool
                                 .submit_raw(
                                     chainstate,
+                                    sortdb,
                                     &parent_consensus_hash,
                                     &parent_header_hash,
                                     tx_bytes,
@@ -3000,6 +3018,7 @@ fn test_build_microblock_stream_forks_with_descendants() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             tx_bytes,
@@ -3032,6 +3051,7 @@ fn test_build_microblock_stream_forks_with_descendants() {
                     mempool
                         .submit_raw(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             tx_bytes,
@@ -3989,6 +4009,7 @@ fn test_is_tx_problematic() {
                         mempool
                             .submit(
                                 chainstate,
+                                sortdb,
                                 &parent_consensus_hash,
                                 &parent_header_hash,
                                 tx,
@@ -4015,6 +4036,7 @@ fn test_is_tx_problematic() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &contract_spends_too_much_tx,
@@ -4063,6 +4085,7 @@ fn test_is_tx_problematic() {
                     mempool
                         .submit(
                             chainstate,
+                           sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &spend_too_much,
@@ -4113,6 +4136,7 @@ fn test_is_tx_problematic() {
                     mempool
                         .submit(
                             chainstate,
+                            sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &runtime_checkerror_problematic,
@@ -4161,6 +4185,7 @@ fn test_is_tx_problematic() {
                     mempool
                         .submit(
                             chainstate,
+                                sortdb,
                             &parent_consensus_hash,
                             &parent_header_hash,
                             &runtime_checkerror_problematic,
@@ -4296,6 +4321,7 @@ fn test_fee_order_mismatch_nonce_order() {
             mempool
                 .submit(
                     chainstate,
+                    sortdb,
                     &parent_consensus_hash,
                     &parent_header_hash,
                     &stx_transfer0,
@@ -4308,6 +4334,7 @@ fn test_fee_order_mismatch_nonce_order() {
             mempool
                 .submit(
                     chainstate,
+                    sortdb,
                     &parent_consensus_hash,
                     &parent_header_hash,
                     &stx_transfer1,

--- a/src/chainstate/stacks/tests/block_construction.rs
+++ b/src/chainstate/stacks/tests/block_construction.rs
@@ -28,6 +28,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use clarity::vm::database::ClarityDatabase;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use rand::Rng;
@@ -4226,6 +4227,240 @@ fn test_is_tx_problematic() {
 
                 (anchored_block.0, vec![])
             },
+        );
+
+        let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());
+        peer.process_stacks_epoch_at_tip(&stacks_block, &microblocks);
+
+        last_block = Some(StacksBlockHeader::make_index_block_hash(
+            &consensus_hash,
+            &stacks_block.block_hash(),
+        ));
+    }
+}
+
+#[test]
+fn mempool_incorporate_pox_unlocks() {
+    let mut initial_balances = vec![];
+    let total_balance = 10_000_000_000;
+    let pk = StacksPrivateKey::new();
+    let addr = StacksAddress::from_public_keys(
+        C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+        &AddressHashMode::SerializeP2PKH,
+        1,
+        &vec![StacksPublicKey::from_private(&pk)],
+    )
+    .unwrap();
+    initial_balances.push((addr.to_account_principal(), total_balance));
+    let principal = PrincipalData::from(addr.clone());
+
+    let mut peer_config = TestPeerConfig::new(function_name!(), 2020, 2021);
+    peer_config.initial_balances = initial_balances;
+    peer_config.epochs = Some(vec![
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch20,
+            start_height: 0,
+            end_height: 1,
+            block_limit: ExecutionCost::max_value(),
+            network_epoch: PEER_VERSION_EPOCH_2_0,
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch2_05,
+            start_height: 1,
+            end_height: 36,
+            block_limit: ExecutionCost::max_value(),
+            network_epoch: PEER_VERSION_EPOCH_2_05,
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch21,
+            start_height: 36,
+            end_height: i64::MAX as u64,
+            block_limit: ExecutionCost::max_value(),
+            network_epoch: PEER_VERSION_EPOCH_2_1,
+        },
+    ]);
+    peer_config.burnchain.pox_constants.v1_unlock_height =
+        peer_config.epochs.as_ref().unwrap()[1].end_height as u32 + 1;
+    let pox_constants = peer_config.burnchain.pox_constants.clone();
+
+    let mut peer = TestPeer::new(peer_config);
+
+    let chainstate_path = peer.chainstate_path.clone();
+
+    let first_stacks_block_height = {
+        let sn = SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+            .unwrap();
+        sn.block_height
+    };
+
+    let first_block_height = peer.sortdb.as_ref().unwrap().first_block_height;
+    let first_pox_cycle = pox_constants
+        .block_height_to_reward_cycle(first_block_height, first_stacks_block_height)
+        .unwrap();
+    let active_pox_cycle_start =
+        pox_constants.reward_cycle_to_block_height(first_block_height, first_pox_cycle + 1);
+    let lockup_end = pox_constants.v1_unlock_height as u64;
+
+    // test for two PoX cycles
+    let num_blocks = 3 + lockup_end - first_stacks_block_height;
+    info!(
+        "Starting test";
+        "num_blocks" => num_blocks,
+        "first_stacks_block_height" => first_stacks_block_height,
+        "active_pox_cycle_start" => active_pox_cycle_start,
+        "active_pox_cycle_end" => lockup_end,
+        "first_block_height" => first_block_height,
+    );
+
+    let recipient_addr_str = "ST1RFD5Q2QPK3E0F08HG9XDX7SSC7CNRS0QR0SGEV";
+    let recipient = StacksAddress::from_string(recipient_addr_str).unwrap();
+
+    let mut last_block = None;
+    for tenure_id in 0..num_blocks {
+        // send transactions to the mempool
+        let tip = SortitionDB::get_canonical_burn_chain_tip(&peer.sortdb.as_ref().unwrap().conn())
+            .unwrap();
+
+        let (burn_ops, stacks_block, microblocks) = peer.make_tenure(
+            |ref mut miner,
+             ref mut sortdb,
+             ref mut chainstate,
+             vrf_proof,
+             ref parent_opt,
+             ref parent_microblock_header_opt| {
+                 let parent_tip = match parent_opt {
+                     None => StacksChainState::get_genesis_header_info(chainstate.db()).unwrap(),
+                     Some(block) => {
+                         let ic = sortdb.index_conn();
+                         let snapshot =
+                             SortitionDB::get_block_snapshot_for_winning_stacks_block(
+                                 &ic,
+                                 &tip.sortition_id,
+                                 &block.block_hash(),
+                             )
+                             .unwrap()
+                             .unwrap(); // succeeds because we don't fork
+                         StacksChainState::get_anchored_block_header_info(
+                             chainstate.db(),
+                             &snapshot.consensus_hash,
+                             &snapshot.winning_stacks_block_hash,
+                         )
+                             .unwrap()
+                             .unwrap()
+                     }
+                 };
+
+                 let parent_height = parent_tip.burn_header_height;
+
+                 let parent_header_hash = parent_tip.anchored_header.block_hash();
+                 let parent_consensus_hash = parent_tip.consensus_hash.clone();
+                 let coinbase_tx = make_coinbase(miner, tenure_id as usize);
+
+                 let mut mempool =
+                     MemPoolDB::open_test(false, 0x80000000, &chainstate_path).unwrap();
+
+                 let mut expected_txids = vec![];
+                 expected_txids.push(coinbase_tx.txid());
+
+                 // this will be the height of the block that includes this new tenure
+                 let my_height = first_stacks_block_height + 1 + tenure_id;
+
+                 let available_balance = chainstate.with_read_only_clarity_tx(&sortdb.index_conn(), &parent_tip.index_block_hash(), |clarity_tx| {
+                     clarity_tx.with_clarity_db_readonly(|db| {
+                         let burn_block_height = db.get_current_burnchain_block_height() as u64;
+                         let v1_unlock_height = db.get_v1_unlock_height();
+                         let balance = db.get_account_stx_balance(&principal);
+                         info!("Checking balance"; "v1_unlock_height" => v1_unlock_height, "burn_block_height" => burn_block_height);
+                         balance.get_available_balance_at_burn_block(burn_block_height, v1_unlock_height)
+                     })
+                 }).unwrap();
+
+                 if tenure_id <= 1 {
+                     assert_eq!(available_balance, total_balance as u128, "Failed at tenure_id={}", tenure_id);
+                 } else if my_height <= lockup_end + 1 {
+                     assert_eq!(available_balance, 0, "Failed at tenure_id={}", tenure_id);
+                 } else if my_height == lockup_end + 2 {
+                     assert_eq!(available_balance, total_balance as u128 - 10_000, "Failed at tenure_id={}", tenure_id);
+                 } else {
+                     assert_eq!(available_balance, 0, "Failed at tenure_id={}", tenure_id);
+                 }
+
+                 if tenure_id == 1 {
+                     let stack_stx = make_user_contract_call(
+                         &pk,
+                         0,
+                         10_000,
+                         &StacksAddress::burn_address(false),
+                         "pox",
+                         "stack-stx",
+                         vec![
+                             Value::UInt(total_balance as u128 - 10_000),
+                             Value::Tuple(
+                                 TupleData::from_data(vec![
+                                     ("version".into(), Value::buff_from(vec![0x00]).unwrap()),
+                                     ("hashbytes".into(), Value::buff_from(vec![0; 20]).unwrap()),
+                                 ]).unwrap(),
+                             ),
+                             Value::UInt(my_height as u128),
+                             Value::UInt(10)
+                         ],
+                     );
+                     mempool
+                         .submit(
+                             chainstate,
+                             sortdb,
+                             &parent_consensus_hash,
+                             &parent_header_hash,
+                             &stack_stx,
+                             None,
+                             &ExecutionCost::max_value(),
+                             &StacksEpochId::Epoch2_05,
+                         )
+                         .unwrap();
+                     expected_txids.push(stack_stx.txid());
+                 } else if my_height == lockup_end + 2 {
+                     let stx_transfer = make_user_stacks_transfer(
+                         &pk,
+                         1,
+                         10_000,
+                         &StacksAddress::burn_address(false).into(),
+                         total_balance - 10_000 - 10_000,
+                     );
+                     mempool
+                         .submit(
+                             chainstate,
+                             sortdb,
+                             &parent_consensus_hash,
+                             &parent_header_hash,
+                             &stx_transfer,
+                             None,
+                             &ExecutionCost::max_value(),
+                             &StacksEpochId::Epoch2_05,
+                         )
+                         .unwrap();
+                     expected_txids.push(stx_transfer.txid());
+                 }
+
+                 let anchored_block = StacksBlockBuilder::build_anchored_block(
+                     chainstate,
+                     &sortdb.index_conn(),
+                     &mut mempool,
+                     &parent_tip,
+                     tip.total_burn,
+                     vrf_proof,
+                     Hash160([tenure_id as u8; 20]),
+                     &coinbase_tx,
+                     BlockBuilderSettings::limited(),
+                     None,
+                 )
+                 .unwrap();
+
+                 // make sure the right txs get included
+                 let txids : Vec<_> = anchored_block.0.txs.iter().map(|tx| tx.txid()).collect();
+                 assert_eq!(txids, expected_txids);
+
+                 (anchored_block.0, vec![])
+             },
         );
 
         let (_, _, consensus_hash) = peer.next_burnchain_block(burn_ops.clone());

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -38,6 +38,7 @@ use rusqlite::NO_PARAMS;
 use siphasher::sip::SipHasher; // this is SipHash-2-4
 
 use crate::burnchains::Txid;
+use crate::chainstate::burn::db::sortdb::SortitionDB;
 use crate::chainstate::burn::ConsensusHash;
 use crate::chainstate::stacks::{
     db::blocks::MemPoolRejection, db::ClarityTx, db::StacksChainState, db::TxStreamData,
@@ -174,10 +175,17 @@ impl MemPoolAdmitter {
     pub fn will_admit_tx(
         &mut self,
         chainstate: &mut StacksChainState,
+        sortdb: &SortitionDB,
         tx: &StacksTransaction,
         tx_size: u64,
     ) -> Result<(), MemPoolRejection> {
-        chainstate.will_admit_mempool_tx(&self.cur_consensus_hash, &self.cur_block, tx, tx_size)
+        chainstate.will_admit_mempool_tx(
+            &sortdb.index_conn(),
+            &self.cur_consensus_hash,
+            &self.cur_block,
+            tx,
+            tx_size,
+        )
     }
 }
 
@@ -1973,6 +1981,7 @@ impl MemPoolDB {
     fn tx_submit(
         mempool_tx: &mut MemPoolTx,
         chainstate: &mut StacksChainState,
+        sortdb: &SortitionDB,
         consensus_hash: &ConsensusHash,
         block_hash: &BlockHeaderHash,
         tx: &StacksTransaction,
@@ -2027,7 +2036,9 @@ impl MemPoolDB {
             mempool_tx
                 .admitter
                 .set_block(&block_hash, (*consensus_hash).clone());
-            mempool_tx.admitter.will_admit_tx(chainstate, tx, len)?;
+            mempool_tx
+                .admitter
+                .will_admit_tx(chainstate, sortdb, tx, len)?;
         }
 
         MemPoolDB::try_add_tx(
@@ -2064,6 +2075,7 @@ impl MemPoolDB {
     pub fn submit(
         &mut self,
         chainstate: &mut StacksChainState,
+        sortdb: &SortitionDB,
         consensus_hash: &ConsensusHash,
         block_hash: &BlockHeaderHash,
         tx: &StacksTransaction,
@@ -2101,6 +2113,7 @@ impl MemPoolDB {
         MemPoolDB::tx_submit(
             &mut mempool_tx,
             chainstate,
+            sortdb,
             consensus_hash,
             block_hash,
             tx,
@@ -2116,6 +2129,7 @@ impl MemPoolDB {
     pub fn miner_submit(
         &mut self,
         chainstate: &mut StacksChainState,
+        sortdb: &SortitionDB,
         consensus_hash: &ConsensusHash,
         block_hash: &BlockHeaderHash,
         tx: &StacksTransaction,
@@ -2129,6 +2143,7 @@ impl MemPoolDB {
         MemPoolDB::tx_submit(
             &mut mempool_tx,
             chainstate,
+            sortdb,
             consensus_hash,
             block_hash,
             tx,
@@ -2146,6 +2161,7 @@ impl MemPoolDB {
     pub fn submit_raw(
         &mut self,
         chainstate: &mut StacksChainState,
+        sortdb: &SortitionDB,
         consensus_hash: &ConsensusHash,
         block_hash: &BlockHeaderHash,
         tx_bytes: Vec<u8>,
@@ -2187,6 +2203,7 @@ impl MemPoolDB {
         MemPoolDB::tx_submit(
             &mut mempool_tx,
             chainstate,
+            sortdb,
             consensus_hash,
             block_hash,
             &tx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1433,6 +1433,7 @@ simulating a miner.
                         }
                         let result = mempool_db.submit(
                             &mut chain_state,
+                            &sort_db,
                             &stacks_block.consensus_hash,
                             &stacks_block.anchored_block_hash,
                             &raw_tx,

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -5246,6 +5246,7 @@ impl PeerNetwork {
 
         if let Err(e) = mempool.submit(
             chainstate,
+            sortdb,
             consensus_hash,
             block_hash,
             &tx,

--- a/src/net/relay.rs
+++ b/src/net/relay.rs
@@ -5824,6 +5824,7 @@ pub mod test {
             let versioned_contract = (*versioned_contract_opt.borrow()).clone().unwrap();
             let versioned_contract_len = versioned_contract.serialize_to_vec().len();
             match node.chainstate.will_admit_mempool_tx(
+                &sortdb.index_conn(),
                 &consensus_hash,
                 &stacks_block.block_hash(),
                 &versioned_contract,
@@ -5873,6 +5874,7 @@ pub mod test {
         let versioned_contract = (*versioned_contract_opt.borrow()).clone().unwrap();
         let versioned_contract_len = versioned_contract.serialize_to_vec().len();
         match node.chainstate.will_admit_mempool_tx(
+            &sortdb.index_conn(),
             &consensus_hash,
             &stacks_block.block_hash(),
             &versioned_contract,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -2093,6 +2093,7 @@ impl ConversationHttp {
             } else {
                 match mempool.submit(
                     chainstate,
+                    sortdb,
                     &consensus_hash,
                     &block_hash,
                     &tx,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1594,6 +1594,7 @@ impl BlockMinerThread {
     fn load_and_vet_parent_microblocks(
         &mut self,
         chain_state: &mut StacksChainState,
+        sortdb: &SortitionDB,
         mem_pool: &mut MemPoolDB,
         parent_block_info: &mut ParentStacksBlockInfo,
     ) -> Option<Vec<StacksMicroblock>> {
@@ -1662,6 +1663,7 @@ impl BlockMinerThread {
                     // anchored block.
                     if let Err(e) = mem_pool.miner_submit(
                         chain_state,
+                        sortdb,
                         &parent_consensus_hash,
                         &stacks_parent_header.anchored_header.block_hash(),
                         &poison_microblock_tx,
@@ -1889,6 +1891,7 @@ impl BlockMinerThread {
         // target it to the microblock tail in parent_block_info
         let microblocks_opt = self.load_and_vet_parent_microblocks(
             &mut chain_state,
+            &burn_db,
             &mut mem_pool,
             &mut parent_block_info,
         );

--- a/testnet/stacks-node/src/tenure.rs
+++ b/testnet/stacks-node/src/tenure.rs
@@ -5,6 +5,10 @@ use super::{BurnchainTip, Config};
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+use stacks::burnchains::PoxConstants;
+#[cfg(test)]
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::db::sortdb::SortitionDBConn;
 use stacks::chainstate::stacks::db::StacksChainState;
 use stacks::chainstate::stacks::{
@@ -122,5 +126,15 @@ impl<'a> Tenure {
         )
         .unwrap();
         chain_state
+    }
+
+    #[cfg(test)]
+    pub fn open_fake_sortdb(&self) -> SortitionDB {
+        SortitionDB::open(
+            &self.config.get_burn_db_file_path(),
+            true,
+            PoxConstants::testnet_default(),
+        )
+        .unwrap()
     }
 }

--- a/testnet/stacks-node/src/tests/bitcoin_regtest.rs
+++ b/testnet/stacks-node/src/tests/bitcoin_regtest.rs
@@ -372,6 +372,8 @@ fn bitcoind_integration(segwit_flag: bool) {
     // Use tenure's hook for submitting transactions
     run_loop.callbacks.on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
         let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
+
         match round {
             1 => {
                 // On round 1, publish the KV contract
@@ -391,7 +393,7 @@ fn bitcoind_integration(segwit_flag: bool) {
                 // ./blockstack-cli --testnet publish 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 0 0 store /tmp/out.clar
                 let header_hash = chain_tip.block.block_hash();
                 let consensus_hash = chain_tip.metadata.consensus_hash;
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash, PUBLISH_CONTRACT.to_owned(), &ExecutionCost::max_value(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash, PUBLISH_CONTRACT.to_owned(), &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,).unwrap();
             },
             2 => {
@@ -400,7 +402,7 @@ fn bitcoind_integration(segwit_flag: bool) {
                 let header_hash = chain_tip.block.block_hash();
                 let consensus_hash = chain_tip.metadata.consensus_hash;
                 let get_foo = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000001000000000000000a0100b7ff8b6c20c427b4f4f09c1ad7e50027e2b076b2ddc0ab55e64ef5ea3771dd4763a79bc5a2b1a79b72ce03dd146ccf24b84942d675a815819a8b85aa8065dfaa030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(), &ExecutionCost::max_value(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(), &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,).unwrap();
             },
             3 => {
@@ -409,7 +411,7 @@ fn bitcoind_integration(segwit_flag: bool) {
                 let header_hash = chain_tip.block.block_hash();
                 let consensus_hash = chain_tip.metadata.consensus_hash;
                 let set_foo_bar = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000002000000000000000a010142a01caf6a32b367664869182f0ebc174122a5a980937ba259d44cc3ebd280e769a53dd3913c8006ead680a6e1c98099fcd509ce94b0a4e90d9f4603b101922d030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265097365742d76616c7565000000020d00000003666f6f0d00000003626172";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(set_foo_bar).unwrap().to_vec(), &ExecutionCost::max_value(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(set_foo_bar).unwrap().to_vec(), &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,).unwrap();
             },
             4 => {
@@ -418,7 +420,7 @@ fn bitcoind_integration(segwit_flag: bool) {
                 let header_hash = chain_tip.block.block_hash();
                 let consensus_hash = chain_tip.metadata.consensus_hash;
                 let get_foo = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000003000000000000000a010046c2c1c345231443fef9a1f64fccfef3e1deacc342b2ab5f97612bb3742aa799038b20aea456789aca6b883e52f84a31adfee0bc2079b740464877af8f2f87d2030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(), &ExecutionCost::max_value(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(), &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,).unwrap();
             },
             5 => {
@@ -427,7 +429,7 @@ fn bitcoind_integration(segwit_flag: bool) {
                 let header_hash = chain_tip.block.block_hash();
                 let consensus_hash = chain_tip.metadata.consensus_hash;
                 let transfer_1000_stx = "80800000000400b71a091b4b8b7661a661c620966ab6573bc2dcd30000000000000000000000000000000a0000393810832bacd44cfc4024980876135de6b95429bdb610d5ce96a92c9ee9bfd81ec77ea0f1748c8515fc9a1589e51d8b92bf028e3e84ade1249682c05271d5b803020000000000051a525b8a36ef8a73548cd0940c248d3b71ecf4a45100000000000003e800000000000000000000000000000000000000000000000000000000000000000000";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(transfer_1000_stx).unwrap().to_vec(), &ExecutionCost::max_value(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(transfer_1000_stx).unwrap().to_vec(), &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,).unwrap();
             },
             _ => {}

--- a/testnet/stacks-node/src/tests/integrations.rs
+++ b/testnet/stacks-node/src/tests/integrations.rs
@@ -205,6 +205,7 @@ fn integration_test_get_info() {
         .callbacks
         .on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
 
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let principal_sk = StacksPrivateKey::from_hex(SK_2).unwrap();
@@ -221,6 +222,7 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,
@@ -234,6 +236,7 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,
@@ -247,6 +250,7 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,
@@ -281,6 +285,7 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,
@@ -304,6 +309,7 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         tx,
@@ -325,6 +331,7 @@ fn integration_test_get_info() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         tx_xfer,
@@ -1095,6 +1102,7 @@ fn contract_stx_transfer() {
         .callbacks
         .on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
 
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
@@ -1117,6 +1125,7 @@ fn contract_stx_transfer() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         xfer_to_contract,
@@ -1132,6 +1141,7 @@ fn contract_stx_transfer() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,
@@ -1152,6 +1162,7 @@ fn contract_stx_transfer() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         publish_tx,
@@ -1173,6 +1184,7 @@ fn contract_stx_transfer() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         tx,
@@ -1197,6 +1209,7 @@ fn contract_stx_transfer() {
                         .mem_pool
                         .submit(
                             &mut chainstate_copy,
+                            &sortdb,
                             &consensus_hash,
                             &header_hash,
                             &xfer_to_contract,
@@ -1215,6 +1228,7 @@ fn contract_stx_transfer() {
                     .mem_pool
                     .submit(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         &xfer_to_contract,
@@ -1413,6 +1427,7 @@ fn mine_transactions_out_of_order() {
         .callbacks
         .on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
 
             let sk = StacksPrivateKey::from_hex(SK_3).unwrap();
             let header_hash = chain_tip.block.block_hash();
@@ -1433,6 +1448,7 @@ fn mine_transactions_out_of_order() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         xfer_to_contract,
@@ -1447,6 +1463,7 @@ fn mine_transactions_out_of_order() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,
@@ -1461,6 +1478,7 @@ fn mine_transactions_out_of_order() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         xfer_to_contract,
@@ -1475,6 +1493,7 @@ fn mine_transactions_out_of_order() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         xfer_to_contract,
@@ -1564,6 +1583,7 @@ fn mine_contract_twice() {
         .callbacks
         .on_new_tenure(|round, _burnchain_tip, _chain_tip, tenure| {
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
 
             if round == 1 {
@@ -1578,6 +1598,7 @@ fn mine_contract_twice() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         publish_tx,
@@ -1649,6 +1670,7 @@ fn bad_contract_tx_rollback() {
         .callbacks
         .on_new_tenure(|round, _burnchain_tip, _chain_tip, tenure| {
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
 
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
@@ -1674,6 +1696,7 @@ fn bad_contract_tx_rollback() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         xfer_to_contract,
@@ -1692,6 +1715,7 @@ fn bad_contract_tx_rollback() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         xfer_to_contract,
@@ -1706,6 +1730,7 @@ fn bad_contract_tx_rollback() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         xfer_to_contract,
@@ -1720,6 +1745,7 @@ fn bad_contract_tx_rollback() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         publish_tx,
@@ -1734,6 +1760,7 @@ fn bad_contract_tx_rollback() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         publish_tx,
@@ -1960,6 +1987,7 @@ fn block_limit_runtime_test() {
         .callbacks
         .on_new_tenure(|round, _burnchain_tip, _chain_tip, tenure| {
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
 
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let _contract_identifier = QualifiedContractIdentifier::parse(&format!(
@@ -1985,6 +2013,7 @@ fn block_limit_runtime_test() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         consensus_hash,
                         block_hash,
                         publish_tx,
@@ -2014,6 +2043,7 @@ fn block_limit_runtime_test() {
                         .mem_pool
                         .submit_raw(
                             &mut chainstate_copy,
+                            &sortdb,
                             consensus_hash,
                             block_hash,
                             tx,
@@ -2087,6 +2117,7 @@ fn mempool_errors() {
         .on_new_tenure(|round, _burnchain_tip, chain_tip, tenure| {
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let mut chainstate_copy = tenure.open_chainstate();
+            let sortdb = tenure.open_fake_sortdb();
 
             let header_hash = chain_tip.block.block_hash();
             let consensus_hash = chain_tip.metadata.consensus_hash;
@@ -2100,6 +2131,7 @@ fn mempool_errors() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx,

--- a/testnet/stacks-node/src/tests/mempool.rs
+++ b/testnet/stacks-node/src/tests/mempool.rs
@@ -16,6 +16,7 @@ use stacks::cost_estimates::UnitEstimator;
 use stacks::net::Error as NetError;
 use stacks::types::chainstate::{BlockHeaderHash, StacksAddress};
 use stacks::util::{hash::*, secp256k1::*};
+use stacks::vm::database::NULL_BURN_STATE_DB;
 use stacks::vm::{
     representations::ContractName, types::PrincipalData, types::QualifiedContractIdentifier,
     types::StandardPrincipalData, Value,
@@ -108,6 +109,7 @@ fn mempool_setup_chainstate() {
             let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
             let header_hash = chain_tip.block.block_hash();
             let consensus_hash = chain_tip.metadata.consensus_hash;
+            let sortdb = tenure.open_fake_sortdb();
 
             if round == 1 {
                 eprintln!("Tenure in 1 started!");
@@ -118,6 +120,7 @@ fn mempool_setup_chainstate() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx1,
@@ -132,6 +135,7 @@ fn mempool_setup_chainstate() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx2,
@@ -151,6 +155,7 @@ fn mempool_setup_chainstate() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx3,
@@ -170,6 +175,7 @@ fn mempool_setup_chainstate() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx4,
@@ -189,6 +195,7 @@ fn mempool_setup_chainstate() {
                     .mem_pool
                     .submit_raw(
                         &mut chainstate_copy,
+                        &sortdb,
                         &consensus_hash,
                         &header_hash,
                         publish_tx4,
@@ -230,7 +237,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap();
 
                 let tx_bytes = make_contract_call(
@@ -245,14 +258,26 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap();
 
                 let tx_bytes = make_stacks_transfer(&contract_sk, 5, 200, &other_addr, 1000);
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap();
 
                 // bad signature
@@ -260,7 +285,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(
@@ -296,7 +327,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
 
                 assert!(if let MemPoolRejection::BadAddressVersionByte = e {
@@ -319,7 +356,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 assert!(if let MemPoolRejection::BadAddressVersionByte = e {
                     true
@@ -332,7 +375,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::FeeTooLow(0, _) = e {
@@ -346,7 +395,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::BadNonces(_) = e {
@@ -360,7 +415,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::NotEnoughFunds(111000, 99500) = e {
@@ -375,7 +436,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::TransferRecipientIsSender(r) = e {
@@ -392,7 +459,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::BadAddressVersionByte = e {
@@ -419,7 +492,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::BadTransactionVersion = e {
@@ -433,7 +512,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::TransferAmountMustBePositive = e {
@@ -447,7 +532,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::NotEnoughFunds(111000, 99500) = e {
@@ -460,7 +551,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::NotEnoughFunds(100700, 99500) = e {
@@ -481,7 +578,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::NoSuchContract = e {
@@ -502,7 +605,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::NoSuchPublicFunction = e {
@@ -523,7 +632,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::BadFunctionArgument(_) = e {
@@ -537,7 +652,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::ContractAlreadyExists(_) = e {
@@ -566,7 +687,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(
@@ -597,7 +724,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::InvalidMicroblocks = e {
@@ -629,7 +762,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(
@@ -644,7 +783,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 eprintln!("Err: {:?}", e);
                 assert!(if let MemPoolRejection::NoCoinbaseViaMempool = e {
@@ -696,7 +841,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap();
 
                 let contract_id = QualifiedContractIdentifier::new(
@@ -717,7 +868,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap();
 
                 let contract_id = QualifiedContractIdentifier::new(
@@ -738,7 +895,13 @@ fn mempool_setup_chainstate() {
                 let tx =
                     StacksTransaction::consensus_deserialize(&mut tx_bytes.as_slice()).unwrap();
                 let e = chain_state
-                    .will_admit_mempool_tx(consensus_hash, block_hash, &tx, tx_bytes.len() as u64)
+                    .will_admit_mempool_tx(
+                        &NULL_BURN_STATE_DB,
+                        consensus_hash,
+                        block_hash,
+                        &tx,
+                        tx_bytes.len() as u64,
+                    )
                     .unwrap_err();
                 assert!(if let MemPoolRejection::BadFunctionArgument(_) = e {
                     true

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -529,11 +529,12 @@ fn should_succeed_mining_valid_txs() {
         let consensus_hash = chain_tip.metadata.consensus_hash;
 
         let mut chainstate_copy = tenure.open_chainstate();
+        let sortdb = tenure.open_fake_sortdb();
 
         match round {
             1 => {
                 // On round 1, publish the KV contract
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash, PUBLISH_CONTRACT.to_owned(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash, PUBLISH_CONTRACT.to_owned(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch21,
                 ).unwrap();
@@ -542,7 +543,7 @@ fn should_succeed_mining_valid_txs() {
                 // On round 2, publish a "get:foo" transaction
                 // ./blockstack-cli --testnet contract-call 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 10 1 STGT7GSMZG7EA0TS6MVSKT5JC1DCDFGZWJJZXN8A store get-value -e \"foo\"
                 let get_foo = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000001000000000000000a0100b7ff8b6c20c427b4f4f09c1ad7e50027e2b076b2ddc0ab55e64ef5ea3771dd4763a79bc5a2b1a79b72ce03dd146ccf24b84942d675a815819a8b85aa8065dfaa030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch21,
                 ).unwrap();
@@ -551,7 +552,7 @@ fn should_succeed_mining_valid_txs() {
                 // On round 3, publish a "set:foo=bar" transaction
                 // ./blockstack-cli --testnet contract-call 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 10 2 STGT7GSMZG7EA0TS6MVSKT5JC1DCDFGZWJJZXN8A store set-value -e \"foo\" -e \"bar\" 
                 let set_foo_bar = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000002000000000000000a010142a01caf6a32b367664869182f0ebc174122a5a980937ba259d44cc3ebd280e769a53dd3913c8006ead680a6e1c98099fcd509ce94b0a4e90d9f4603b101922d030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265097365742d76616c7565000000020d00000003666f6f0d00000003626172";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(set_foo_bar).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(set_foo_bar).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch21,
                 ).unwrap();
@@ -560,7 +561,7 @@ fn should_succeed_mining_valid_txs() {
                 // On round 4, publish a "get:foo" transaction
                 // ./blockstack-cli --testnet contract-call 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 10 3 STGT7GSMZG7EA0TS6MVSKT5JC1DCDFGZWJJZXN8A store get-value -e \"foo\"
                 let get_foo = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000003000000000000000a010046c2c1c345231443fef9a1f64fccfef3e1deacc342b2ab5f97612bb3742aa799038b20aea456789aca6b883e52f84a31adfee0bc2079b740464877af8f2f87d2030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch21,
                 ).unwrap();
@@ -569,7 +570,7 @@ fn should_succeed_mining_valid_txs() {
                 // On round 5, publish a stacks transaction
                 // ./blockstack-cli --testnet token-transfer b1cf9cee5083f421c84d7cb53be5edf2801c3c78d63d53917aee0bdc8bd160ee01 10 0 ST195Q2HPXY576N4CT2A0R94D7DRYSX54A5X3YZTH 1000
                 let transfer_1000_stx = "80800000000400b71a091b4b8b7661a661c620966ab6573bc2dcd30000000000000000000000000000000a0000393810832bacd44cfc4024980876135de6b95429bdb610d5ce96a92c9ee9bfd81ec77ea0f1748c8515fc9a1589e51d8b92bf028e3e84ade1249682c05271d5b803020000000000051a525b8a36ef8a73548cd0940c248d3b71ecf4a45100000000000003e800000000000000000000000000000000000000000000000000000000000000000000";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(transfer_1000_stx).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(transfer_1000_stx).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch21,
                 ).unwrap();
@@ -812,13 +813,14 @@ fn should_succeed_handling_malformed_and_valid_txs() {
         let header_hash = chain_tip.block.block_hash();
         let consensus_hash = chain_tip.metadata.consensus_hash;
         let mut chainstate_copy = tenure.open_chainstate();
+        let sortdb = tenure.open_fake_sortdb();
 
         match round {
             1 => {
                 // On round 1, publish the KV contract
                 let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
                 let publish_contract = make_contract_publish(&contract_sk, 0, 10, "store", STORE_CONTRACT);
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,publish_contract,
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,publish_contract,
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,
                                            ).unwrap();
@@ -828,7 +830,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 // Will not be mined
                 // ./blockstack-cli contract-call 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 10 1 STGT7GSMZG7EA0TS6MVSKT5JC1DCDFGZWJJZXN8A store get-value -e \"foo\"
                 let get_foo = "0000000001040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000001000000000000000a0101ef2b00e7e55ee5cb7684d5313c7c49680c97e60cb29f0166798e6ffabd984a030cf0a7b919bcf5fa052efd5d9efd96b927213cb3af1cfb8d9c5a0be0fccda64d030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,
                                            ).unwrap();
@@ -838,7 +840,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 // Will not be mined
                 // ./blockstack-cli --testnet contract-call 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 10 1 STGT7GSMZG7EA0TS6MVSKT5JC1DCDFGZWJJZXN8A store set-value -e \"foo\" -e \"bar\"
                 let set_foo_bar = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000001000000000000000a010093f733efcebe2b239bb22e2e1ed25612547403af66b29282ed1f6fdfbbbf8f7f6ef107256d07947cbb72e165d723af99c447d6e25e7fbb6a92fd9a51c5ef7ee9030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265097365742d76616c7565000000020d00000003666f6f0d00000003626172";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(set_foo_bar).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(set_foo_bar).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,
                 ).unwrap();
@@ -847,7 +849,7 @@ fn should_succeed_handling_malformed_and_valid_txs() {
                 // On round 4, publish a "get:foo" transaction
                 // ./blockstack-cli --testnet contract-call 043ff5004e3d695060fa48ac94c96049b8c14ef441c50a184a6a3875d2a000f3 10 1 STGT7GSMZG7EA0TS6MVSKT5JC1DCDFGZWJJZXN8A store get-value -e \"foo\"
                 let get_foo = "8080000000040021a3c334fc0ee50359353799e8b2605ac6be1fe40000000000000001000000000000000a0100b7ff8b6c20c427b4f4f09c1ad7e50027e2b076b2ddc0ab55e64ef5ea3771dd4763a79bc5a2b1a79b72ce03dd146ccf24b84942d675a815819a8b85aa8065dfaa030200000000021a21a3c334fc0ee50359353799e8b2605ac6be1fe40573746f7265096765742d76616c7565000000010d00000003666f6f";
-                tenure.mem_pool.submit_raw(&mut chainstate_copy, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
+                tenure.mem_pool.submit_raw(&mut chainstate_copy, &sortdb, &consensus_hash, &header_hash,hex_bytes(get_foo).unwrap().to_vec(),
                                 &ExecutionCost::max_value(),
                                 &StacksEpochId::Epoch20,
                 ).unwrap();


### PR DESCRIPTION
### Description

This fixes the mempool admission behavior in #3623 by supplying a pointer to the current burn state (sortition db) to the mempool admission logic.

Will update this PR with regression testing before merging.

### Applicable issues
- fixes #3623

### Checklist
- [x] Test coverage for new or modified code paths
- [x] Changelog is updated
