### PR TITLE
Add AI code policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -582,3 +582,6 @@ Keep in mind that better variable names can reduce the need for comments, e.g.:
 that are not licensed under compatible terms will be rejected.  Moreover,
 contributions will not be accepted unless _all_ authors accept the project's
 contributor license agreement.
+
+# Use of AI-code Generation
+The Stacks Foundation has a very script policy of no AI-generated code due to uncertainly about licensing issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -584,4 +584,4 @@ contributions will not be accepted unless _all_ authors accept the project's
 contributor license agreement.
 
 # Use of AI-code Generation
-The Stacks Foundation has a very script policy of no AI-generated code due to uncertainly about licensing issues.
+The Stacks Foundation has a very strict policy of not accepting AI-generated code PRs due to uncertainly about licensing issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -583,5 +583,5 @@ that are not licensed under compatible terms will be rejected.  Moreover,
 contributions will not be accepted unless _all_ authors accept the project's
 contributor license agreement.
 
-# Use of AI-code Generation
+## Use of AI-code Generation
 The Stacks Foundation has a very strict policy of not accepting AI-generated code PRs due to uncertainly about licensing issues.


### PR DESCRIPTION
@jcnelson:

> Even if GPT-4 produced perfect, bug-free code (which I very much doubt), it's not even clear that we could use it for licensing reasons. GPT-4-generated code is a derived work from other peoples' code, which may not be GPL-compatible (and we don't know who these people are, so there's no way we could get them to sign the CLA)
> 
> I think for now, we should have a very strict policy of no AI-generated code. We should add that to the CONTRIBUTING file.