### PR TITLE
Fix/def-sorter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [2.2.0.0.0]
+
+- Fixed a bug in the definition sorter, where functions could be sorted
+  incorrectly due to comments not being handled correctly in the AST. This
+  problem was exposed with 2.1, because 2.1 introduces a new parser that
+  includes comment nodes in the pre-symbolic expression AST. Because this bug
+  would make an otherwise legal contract get rejected by a node, this is a
+  **consensus-breaking** change.
+
 ## [Unreleased]
 
 ### Added
@@ -20,13 +29,6 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
   a result of `(err none)` if the top-level code of the smart contract contained
   runtime error and include details about the error in the `vm_error` field of
   the receipt. Fixes issues #3154, #3328.
-
-- Fixed a bug in the definition sorter, where functions could be sorted
-  incorrectly due to comments not being handled correctly in the AST. This
-  problem was exposed with 2.1, because 2.1 introduces a new parser that
-  includes comment nodes in the pre-symbolic expression AST. Because this bug
-  would make an otherwise legal contract get rejected by a node, this is a
-  **consensus-breaking** change.
 
 ## [2.1.0.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
   runtime error and include details about the error in the `vm_error` field of
   the receipt. Fixes issues #3154, #3328.
 
+- Fixed a bug in the definition sorter, where functions could be sorted
+  incorrectly due to comments not being handled correctly in the AST. This
+  problem was exposed with 2.1, because 2.1 introduces a new parser that
+  includes comment nodes in the pre-symbolic expression AST. Because this bug
+  would make an otherwise legal contract get rejected by a node, this is a
+  **consensus-breaking** change.
+
 ## [2.1.0.0.2]
 
 This software update is a hotfix to resolve improper unlock handling

--- a/clarity/src/vm/analysis/mod.rs
+++ b/clarity/src/vm/analysis/mod.rs
@@ -137,7 +137,9 @@ pub fn run_analysis(
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 TypeChecker2_05::run_pass(&epoch, &mut contract_analysis, db)
             }
-            StacksEpochId::Epoch21 => TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
+                TypeChecker2_1::run_pass(&epoch, &mut contract_analysis, db)
+            }
             StacksEpochId::Epoch10 => unreachable!("Epoch 1.0 is not a valid epoch for analysis"),
         }?;
         TraitChecker::run_pass(&epoch, &mut contract_analysis, db)?;

--- a/clarity/src/vm/analysis/type_checker/mod.rs
+++ b/clarity/src/vm/analysis/type_checker/mod.rs
@@ -50,7 +50,9 @@ impl FunctionType {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 self.check_args_2_05(accounting, args)
             }
-            StacksEpochId::Epoch21 => self.check_args_2_1(accounting, args, clarity_version),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
+                self.check_args_2_1(accounting, args, clarity_version)
+            }
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),
         }
     }
@@ -66,7 +68,7 @@ impl FunctionType {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => {
                 self.check_args_by_allowing_trait_cast_2_05(db, func_args)
             }
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                 self.check_args_by_allowing_trait_cast_2_1(db, clarity_version, func_args)
             }
             StacksEpochId::Epoch10 => unreachable!("Epoch10 is not supported"),

--- a/clarity/src/vm/ast/definition_sorter/mod.rs
+++ b/clarity/src/vm/ast/definition_sorter/mod.rs
@@ -325,7 +325,7 @@ impl<'a> DefinitionSorter {
 
         for pair in pairs.iter() {
             self.probe_for_dependencies_in_key_value_pair(
-                pair.iter().collect(),
+                self.filter_comments(pair),
                 tle_index,
                 version,
             )?;

--- a/clarity/src/vm/ast/definition_sorter/mod.rs
+++ b/clarity/src/vm/ast/definition_sorter/mod.rs
@@ -258,7 +258,7 @@ impl<'a> DefinitionSorter {
                                     // Args: [((name-1 value-1) (name-2 value-2)), ...]: handle 1st arg as a tuple
                                     if function_args.len() > 1 {
                                         if let Some(bindings) = function_args[0].match_list() {
-                                            self.probe_for_dependencies_in_list_of_wrapped_key_value_pairs(self.filter_comments(bindings.iter()), tle_index, version)?;
+                                            self.probe_for_dependencies_in_list_of_wrapped_key_value_pairs(&self.filter_comments(bindings.iter()), tle_index, version)?;
                                         }
                                         for expr in
                                             function_args[1..function_args.len()].into_iter()
@@ -282,7 +282,7 @@ impl<'a> DefinitionSorter {
                                 NativeFunctions::TupleCons => {
                                     // Args: [(key-name A), (key-name-2 B), ...]: handle as a tuple
                                     self.probe_for_dependencies_in_list_of_wrapped_key_value_pairs(
-                                        function_args,
+                                        &function_args,
                                         tle_index,
                                         version,
                                     )?;
@@ -300,7 +300,7 @@ impl<'a> DefinitionSorter {
             }
             Tuple(ref exprs) => {
                 self.probe_for_dependencies_in_tuple(
-                    self.filter_comments(exprs.iter()),
+                    &self.filter_comments(exprs.iter()),
                     tle_index,
                     version,
                 )?;
@@ -319,7 +319,7 @@ impl<'a> DefinitionSorter {
     ///   probe them for dependencies as if they were part of a tuple definition.
     fn probe_for_dependencies_in_tuple(
         &mut self,
-        pairs: Vec<&PreSymbolicExpression>,
+        pairs: &[&PreSymbolicExpression],
         tle_index: usize,
         version: ClarityVersion,
     ) -> ParseResult<()> {
@@ -330,7 +330,7 @@ impl<'a> DefinitionSorter {
 
         for pair in pairs.iter() {
             self.probe_for_dependencies_in_key_value_pair(
-                self.filter_comments(pair.iter().map(|x| *x)),
+                &self.filter_comments(pair.iter().map(|x| *x)),
                 tle_index,
                 version,
             )?;
@@ -350,9 +350,8 @@ impl<'a> DefinitionSorter {
             // 2. (define-public (func_name (arg uint) ...) body)
             // The goal here is to traverse case 2, looking for trait references
             if let Some((_, pairs)) = self.filter_comments(func_sig.iter()).split_first() {
-                let pairs_vec: Vec<&PreSymbolicExpression> = pairs.to_vec();
                 self.probe_for_dependencies_in_list_of_wrapped_key_value_pairs(
-                    pairs_vec, tle_index, version,
+                    &pairs, tle_index, version,
                 )?;
             }
         }
@@ -361,7 +360,7 @@ impl<'a> DefinitionSorter {
 
     fn probe_for_dependencies_in_list_of_wrapped_key_value_pairs(
         &mut self,
-        pairs: Vec<&PreSymbolicExpression>,
+        pairs: &[&PreSymbolicExpression],
         tle_index: usize,
         version: ClarityVersion,
     ) -> ParseResult<()> {
@@ -379,7 +378,7 @@ impl<'a> DefinitionSorter {
     ) -> ParseResult<()> {
         if let Some(pair) = expr.match_list() {
             self.probe_for_dependencies_in_key_value_pair(
-                self.filter_comments(pair.iter()),
+                &self.filter_comments(pair.iter()),
                 tle_index,
                 version,
             )?;
@@ -389,7 +388,7 @@ impl<'a> DefinitionSorter {
 
     fn probe_for_dependencies_in_key_value_pair(
         &mut self,
-        pair: Vec<&PreSymbolicExpression>,
+        pair: &[&PreSymbolicExpression],
         tle_index: usize,
         version: ClarityVersion,
     ) -> ParseResult<()> {

--- a/clarity/src/vm/ast/definition_sorter/tests.rs
+++ b/clarity/src/vm/ast/definition_sorter/tests.rs
@@ -401,6 +401,7 @@ fn should_not_conflict_with_atoms_from_trait_definitions(
 #[apply(test_clarity_versions_definition_sorter)]
 fn should_handle_comments_in_lists(#[case] version: ClarityVersion, #[case] epoch: StacksEpochId) {
     let contracts = [
+        // comment in general lists
         r#"
 (define-trait use-empty-trait (
   ;; this is a comment
@@ -413,6 +414,7 @@ fn should_handle_comments_in_lists(#[case] version: ClarityVersion, #[case] epoc
 )
 (define-trait empty-trait ())
     "#,
+        // comment in a let
         r#"
 (define-public (bar)
   (let ((x
@@ -423,6 +425,7 @@ fn should_handle_comments_in_lists(#[case] version: ClarityVersion, #[case] epoc
 )
 (define-private (foo) (ok u1))
     "#,
+        // comment in a tuple
         r#"
 (define-public (bar)
   (ok (tuple 
@@ -432,6 +435,7 @@ fn should_handle_comments_in_lists(#[case] version: ClarityVersion, #[case] epoc
   )
   (define-private (foo) (ok u1))
     "#,
+        // comment in a tuple, sugared-syntax
         r#"
 (define-public (bar)
   (ok {
@@ -441,6 +445,7 @@ fn should_handle_comments_in_lists(#[case] version: ClarityVersion, #[case] epoc
 )
 (define-private (foo) (ok u1))
     "#,
+        //comment in function parameter definition
         r#"
 (define-public (
   ;; this is a comment
@@ -450,6 +455,7 @@ fn should_handle_comments_in_lists(#[case] version: ClarityVersion, #[case] epoc
 )
 (define-trait empty-trait ())
     "#,
+        // comment in trait definition
         r#"
 (define-public (bar (t <empty-trait>))
   (ok true)

--- a/clarity/src/vm/ast/mod.rs
+++ b/clarity/src/vm/ast/mod.rs
@@ -249,7 +249,7 @@ fn inner_build_ast<T: CostTracker>(
         }
         _ => (),
     }
-    match DefinitionSorter::run_pass(&mut contract_ast, cost_track, clarity_version) {
+    match DefinitionSorter::run_pass(&mut contract_ast, cost_track, clarity_version, epoch) {
         Err(e) if error_early => return Err(e),
         Err(e) => {
             diagnostics.push(e.diagnostic);

--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -699,7 +699,7 @@ impl LimitedCostTracker {
             }
             StacksEpochId::Epoch20 => COSTS_1_NAME.to_string(),
             StacksEpochId::Epoch2_05 => COSTS_2_NAME.to_string(),
-            StacksEpochId::Epoch21 => COSTS_3_NAME.to_string(),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => COSTS_3_NAME.to_string(),
         }
     }
 }

--- a/clarity/src/vm/functions/mod.rs
+++ b/clarity/src/vm/functions/mod.rs
@@ -54,8 +54,10 @@ macro_rules! switch_on_global_epoch {
                 }
                 StacksEpochId::Epoch20 => $Epoch2Version(args, env, context),
                 StacksEpochId::Epoch2_05 => $Epoch205Version(args, env, context),
-                // Note: We reuse 2.05 for 2.1.
-                StacksEpochId::Epoch21 => $Epoch205Version(args, env, context),
+                // Note: We reuse 2.05 for 2.1 and above
+                StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
+                    $Epoch205Version(args, env, context)
+                }
             }
         }
     };

--- a/clarity/src/vm/types/signatures.rs
+++ b/clarity/src/vm/types/signatures.rs
@@ -529,7 +529,7 @@ impl TypeSignature {
     pub fn admits_type(&self, epoch: &StacksEpochId, other: &TypeSignature) -> Result<bool> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => self.admits_type_v2_0(&other),
-            StacksEpochId::Epoch21 => self.admits_type_v2_1(other),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => self.admits_type_v2_1(other),
             StacksEpochId::Epoch10 => unreachable!("epoch 1.0 not supported"),
         }
     }
@@ -1045,7 +1045,7 @@ impl TypeSignature {
     ) -> Result<TypeSignature> {
         match epoch {
             StacksEpochId::Epoch20 | StacksEpochId::Epoch2_05 => Self::least_supertype_v2_0(a, b),
-            StacksEpochId::Epoch21 => Self::least_supertype_v2_1(a, b),
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => Self::least_supertype_v2_1(a, b),
             StacksEpochId::Epoch10 => unreachable!("Clarity 1.0 is not supported"),
         }
     }

--- a/clarity/src/vm/version.rs
+++ b/clarity/src/vm/version.rs
@@ -30,7 +30,7 @@ impl ClarityVersion {
             }
             StacksEpochId::Epoch20 => ClarityVersion::Clarity1,
             StacksEpochId::Epoch2_05 => ClarityVersion::Clarity1,
-            StacksEpochId::Epoch21 => ClarityVersion::Clarity2,
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => ClarityVersion::Clarity2,
         }
     }
 }

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2847,6 +2847,7 @@ impl SortitionDB {
             }
             StacksEpochId::Epoch2_05 => version == "2" || version == "3" || version == "4",
             StacksEpochId::Epoch21 => version == "3" || version == "4",
+            StacksEpochId::Epoch22 => version == "4",
         }
     }
 

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -38,6 +38,7 @@ use crate::chainstate::stacks::address::PoxAddress;
 use crate::chainstate::stacks::index::storage::TrieFileStorage;
 use crate::chainstate::stacks::{StacksPrivateKey, StacksPublicKey};
 use crate::codec::{write_next, Error as codec_error, StacksMessageCodec};
+use crate::core::STACKS_EPOCH_2_2_MARKER;
 use crate::core::{StacksEpoch, StacksEpochId};
 use crate::core::{STACKS_EPOCH_2_05_MARKER, STACKS_EPOCH_2_1_MARKER};
 use crate::net::Error as net_error;
@@ -753,6 +754,7 @@ impl LeaderBlockCommitOp {
             }
             StacksEpochId::Epoch2_05 => self.check_epoch_commit_marker(STACKS_EPOCH_2_05_MARKER),
             StacksEpochId::Epoch21 => self.check_epoch_commit_marker(STACKS_EPOCH_2_1_MARKER),
+            StacksEpochId::Epoch22 => self.check_epoch_commit_marker(STACKS_EPOCH_2_2_MARKER),
         }
     }
 
@@ -767,7 +769,7 @@ impl LeaderBlockCommitOp {
     ) -> Result<SortitionId, op_error> {
         let tx_tip = tx.context.chain_tip.clone();
         let intended_sortition = match epoch_id {
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                 // correct behavior -- uses *sortition height* to find the intended sortition ID
                 let sortition_height = self
                     .block_height

--- a/src/chainstate/coordinator/mod.rs
+++ b/src/chainstate/coordinator/mod.rs
@@ -3006,7 +3006,7 @@ impl<
                                     return Ok(Some(pox_anchor));
                                 }
                             }
-                            StacksEpochId::Epoch21 => {
+                            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                                 // 2.1 behavior: the anchor block must also be the
                                 // heaviest-confirmed anchor block by BTC weight, and the highest
                                 // such anchor block if there are multiple contenders.

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4878,21 +4878,43 @@ impl StacksChainState {
                             receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
                             applied = true;
                         }
+                        StacksEpochId::Epoch22 => {
+                            receipts.push(clarity_tx.block.initialize_epoch_2_05()?);
+                            receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                            // Note that there is currently no initialization required for 2.2
+                            applied = true;
+                        }
                         _ => {
                             panic!("Bad Stacks epoch transition; parent_epoch = {}, current_epoch = {}", &stacks_parent_epoch, &sortition_epoch.epoch_id);
                         }
                     },
                     StacksEpochId::Epoch2_05 => {
-                        assert_eq!(
-                            sortition_epoch.epoch_id,
-                            StacksEpochId::Epoch21,
-                            "Should only transition from Epoch2_05 to Epoch21"
-                        );
-                        receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
-                        applied = true;
+                        match sortition_epoch.epoch_id {
+                            StacksEpochId::Epoch21 => {
+                                receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                                applied = true;
+                            }
+                            StacksEpochId::Epoch22 => {
+                                receipts.append(&mut clarity_tx.block.initialize_epoch_2_1()?);
+                                // Note that there is currently no initialization required for 2.2
+                                applied = true;
+                            }
+                            _ => {
+                                panic!("Bad Stacks epoch transition; parent_epoch = {}, current_epoch = {}", &stacks_parent_epoch, &sortition_epoch.epoch_id);
+                            }
+                        }
                     }
                     StacksEpochId::Epoch21 => {
-                        panic!("No defined transition from Epoch21 forward")
+                        assert_eq!(
+                            sortition_epoch.epoch_id,
+                            StacksEpochId::Epoch22,
+                            "Should only transition from Epoch21 to Epoch22"
+                        );
+                        // Note that there is currently no initialization required for 2.2
+                        applied = true;
+                    }
+                    StacksEpochId::Epoch22 => {
+                        panic!("No defined transition from Epoch22 forward")
                     }
                 }
             }
@@ -5479,7 +5501,7 @@ impl StacksChainState {
                 // The DelegateStx bitcoin wire format does not exist before Epoch 2.1.
                 Ok((stack_ops, transfer_ops, vec![]))
             }
-            StacksEpochId::Epoch21 => {
+            StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => {
                 StacksChainState::get_stacking_and_transfer_and_delegate_burn_ops_v210(
                     chainstate_tx,
                     parent_index_hash,

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -223,6 +223,7 @@ impl DBConfig {
                 self.version == "2" || self.version == "3" || self.version == "4"
             }
             StacksEpochId::Epoch21 => self.version == "3" || self.version == "4",
+            StacksEpochId::Epoch22 => self.version == "4",
         }
     }
 }

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -8548,6 +8548,7 @@ pub mod test {
                     StacksEpochId::Epoch20 => self.get_stacks_epoch(0),
                     StacksEpochId::Epoch2_05 => self.get_stacks_epoch(1),
                     StacksEpochId::Epoch21 => self.get_stacks_epoch(2),
+                    StacksEpochId::Epoch22 => self.get_stacks_epoch(3),
                 }
             }
             fn get_pox_payout_addrs(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -702,7 +702,7 @@ impl StacksEpochExtension for StacksEpoch {
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch2_05,
                 start_height: 0,
-                end_height: first_burnchain_height,
+                end_height: 0,
                 block_limit: ExecutionCost {
                     write_length: 205205,
                     write_count: 205205,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -57,6 +57,7 @@ pub const PEER_VERSION_EPOCH_1_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_05: u8 = 0x05;
 pub const PEER_VERSION_EPOCH_2_1: u8 = 0x06;
+pub const PEER_VERSION_EPOCH_2_2: u8 = 0x07;
 
 // network identifiers
 pub const NETWORK_ID_MAINNET: u32 = 0x17000000;
@@ -326,6 +327,10 @@ pub static STACKS_EPOCH_2_05_MARKER: u8 = 0x05;
 /// *or greater*.
 pub static STACKS_EPOCH_2_1_MARKER: u8 = 0x06;
 
+/// Stacks 2.2 epoch marker.  All block-commits in 2.2 must have a memo bitfield with this value
+/// *or greater*.
+pub static STACKS_EPOCH_2_2_MARKER: u8 = 0x07;
+
 #[test]
 fn test_ord_for_stacks_epoch() {
     let epochs = STACKS_EPOCHS_MAINNET.clone();
@@ -392,6 +397,10 @@ pub trait StacksEpochExtension {
     fn unit_test_2_1(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
     #[cfg(test)]
     fn unit_test_2_1_only(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
+    #[cfg(test)]
+    fn unit_test_2_2(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
+    #[cfg(test)]
+    fn unit_test_2_2_only(epoch_2_0_block_height: u64) -> Vec<StacksEpoch>;
     fn all(
         epoch_2_0_block_height: u64,
         epoch_2_05_block_height: u64,
@@ -605,6 +614,134 @@ impl StacksEpochExtension for StacksEpoch {
     }
 
     #[cfg(test)]
+    fn unit_test_2_2(first_burnchain_height: u64) -> Vec<StacksEpoch> {
+        info!(
+            "StacksEpoch unit_test first_burn_height = {}",
+            first_burnchain_height
+        );
+
+        vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: first_burnchain_height,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: first_burnchain_height,
+                end_height: first_burnchain_height + 4,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: first_burnchain_height + 4,
+                end_height: first_burnchain_height + 8,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: first_burnchain_height + 8,
+                end_height: first_burnchain_height + 12,
+                block_limit: ExecutionCost {
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch22,
+                start_height: first_burnchain_height + 12,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    write_length: 220220,
+                    write_count: 220220,
+                    read_length: 220220,
+                    read_count: 220220,
+                    runtime: 220220,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_2,
+            },
+        ]
+    }
+
+    #[cfg(test)]
+    fn unit_test_2_2_only(first_burnchain_height: u64) -> Vec<StacksEpoch> {
+        info!(
+            "StacksEpoch unit_test first_burn_height = {}",
+            first_burnchain_height
+        );
+
+        vec![
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch10,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_1_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch20,
+                start_height: 0,
+                end_height: 0,
+                block_limit: ExecutionCost::max_value(),
+                network_epoch: PEER_VERSION_EPOCH_2_0,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch2_05,
+                start_height: 0,
+                end_height: first_burnchain_height,
+                block_limit: ExecutionCost {
+                    write_length: 205205,
+                    write_count: 205205,
+                    read_length: 205205,
+                    read_count: 205205,
+                    runtime: 205205,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_05,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch21,
+                start_height: 0,
+                end_height: first_burnchain_height,
+                block_limit: ExecutionCost {
+                    write_length: 210210,
+                    write_count: 210210,
+                    read_length: 210210,
+                    read_count: 210210,
+                    runtime: 210210,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_1,
+            },
+            StacksEpoch {
+                epoch_id: StacksEpochId::Epoch22,
+                start_height: first_burnchain_height,
+                end_height: STACKS_EPOCH_MAX,
+                block_limit: ExecutionCost {
+                    write_length: 220220,
+                    write_count: 210220,
+                    read_length: 210220,
+                    read_count: 210220,
+                    runtime: 220220,
+                },
+                network_epoch: PEER_VERSION_EPOCH_2_2,
+            },
+        ]
+    }
+
+    #[cfg(test)]
     fn unit_test(stacks_epoch_id: StacksEpochId, first_burnchain_height: u64) -> Vec<StacksEpoch> {
         match stacks_epoch_id {
             StacksEpochId::Epoch10 | StacksEpochId::Epoch20 => {
@@ -612,6 +749,7 @@ impl StacksEpochExtension for StacksEpoch {
             }
             StacksEpochId::Epoch2_05 => StacksEpoch::unit_test_2_05(first_burnchain_height),
             StacksEpochId::Epoch21 => StacksEpoch::unit_test_2_1(first_burnchain_height),
+            StacksEpochId::Epoch22 => StacksEpoch::unit_test_2_2(first_burnchain_height),
         }
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -287,7 +287,7 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref STACKS_EPOCHS_REGTEST: [StacksEpoch; 4] = [
+    pub static ref STACKS_EPOCHS_REGTEST: [StacksEpoch; 5] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -312,6 +312,13 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,
             start_height: 2000,
+            end_height: 3000,
+            block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_1
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch22,
+            start_height: 3000,
             end_height: STACKS_EPOCH_MAX,
             block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_1

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -229,8 +229,7 @@ impl PessimisticEstimator {
                     StacksEpochId::Epoch10 => "",
                     StacksEpochId::Epoch20 => "",
                     StacksEpochId::Epoch2_05 => ":2.05",
-                    StacksEpochId::Epoch21 => ":2.1",
-                    StacksEpochId::Epoch22 => ":2.2",
+                    StacksEpochId::Epoch21 | StacksEpochId::Epoch22 => ":2.1",
                 };
                 format!(
                     "cc{}:{}:{}.{}",

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -230,6 +230,7 @@ impl PessimisticEstimator {
                     StacksEpochId::Epoch20 => "",
                     StacksEpochId::Epoch2_05 => ":2.05",
                     StacksEpochId::Epoch21 => ":2.1",
+                    StacksEpochId::Epoch22 => ":2.2",
                 };
                 format!(
                     "cc{}:{}:{}.{}",

--- a/stacks-common/src/types/mod.rs
+++ b/stacks-common/src/types/mod.rs
@@ -64,6 +64,7 @@ pub const PEER_VERSION_EPOCH_1_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_0: u8 = 0x00;
 pub const PEER_VERSION_EPOCH_2_05: u8 = 0x05;
 pub const PEER_VERSION_EPOCH_2_1: u8 = 0x06;
+pub const PEER_VERSION_EPOCH_2_2: u8 = 0x07;
 
 #[repr(u32)]
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Copy, Serialize, Deserialize)]
@@ -72,6 +73,7 @@ pub enum StacksEpochId {
     Epoch20 = 0x02000,
     Epoch2_05 = 0x02005,
     Epoch21 = 0x0200a,
+    Epoch22 = 0x02014,
 }
 
 impl StacksEpochId {
@@ -87,6 +89,7 @@ impl std::fmt::Display for StacksEpochId {
             StacksEpochId::Epoch20 => write!(f, "2.0"),
             StacksEpochId::Epoch2_05 => write!(f, "2.05"),
             StacksEpochId::Epoch21 => write!(f, "2.1"),
+            StacksEpochId::Epoch22 => write!(f, "2.2"),
         }
     }
 }
@@ -100,6 +103,7 @@ impl TryFrom<u32> for StacksEpochId {
             x if x == StacksEpochId::Epoch20 as u32 => Ok(StacksEpochId::Epoch20),
             x if x == StacksEpochId::Epoch2_05 as u32 => Ok(StacksEpochId::Epoch2_05),
             x if x == StacksEpochId::Epoch21 as u32 => Ok(StacksEpochId::Epoch21),
+            x if x == StacksEpochId::Epoch22 as u32 => Ok(StacksEpochId::Epoch22),
             _ => Err("Invalid epoch"),
         }
     }

--- a/testnet/stacks-node/src/tests/epoch_22.rs
+++ b/testnet/stacks-node/src/tests/epoch_22.rs
@@ -1,0 +1,442 @@
+use std::env;
+use std::thread;
+
+use stacks::burnchains::Burnchain;
+use stacks::chainstate::stacks::db::StacksChainState;
+use stacks::chainstate::stacks::StacksBlockHeader;
+
+use crate::config::Config;
+use crate::config::EventKeyType;
+use crate::config::EventObserverConfig;
+use crate::config::InitialBalance;
+use crate::neon;
+use crate::neon::RunLoopCounter;
+use crate::tests::bitcoin_regtest::BitcoinCoreController;
+use crate::tests::neon_integrations::*;
+use crate::tests::*;
+use crate::BitcoinRegtestController;
+use crate::BurnchainController;
+use stacks::core;
+
+use stacks::chainstate::burn::operations::leader_block_commit::BURN_BLOCK_MINED_AT_MODULUS;
+use stacks::chainstate::burn::operations::BlockstackOperationType;
+use stacks::chainstate::burn::operations::LeaderBlockCommitOp;
+
+use stacks::chainstate::stacks::address::PoxAddress;
+
+use stacks::burnchains::PoxConstants;
+use stacks::burnchains::Txid;
+
+use stacks_common::types::chainstate::BlockHeaderHash;
+use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::chainstate::VRFSeed;
+use stacks_common::util::secp256k1::Secp256k1PublicKey;
+
+use stacks::chainstate::coordinator::comm::CoordinatorChannels;
+
+use clarity::vm::types::PrincipalData;
+
+use crate::Keychain;
+
+const MINER_BURN_PUBLIC_KEY: &'static str =
+    "03dc62fe0b8964d01fc9ca9a5eec0e22e557a12cc656919e648f04e0b26fea5faa";
+
+#[allow(dead_code)]
+fn advance_to_2_2(
+    mut initial_balances: Vec<InitialBalance>,
+    block_reward_recipient: Option<PrincipalData>,
+    pox_constants: Option<PoxConstants>,
+    segwit: bool,
+) -> (
+    Config,
+    BitcoinCoreController,
+    BitcoinRegtestController,
+    RunLoopCounter,
+    CoordinatorChannels,
+) {
+    let epoch_2_05 = 210;
+    let epoch_2_1 = 215;
+    let epoch_2_2 = 220;
+
+    test_observer::spawn();
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    conf.burnchain.peer_host = "localhost".to_string();
+    conf.initial_balances.append(&mut initial_balances);
+    conf.miner.block_reward_recipient = block_reward_recipient;
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = epoch_2_05;
+    epochs[2].start_height = epoch_2_05;
+    epochs[2].end_height = epoch_2_1;
+    epochs[3].start_height = epoch_2_1;
+    epochs[3].end_height = epoch_2_2;
+    epochs[4].start_height = epoch_2_2;
+
+    conf.burnchain.epochs = Some(epochs);
+
+    conf.miner.segwit = segwit;
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let reward_cycle_len = 2000;
+    let prepare_phase_len = 100;
+    let pox_constants = pox_constants.unwrap_or(PoxConstants::new(
+        reward_cycle_len,
+        prepare_phase_len,
+        4 * prepare_phase_len / 5,
+        5,
+        15,
+        u64::max_value() - 2,
+        u64::max_value() - 1,
+        u32::max_value(),
+    ));
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    // give one coinbase to the miner, and then burn the rest
+    // if segwit is supported, then give one coinbase to the segwit address as well as the legacy
+    // address. This is needed to allow the miner to boot up into 2.1 through epochs 2.0 and 2.05.
+    let mining_pubkey = if conf.miner.segwit {
+        btc_regtest_controller.set_use_segwit(false);
+        btc_regtest_controller.bootstrap_chain(1);
+
+        btc_regtest_controller.set_use_segwit(conf.miner.segwit);
+        btc_regtest_controller.bootstrap_chain(1);
+
+        let mining_pubkey = btc_regtest_controller.get_mining_pubkey().unwrap();
+        debug!("Mining pubkey is {}", &mining_pubkey);
+        btc_regtest_controller.set_mining_pubkey(MINER_BURN_PUBLIC_KEY.to_string());
+
+        mining_pubkey
+    } else {
+        btc_regtest_controller.bootstrap_chain(1);
+
+        let mining_pubkey = btc_regtest_controller.get_mining_pubkey().unwrap();
+        debug!("Mining pubkey is {}", &mining_pubkey);
+        btc_regtest_controller.set_mining_pubkey(MINER_BURN_PUBLIC_KEY.to_string());
+
+        btc_regtest_controller.bootstrap_chain(1);
+
+        mining_pubkey
+    };
+
+    // bitcoin chain starts at epoch 2.05 boundary, minus 5 blocks to go
+    btc_regtest_controller.bootstrap_chain(epoch_2_05 - 7);
+
+    // only one UTXO for our mining pubkey (which is uncompressed, btw)
+    // NOTE: if we're using segwit, then the mining pubkey will be compressed for the segwit UTXO
+    // generation (i.e. it'll be treated as different from the uncompressed public key).
+    let utxos = btc_regtest_controller
+        .get_all_utxos(&Secp256k1PublicKey::from_hex(&mining_pubkey).unwrap());
+
+    eprintln!(
+        "UTXOs for {} (segwit={}): {:?}",
+        &mining_pubkey, conf.miner.segwit, &utxos
+    );
+    assert_eq!(utxos.len(), 1);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    let runloop_burnchain = burnchain_config.clone();
+    thread::spawn(move || run_loop.start(Some(runloop_burnchain), 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let tip_info = get_chain_info(&conf);
+    assert_eq!(tip_info.burn_block_height, epoch_2_05 - 4);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // cross the epoch 2.05 boundary
+    for _i in 0..3 {
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let tip_info = get_chain_info(&conf);
+    assert_eq!(tip_info.burn_block_height, epoch_2_05 + 1);
+
+    // these should all succeed across the epoch 2.1, then 2.2 boundaries
+    for _i in 0..10 {
+        let tip_info = get_chain_info(&conf);
+
+        // this block is the epoch transition?
+        let (chainstate, _) = StacksChainState::open(
+            false,
+            conf.burnchain.chain_id,
+            &conf.get_chainstate_path_str(),
+            None,
+        )
+        .unwrap();
+        let res = StacksChainState::block_crosses_epoch_boundary(
+            &chainstate.db(),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+        )
+        .unwrap();
+        debug!(
+            "Epoch transition at {} ({}/{}) height {}: {}",
+            &StacksBlockHeader::make_index_block_hash(
+                &tip_info.stacks_tip_consensus_hash,
+                &tip_info.stacks_tip
+            ),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+            tip_info.burn_block_height,
+            res
+        );
+
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let tip_info = get_chain_info(&conf);
+    assert_eq!(tip_info.burn_block_height, epoch_2_1 + 1);
+
+    let account = get_account(&http_origin, &miner_account);
+    assert_eq!(account.nonce, 9);
+
+    eprintln!("Begin Stacks 2.2");
+    return (
+        conf,
+        btcd_controller,
+        btc_regtest_controller,
+        blocks_processed,
+        channel,
+    );
+}
+
+#[test]
+#[ignore]
+fn transition_empty_blocks() {
+    // very simple test to verify that the miner will keep making valid (empty) blocks after the
+    // transition.  Really tests that the block-commits are well-formed before and after the epoch
+    // transition.
+    if env::var("BITCOIND_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    let epoch_2_05 = 210;
+    let epoch_2_1 = 215;
+    let epoch_2_2 = 220;
+
+    let (mut conf, miner_account) = neon_integration_test_conf();
+
+    let mut epochs = core::STACKS_EPOCHS_REGTEST.to_vec();
+    epochs[1].end_height = epoch_2_05;
+    epochs[2].start_height = epoch_2_05;
+    epochs[2].end_height = epoch_2_1;
+    epochs[3].start_height = epoch_2_1;
+    epochs[3].end_height = epoch_2_2;
+    epochs[4].start_height = epoch_2_2;
+
+    conf.node.mine_microblocks = false;
+    conf.burnchain.max_rbf = 1000000;
+    conf.miner.first_attempt_time_ms = 5_000;
+    conf.miner.subsequent_attempt_time_ms = 10_000;
+    conf.node.wait_time_for_blocks = 0;
+
+    conf.burnchain.epochs = Some(epochs);
+
+    test_observer::spawn();
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    let keychain = Keychain::default(conf.node.seed.clone());
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    let mut burnchain_config = Burnchain::regtest(&conf.get_burn_db_path());
+
+    let reward_cycle_len = 10;
+    let prepare_phase_len = 3;
+    let pox_constants = PoxConstants::new(
+        reward_cycle_len,
+        prepare_phase_len,
+        4 * prepare_phase_len / 5,
+        5,
+        15,
+        u64::max_value() - 2,
+        u64::max_value() - 1,
+        (epoch_2_1 + 1) as u32,
+    );
+    burnchain_config.pox_constants = pox_constants.clone();
+
+    let mut btcd_controller = BitcoinCoreController::new(conf.clone());
+    btcd_controller
+        .start_bitcoind()
+        .map_err(|_e| ())
+        .expect("Failed starting bitcoind");
+
+    let mut btc_regtest_controller = BitcoinRegtestController::with_burnchain(
+        conf.clone(),
+        None,
+        Some(burnchain_config.clone()),
+        None,
+    );
+
+    btc_regtest_controller.bootstrap_chain(201);
+
+    eprintln!("Chain bootstrapped...");
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    let runloop_burnchain_config = burnchain_config.clone();
+    thread::spawn(move || run_loop.start(Some(runloop_burnchain_config), 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    // first block wakes up the run loop
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    // first block will hold our VRF registration
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let tip_info = get_chain_info(&conf);
+    let key_block_ptr = tip_info.burn_block_height as u32;
+    let key_vtxindex = 1; // nothing else here but the coinbase
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+
+    let burnchain = Burnchain::regtest(&conf.get_burn_db_path());
+    let mut bitcoin_controller = BitcoinRegtestController::new_dummy(conf.clone());
+
+    let mut crossed_22_boundary = false;
+
+    // these should all succeed across the epoch boundary
+    for _i in 0..35 {
+        // also, make *huge* block-commits with invalid marker bytes once we reach the new
+        // epoch, and verify that it fails.
+        let tip_info = get_chain_info(&conf);
+        let pox_info = get_pox_info(&http_origin);
+
+        eprintln!(
+            "\nPoX info at {}\n{:?}\n\n",
+            tip_info.burn_block_height, &pox_info
+        );
+
+        // this block is the epoch transition?
+        let (chainstate, _) = StacksChainState::open(
+            false,
+            conf.burnchain.chain_id,
+            &conf.get_chainstate_path_str(),
+            None,
+        )
+        .unwrap();
+        let res = StacksChainState::block_crosses_epoch_boundary(
+            &chainstate.db(),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+        )
+        .unwrap();
+        debug!(
+            "Epoch transition at {} ({}/{}) height {}: {}",
+            &StacksBlockHeader::make_index_block_hash(
+                &tip_info.stacks_tip_consensus_hash,
+                &tip_info.stacks_tip
+            ),
+            &tip_info.stacks_tip_consensus_hash,
+            &tip_info.stacks_tip,
+            tip_info.burn_block_height,
+            res
+        );
+
+        if tip_info.burn_block_height == epoch_2_05
+            || tip_info.burn_block_height == epoch_2_1
+            || tip_info.burn_block_height == epoch_2_2
+        {
+            assert!(res);
+            if tip_info.burn_block_height == epoch_2_2 {
+                crossed_22_boundary = true;
+            }
+        } else {
+            assert!(!res);
+        }
+
+        if tip_info.burn_block_height + 1 >= epoch_2_1 {
+            let burn_fee_cap = 100000000; // 1 BTC
+            let commit_outs = if !burnchain.is_in_prepare_phase(tip_info.burn_block_height + 1) {
+                vec![
+                    PoxAddress::standard_burn_address(conf.is_mainnet()),
+                    PoxAddress::standard_burn_address(conf.is_mainnet()),
+                ]
+            } else {
+                vec![PoxAddress::standard_burn_address(conf.is_mainnet())]
+            };
+
+            // let's commit
+            let burn_parent_modulus =
+                ((tip_info.burn_block_height + 1) % BURN_BLOCK_MINED_AT_MODULUS) as u8;
+            let op = BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
+                sunset_burn: 0,
+                block_header_hash: BlockHeaderHash([0xff; 32]),
+                burn_fee: burn_fee_cap,
+                input: (Txid([0; 32]), 0),
+                apparent_sender: keychain.get_burnchain_signer(),
+                key_block_ptr,
+                key_vtxindex,
+                memo: vec![0], // bad epoch marker
+                new_seed: VRFSeed([0x11; 32]),
+                parent_block_ptr: 0,
+                parent_vtxindex: 0,
+                // to be filled in
+                vtxindex: 0,
+                txid: Txid([0u8; 32]),
+                block_height: 0,
+                burn_header_hash: BurnchainHeaderHash::zero(),
+                burn_parent_modulus,
+                commit_outs,
+            });
+            let mut op_signer = keychain.generate_op_signer();
+            let res =
+                bitcoin_controller.submit_operation(StacksEpochId::Epoch21, op, &mut op_signer, 1);
+            assert!(res.is_some(), "Failed to submit block-commit");
+        }
+
+        next_block_and_wait(&mut btc_regtest_controller, &blocks_processed);
+    }
+
+    let account = get_account(&http_origin, &miner_account);
+    assert!(crossed_22_boundary);
+    assert!(account.nonce >= 31);
+
+    channel.stop_chains_coordinator();
+}

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -42,6 +42,7 @@ mod atlas;
 mod bitcoin_regtest;
 mod epoch_205;
 mod epoch_21;
+mod epoch_22;
 mod integrations;
 mod mempool;
 pub mod neon_integrations;


### PR DESCRIPTION
There was a bug in the definition sorter once the new parser in 2.1
includes comments in the AST, before pre-symbolic expressions are
converted to symbolic expressions.

As part of this fix, I added a new epoch, 2.2, to isolate these changes, since it is a consensus-breaking change. See commit a1eff2c437a169d1405bb1cda4e76fa7ee593733 for the epoch changes.