### PR TITLE
feat: Support reading burnchain data using the commit-reveal format

### DIFF
--- a/src/chainstate/burn/operations/peg_out_request.rs
+++ b/src/chainstate/burn/operations/peg_out_request.rs
@@ -541,6 +541,7 @@ mod tests {
         .unwrap();
 
         let fixtures = [
+            // Plain OP_RETURN tx without memo
             OpFixture {
             txstr: "02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0300000000000000004f6a4c4c69643e000000000000053900dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cd390500000000000022512000000000000000000000000000000000000000000000000000000000000000002a00000000000000225120000000000000000000000000000000000000000000000000000000000000000000000000",
             signer: StacksAddress::from_string("ST3W2ATS1H9RF29DMYW5QP7NYJ643WNP2YFT4Z45C").unwrap(),
@@ -554,6 +555,7 @@ mod tests {
                 block_height: 0,
                 burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap() }),
             },
+            // Plain OP_RETURN tx with memo
             OpFixture {
             txstr: "02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff030000000000000000536a4c5069643e000000000000053900dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cddeadbeef390500000000000022512000000000000000000000000000000000000000000000000000000000000000002a00000000000000225120000000000000000000000000000000000000000000000000000000000000000000000000",
             signer: StacksAddress::from_string("ST3W2ATS1H9RF29DMYW5QP7NYJ643WNP2YFT4Z45C").unwrap(),
@@ -567,6 +569,49 @@ mod tests {
                 block_height: 0,
                 burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap() }),
             },
+            // OP_DROP data from p2tr-over-p2sh input
+            OpFixture {
+            txstr: "020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff23225120273cb9363da5933fe6f2bdcc3fd27f06865227cb526641cc6dc47de5e9ee06edffffffff030000000000000000056a03696477390500000000000022512000000000000000000000000000000000000000000000000000000000000000002a000000000000002251200000000000000000000000000000000000000000000000000000000000000000027e4c563e000000000000053900dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cddeadbeef000000000000002a7576a9200c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c87ad613c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c00000000",
+            signer: StacksAddress::from_string("ST3W2ATS1H9RF29DMYW5QP7NYJ643WNP2YFT4Z45C").unwrap(),
+            result: Ok(PegOutRequestOp {
+                amount: 1337,
+                recipient: PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                signature: MessageSignature::from_hex("00dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cd").unwrap(),
+                peg_wallet_address: PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                fulfillment_fee: 42, memo: vec![222, 173, 190, 239], txid: Txid::from_hex("8d890bf2f7f77c4384f3cf62584a7ce5ac419068d3b43348c774204efa544694").unwrap(),
+                vtxindex: 1,
+                block_height: 0,
+                burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap() }),
+            },
+            // OP_DROP data from p2wsh-over-p2sh input
+            OpFixture {
+            txstr: "020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff23220020273cb9363da5933fe6f2bdcc3fd27f06865227cb526641cc6dc47de5e9ee06edffffffff030000000000000000056a03696477390500000000000022512000000000000000000000000000000000000000000000000000000000000000002a000000000000002251200000000000000000000000000000000000000000000000000000000000000000017e4c563e000000000000053900dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cddeadbeef000000000000002a7576a9200c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c87ad00000000",
+            signer: StacksAddress::from_string("ST3W2ATS1H9RF29DMYW5QP7NYJ643WNP2YFT4Z45C").unwrap(),
+            result: Ok(PegOutRequestOp {
+                amount: 1337,
+                recipient: PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                signature: MessageSignature::from_hex("00dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cd").unwrap(),
+                peg_wallet_address: PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                fulfillment_fee: 42, memo: vec![222, 173, 190, 239], txid: Txid::from_hex("4d2b347a247c41b32f80c10c7d1c7aa42d4944557ab6bfdfbc829628f196e02f").unwrap(),
+                vtxindex: 1,
+                block_height: 0,
+                burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap() }),
+            },
+            // OP_DROP data from p2sh input
+            OpFixture {
+            txstr: "02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff804c7e4c563e000000000000053900dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cddeadbeef000000000000002a7576a9200c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c87adffffffff030000000000000000056a03696477390500000000000022512000000000000000000000000000000000000000000000000000000000000000002a00000000000000225120000000000000000000000000000000000000000000000000000000000000000000000000",
+            signer: StacksAddress::from_string("ST3W2ATS1H9RF29DMYW5QP7NYJ643WNP2YFT4Z45C").unwrap(),
+            result: Ok(PegOutRequestOp {
+                amount: 1337,
+                recipient: PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                signature: MessageSignature::from_hex("00dc18d08e2ee9f476a89c4c195edd402610176bb6264ec56f3f9e42e7386c543846e09282b6f03495c663c8509df7c97ffbcd2adc537bbabe23abd828a52bc8cd").unwrap(),
+                peg_wallet_address: PoxAddress::Addr32(false, PoxAddressType32::P2TR, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                fulfillment_fee: 42, memo: vec![222, 173, 190, 239], txid: Txid::from_hex("f270c1e86449b53b7ed54b1727c20d9317fb17a13a301126eeae0cdc811001b4").unwrap(),
+                vtxindex: 1,
+                block_height: 0,
+                burn_header_hash: BurnchainHeaderHash::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap() }),
+            },
+
         ];
 
         let parser = BitcoinBlockParser::new(BitcoinNetworkType::Testnet, BLOCKSTACK_MAGIC_MAINNET);


### PR DESCRIPTION
This PR implements support for the commit-reveal protocol as defined in the [commit-reveal design](https://github.com/Trust-Machines/core-eng/blob/main/sbtc-planning/commit-reveal-ops.md). The initial support covers commit-reveal operations embedded in p2sh, p2tr-over-p2sh and p2wsh-over-p2sh scripts.

Closes #3680 