### PR TITLE
feat: add default stacks message codec for bool & option 

### DIFF
--- a/stacks-common/src/codec/mod.rs
+++ b/stacks-common/src/codec/mod.rs
@@ -207,7 +207,6 @@ impl StacksMessageCodec for bool {
             0 => Ok(false),
             1 => Ok(true),
             _ => {
-                warn!("Invalid bool value");
                 return Err(Error::DeserializeError(format!(
                     "Failed to parse bool value: {}",
                     b
@@ -237,7 +236,6 @@ impl<T: StacksMessageCodec> StacksMessageCodec for Option<T> {
             0 => Ok(None),
             1 => Ok(Some(read_next(fd)?)),
             _ => {
-                warn!("Invalid option value");
                 return Err(Error::DeserializeError(format!(
                     "Failed to parse option value: invalid header for option value {}",
                     is_some

--- a/stacks-common/src/codec/tests/mod.rs
+++ b/stacks-common/src/codec/tests/mod.rs
@@ -1,0 +1,71 @@
+use std::io::Cursor;
+
+use super::*;
+
+#[test]
+fn codec_for_bool() {
+    let t = true;
+    let f = false;
+    let t_binary = t.serialize_to_vec();
+    let f_binary = f.serialize_to_vec();
+    assert_eq!(&t_binary, &vec![1u8]);
+    assert_eq!(&f_binary, &vec![0u8]);
+    assert_eq!(
+        bool::consensus_deserialize(&mut Cursor::new(&vec![1u8])).unwrap(),
+        true
+    );
+    assert_eq!(
+        bool::consensus_deserialize(&mut Cursor::new(&vec![0u8])).unwrap(),
+        false
+    );
+    let r = bool::consensus_deserialize(&mut Cursor::new(&vec![2u8]));
+    assert!(r.is_err());
+}
+
+#[test]
+fn codec_for_option() {
+    let t = Some(true);
+    let f = Some(false);
+    let n: Option<bool> = None;
+    let t_binary = t.serialize_to_vec();
+    let f_binary = f.serialize_to_vec();
+    let n_binary = n.serialize_to_vec();
+    assert_eq!(&t_binary, &vec![1u8, 1u8]);
+    assert_eq!(&f_binary, &vec![1u8, 0u8]);
+    assert_eq!(&n_binary, &vec![0u8]);
+    assert_eq!(
+        Option::<bool>::consensus_deserialize(&mut Cursor::new(&vec![1u8, 1u8])).unwrap(),
+        Some(true)
+    );
+    assert_eq!(
+        Option::<bool>::consensus_deserialize(&mut Cursor::new(&vec![1u8, 0u8])).unwrap(),
+        Some(false)
+    );
+    assert_eq!(
+        Option::<bool>::consensus_deserialize(&mut Cursor::new(&vec![0u8])).unwrap(),
+        None
+    );
+    let r = bool::consensus_deserialize(&mut Cursor::new(&vec![2u8]));
+    assert!(r.is_err());
+}
+
+#[test]
+fn codec_for_u128() {
+    let n: u128 = 0x1234567890abcdef1234567890abcdef;
+    let n_binary = n.serialize_to_vec();
+    assert_eq!(
+        &n_binary,
+        &vec![
+            0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab,
+            0xcd, 0xef
+        ]
+    );
+    assert_eq!(
+        u128::consensus_deserialize(&mut Cursor::new(&vec![
+            0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab,
+            0xcd, 0xef
+        ]))
+        .unwrap(),
+        0x1234567890abcdef1234567890abcdef
+    );
+}

--- a/stacks-common/src/codec/tests/mod.rs
+++ b/stacks-common/src/codec/tests/mod.rs
@@ -45,7 +45,6 @@ fn codec_for_option() {
 #[test]
 fn codec_for_u128() {
     let n: u128 = 0x1234567890abcdef1234567890abcdef;
-    let n_binary = n.serialize_to_vec();
     assert_eq!(
         &n.serialize_to_vec(),
         &vec![

--- a/stacks-common/src/codec/tests/mod.rs
+++ b/stacks-common/src/codec/tests/mod.rs
@@ -6,20 +6,17 @@ use super::*;
 fn codec_for_bool() {
     let t = true;
     let f = false;
-    let t_binary = t.serialize_to_vec();
-    let f_binary = f.serialize_to_vec();
-    assert_eq!(&t_binary, &vec![1u8]);
-    assert_eq!(&f_binary, &vec![0u8]);
+    assert_eq!(&t.serialize_to_vec(), &vec![1u8]);
+    assert_eq!(&f.serialize_to_vec(), &vec![0u8]);
     assert_eq!(
-        bool::consensus_deserialize(&mut Cursor::new(&vec![1u8])).unwrap(),
-        true
+        bool::consensus_deserialize(&mut Cursor::new(&t.serialize_to_vec())).unwrap(),
+        t
     );
     assert_eq!(
-        bool::consensus_deserialize(&mut Cursor::new(&vec![0u8])).unwrap(),
-        false
+        bool::consensus_deserialize(&mut Cursor::new(&f.serialize_to_vec())).unwrap(),
+        f
     );
-    let r = bool::consensus_deserialize(&mut Cursor::new(&vec![2u8]));
-    assert!(r.is_err());
+    assert!(bool::consensus_deserialize(&mut Cursor::new(&vec![2u8])).is_err());
 }
 
 #[test]
@@ -27,26 +24,22 @@ fn codec_for_option() {
     let t = Some(true);
     let f = Some(false);
     let n: Option<bool> = None;
-    let t_binary = t.serialize_to_vec();
-    let f_binary = f.serialize_to_vec();
-    let n_binary = n.serialize_to_vec();
-    assert_eq!(&t_binary, &vec![1u8, 1u8]);
-    assert_eq!(&f_binary, &vec![1u8, 0u8]);
-    assert_eq!(&n_binary, &vec![0u8]);
+    assert_eq!(&t.serialize_to_vec(), &vec![1u8, 1u8]);
+    assert_eq!(&f.serialize_to_vec(), &vec![1u8, 0u8]);
+    assert_eq!(&n.serialize_to_vec(), &vec![0u8]);
     assert_eq!(
-        Option::<bool>::consensus_deserialize(&mut Cursor::new(&vec![1u8, 1u8])).unwrap(),
-        Some(true)
+        Option::<bool>::consensus_deserialize(&mut Cursor::new(&t.serialize_to_vec())).unwrap(),
+        t
     );
     assert_eq!(
-        Option::<bool>::consensus_deserialize(&mut Cursor::new(&vec![1u8, 0u8])).unwrap(),
-        Some(false)
+        Option::<bool>::consensus_deserialize(&mut Cursor::new(&f.serialize_to_vec())).unwrap(),
+        f
     );
     assert_eq!(
-        Option::<bool>::consensus_deserialize(&mut Cursor::new(&vec![0u8])).unwrap(),
-        None
+        Option::<bool>::consensus_deserialize(&mut Cursor::new(&n.serialize_to_vec())).unwrap(),
+        n
     );
-    let r = bool::consensus_deserialize(&mut Cursor::new(&vec![2u8]));
-    assert!(r.is_err());
+    assert!(bool::consensus_deserialize(&mut Cursor::new(&vec![2u8])).is_err());
 }
 
 #[test]
@@ -54,18 +47,14 @@ fn codec_for_u128() {
     let n: u128 = 0x1234567890abcdef1234567890abcdef;
     let n_binary = n.serialize_to_vec();
     assert_eq!(
-        &n_binary,
+        &n.serialize_to_vec(),
         &vec![
             0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab,
             0xcd, 0xef
         ]
     );
     assert_eq!(
-        u128::consensus_deserialize(&mut Cursor::new(&vec![
-            0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab,
-            0xcd, 0xef
-        ]))
-        .unwrap(),
-        0x1234567890abcdef1234567890abcdef
+        u128::consensus_deserialize(&mut Cursor::new(&n.serialize_to_vec())).unwrap(),
+        n
     );
 }


### PR DESCRIPTION
### Description

Part of #3645 

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
