### PR TITLE
feat: allow epoch2.2 through epoch2.4 to be configured in regtest mode

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -291,7 +291,7 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref STACKS_EPOCHS_TESTNET: [StacksEpoch; 6] = [
+    pub static ref STACKS_EPOCHS_TESTNET: [StacksEpoch; 7] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -330,15 +330,22 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch23,
             start_height: BITCOIN_TESTNET_STACKS_23_BURN_HEIGHT,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: BITCOIN_TESTNET_STACKS_24_BURN_HEIGHT,
             block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_3
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch24,
+            start_height: BITCOIN_TESTNET_STACKS_24_BURN_HEIGHT,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: BLOCK_LIMIT_MAINNET_21.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_4
         },
     ];
 }
 
 lazy_static! {
-    pub static ref STACKS_EPOCHS_REGTEST: [StacksEpoch; 4] = [
+    pub static ref STACKS_EPOCHS_REGTEST: [StacksEpoch; 7] = [
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,
@@ -363,9 +370,30 @@ lazy_static! {
         StacksEpoch {
             epoch_id: StacksEpochId::Epoch21,
             start_height: 2000,
-            end_height: STACKS_EPOCH_MAX,
+            end_height: 3000,
             block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
             network_epoch: PEER_VERSION_EPOCH_2_1
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch22,
+            start_height: 3000,
+            end_height: 4000,
+            block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_2
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch23,
+            start_height: 4000,
+            end_height: 5000,
+            block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_3
+        },
+        StacksEpoch {
+            epoch_id: StacksEpochId::Epoch24,
+            start_height: 5000,
+            end_height: STACKS_EPOCH_MAX,
+            block_limit: HELIUM_BLOCK_LIMIT_20.clone(),
+            network_epoch: PEER_VERSION_EPOCH_2_4
         },
     ];
 }

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -408,6 +408,33 @@ impl Config {
             burnchain.pox_constants.v1_unlock_height = v1_unlock_height;
         }
 
+        if let Some(epochs) = &self.burnchain.epochs {
+            // Iterate through the epochs vector and find the item where epoch_id == StacksEpochId::Epoch23
+            if let Some(epoch) = epochs
+                .iter()
+                .find(|epoch| epoch.epoch_id == StacksEpochId::Epoch23)
+            {
+                // Override v2_unlock_height to the start_height of epoch2.3
+                debug!(
+                    "Override v2_unlock_height from {} to {}",
+                    burnchain.pox_constants.v2_unlock_height, epoch.start_height
+                );
+                burnchain.pox_constants.v2_unlock_height = epoch.start_height as u32;
+            }
+
+            if let Some(epoch) = epochs
+                .iter()
+                .find(|epoch| epoch.epoch_id == StacksEpochId::Epoch24)
+            {
+                // Override pox_3_activation_height to the start_height of epoch2.4
+                debug!(
+                    "Override pox_3_activation_height from {} to {}",
+                    burnchain.pox_constants.pox_3_activation_height, epoch.start_height
+                );
+                burnchain.pox_constants.pox_3_activation_height = epoch.start_height as u32;
+            }
+        }
+
         if let Some(sunset_start) = self.burnchain.sunset_start {
             debug!(
                 "Override sunset_start from {} to {}",
@@ -507,6 +534,12 @@ impl Config {
                 Ok(StacksEpochId::Epoch2_05)
             } else if epoch_name == EPOCH_CONFIG_2_1_0 {
                 Ok(StacksEpochId::Epoch21)
+            } else if epoch_name == EPOCH_CONFIG_2_2_0 {
+                Ok(StacksEpochId::Epoch22)
+            } else if epoch_name == EPOCH_CONFIG_2_3_0 {
+                Ok(StacksEpochId::Epoch23)
+            } else if epoch_name == EPOCH_CONFIG_2_4_0 {
+                Ok(StacksEpochId::Epoch24)
             } else {
                 Err(format!("Unknown epoch name specified: {}", epoch_name))
             }?;
@@ -529,6 +562,9 @@ impl Config {
             StacksEpochId::Epoch20,
             StacksEpochId::Epoch2_05,
             StacksEpochId::Epoch21,
+            StacksEpochId::Epoch22,
+            StacksEpochId::Epoch23,
+            StacksEpochId::Epoch24,
         ];
         for (expected_epoch, configured_epoch) in expected_list
             .iter()
@@ -1396,6 +1432,9 @@ pub const EPOCH_CONFIG_1_0_0: &'static str = "1.0";
 pub const EPOCH_CONFIG_2_0_0: &'static str = "2.0";
 pub const EPOCH_CONFIG_2_0_5: &'static str = "2.05";
 pub const EPOCH_CONFIG_2_1_0: &'static str = "2.1";
+pub const EPOCH_CONFIG_2_2_0: &'static str = "2.2";
+pub const EPOCH_CONFIG_2_3_0: &'static str = "2.3";
+pub const EPOCH_CONFIG_2_4_0: &'static str = "2.4";
 
 #[derive(Clone, Deserialize, Default, Debug)]
 pub struct BurnchainConfigFile {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -412,14 +412,14 @@ impl Config {
             // Iterate through the epochs vector and find the item where epoch_id == StacksEpochId::Epoch23
             if let Some(epoch) = epochs
                 .iter()
-                .find(|epoch| epoch.epoch_id == StacksEpochId::Epoch23)
+                .find(|epoch| epoch.epoch_id == StacksEpochId::Epoch22)
             {
                 // Override v2_unlock_height to the start_height of epoch2.3
                 debug!(
                     "Override v2_unlock_height from {} to {}",
                     burnchain.pox_constants.v2_unlock_height, epoch.start_height
                 );
-                burnchain.pox_constants.v2_unlock_height = epoch.start_height as u32;
+                burnchain.pox_constants.v2_unlock_height = epoch.start_height as u32 + 1;
             }
 
             if let Some(epoch) = epochs

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -409,12 +409,12 @@ impl Config {
         }
 
         if let Some(epochs) = &self.burnchain.epochs {
-            // Iterate through the epochs vector and find the item where epoch_id == StacksEpochId::Epoch23
+            // Iterate through the epochs vector and find the item where epoch_id == StacksEpochId::Epoch22
             if let Some(epoch) = epochs
                 .iter()
                 .find(|epoch| epoch.epoch_id == StacksEpochId::Epoch22)
             {
-                // Override v2_unlock_height to the start_height of epoch2.3
+                // Override v2_unlock_height to the start_height of epoch2.2
                 debug!(
                     "Override v2_unlock_height from {} to {}",
                     burnchain.pox_constants.v2_unlock_height,

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -417,7 +417,8 @@ impl Config {
                 // Override v2_unlock_height to the start_height of epoch2.3
                 debug!(
                     "Override v2_unlock_height from {} to {}",
-                    burnchain.pox_constants.v2_unlock_height, epoch.start_height
+                    burnchain.pox_constants.v2_unlock_height,
+                    epoch.start_height + 1
                 );
                 burnchain.pox_constants.v2_unlock_height = epoch.start_height as u32 + 1;
             }


### PR DESCRIPTION
Sample config.toml and `/v2/pox` RPC response:
```toml
[[burnchain.epochs]]
epoch_name = "1.0"
start_height = 0

[[burnchain.epochs]]
epoch_name = "2.0"
start_height = 103

[[burnchain.epochs]]
epoch_name = "2.05"
start_height = 104

[[burnchain.epochs]]
epoch_name = "2.1"
start_height = 106

[[burnchain.epochs]]
epoch_name = "2.2"
start_height = 108

[[burnchain.epochs]]
epoch_name = "2.3"
start_height = 109

[[burnchain.epochs]]
epoch_name = "2.4"
start_height = 110
```

```json
{
  "contract_id": "ST000000000000000000002AMW42H.pox-3",
  "pox_activation_threshold_ustx": 600057388429055,
  "first_burnchain_block_height": 0,
  "current_burnchain_block_height": 132,
  "prepare_phase_block_length": 1,
  "reward_phase_block_length": 4,
  "reward_slots": 8,
  "rejection_fraction": 3333333333333333,
  "total_liquid_supply_ustx": 60005738842905576,
  "current_cycle": {
    "id": 26,
    "min_threshold_ustx": 1875180000000000,
    "stacked_ustx": 0,
    "is_pox_active": false
  },
  "next_cycle": {
    "id": 27,
    "min_threshold_ustx": 1875180000000000,
    "min_increment_ustx": 7500717355363,
    "stacked_ustx": 0,
    "prepare_phase_start_block_height": 134,
    "blocks_until_prepare_phase": 2,
    "reward_phase_start_block_height": 135,
    "blocks_until_reward_phase": 3,
    "ustx_until_pox_rejection": 8484139029839119000
  },
  "min_amount_ustx": 1875180000000000,
  "prepare_cycle_length": 1,
  "reward_cycle_id": 26,
  "reward_cycle_length": 5,
  "rejection_votes_left_required": 8484139029839119000,
  "next_reward_cycle_in": 3,
  "contract_versions": [
    {
      "contract_id": "ST000000000000000000002AMW42H.pox",
      "activation_burnchain_block_height": 0,
      "first_reward_cycle_id": 0
    },
    {
      "contract_id": "ST000000000000000000002AMW42H.pox-2",
      "activation_burnchain_block_height": 107,
      "first_reward_cycle_id": 22
    },
    {
      "contract_id": "ST000000000000000000002AMW42H.pox-3",
      "activation_burnchain_block_height": 110,
      "first_reward_cycle_id": 23
    }
  ]
}
```