### PR TITLE
Refactor `u32::max_value()` with `u32::MAX`

### DIFF
--- a/clarity/src/vm/database/clarity_db.rs
+++ b/clarity/src/vm/database/clarity_db.rs
@@ -364,7 +364,7 @@ impl BurnStateDB for NullBurnStateDB {
     }
 
     fn get_v1_unlock_height(&self) -> u32 {
-        u32::max_value()
+        u32::MAX
     }
 
     fn get_pox_prepare_length(&self) -> u32 {

--- a/clarity/src/vm/docs/mod.rs
+++ b/clarity/src/vm/docs/mod.rs
@@ -2764,7 +2764,7 @@ mod test {
             Some(StacksEpoch {
                 epoch_id: StacksEpochId::Epoch21,
                 start_height: 0,
-                end_height: u64::max_value(),
+                end_height: u64::MAX,
                 block_limit: ExecutionCost::max_value(),
                 network_epoch: PEER_VERSION_EPOCH_2_1,
             })
@@ -2774,7 +2774,7 @@ mod test {
         }
 
         fn get_v1_unlock_height(&self) -> u32 {
-            u32::max_value()
+            u32::MAX
         }
 
         fn get_pox_prepare_length(&self) -> u32 {

--- a/clarity/src/vm/test_util/mod.rs
+++ b/clarity/src/vm/test_util/mod.rs
@@ -207,7 +207,7 @@ impl BurnStateDB for UnitTestBurnStateDB {
     }
 
     fn get_v1_unlock_height(&self) -> u32 {
-        u32::max_value()
+        u32::MAX
     }
 
     fn get_pox_prepare_length(&self) -> u32 {

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -345,7 +345,7 @@ impl PoxConstants {
     #[cfg(test)]
     pub fn test_default() -> PoxConstants {
         // 20 reward slots; 10 prepare-phase slots
-        PoxConstants::new(10, 5, 3, 25, 5, 5000, 10000, u32::max_value())
+        PoxConstants::new(10, 5, 3, 25, 5, 5000, 10000, u32::MAX)
     }
 
     /// Returns the PoX contract that is "active" at the given burn block height

--- a/src/burnchains/tests/affirmation.rs
+++ b/src/burnchains/tests/affirmation.rs
@@ -488,8 +488,7 @@ fn test_read_prepare_phase_commits() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -555,8 +554,7 @@ fn test_parent_block_commits() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -647,8 +645,7 @@ fn test_filter_orphan_block_commits() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -708,8 +705,7 @@ fn test_filter_missed_block_commits() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -769,8 +765,7 @@ fn test_find_heaviest_block_commit() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -982,8 +977,7 @@ fn test_find_heaviest_parent_commit_many_commits() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -1235,8 +1229,7 @@ fn test_update_pox_affirmation_maps_3_forks() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -1485,8 +1478,7 @@ fn test_update_pox_affirmation_maps_unique_anchor_block() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -1678,8 +1670,7 @@ fn test_update_pox_affirmation_maps_absent() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -2141,8 +2132,7 @@ fn test_update_pox_affirmation_maps_nothing() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -2408,8 +2398,7 @@ fn test_update_pox_affirmation_fork_2_cycles() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -2700,8 +2689,7 @@ fn test_update_pox_affirmation_fork_duel() {
     let first_height = 0;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;

--- a/src/burnchains/tests/affirmation.rs
+++ b/src/burnchains/tests/affirmation.rs
@@ -489,7 +489,7 @@ fn test_read_prepare_phase_commits() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -556,7 +556,7 @@ fn test_parent_block_commits() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -648,7 +648,7 @@ fn test_filter_orphan_block_commits() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -709,7 +709,7 @@ fn test_filter_missed_block_commits() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -770,7 +770,7 @@ fn test_find_heaviest_block_commit() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -983,7 +983,7 @@ fn test_find_heaviest_parent_commit_many_commits() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -1236,7 +1236,7 @@ fn test_update_pox_affirmation_maps_3_forks() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -1486,7 +1486,7 @@ fn test_update_pox_affirmation_maps_unique_anchor_block() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -1679,7 +1679,7 @@ fn test_update_pox_affirmation_maps_absent() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -2142,7 +2142,7 @@ fn test_update_pox_affirmation_maps_nothing() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(10, 5, 3, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -2409,7 +2409,7 @@ fn test_update_pox_affirmation_fork_2_cycles() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -2701,7 +2701,7 @@ fn test_update_pox_affirmation_fork_duel() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 2, 2, 25, 5, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;

--- a/src/burnchains/tests/db.rs
+++ b/src/burnchains/tests/db.rs
@@ -509,8 +509,7 @@ fn test_get_commit_at() {
     let first_height = 1;
 
     let mut burnchain = Burnchain::regtest(":memory");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -624,8 +623,7 @@ fn test_get_set_check_anchor_block() {
     let first_height = 1;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -709,8 +707,7 @@ fn test_update_block_descendancy() {
     let first_height = 1;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -828,8 +825,7 @@ fn test_update_block_descendancy_with_fork() {
     let first_height = 1;
 
     let mut burnchain = Burnchain::regtest(":memory:");
-    burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
+    burnchain.pox_constants = PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;

--- a/src/burnchains/tests/db.rs
+++ b/src/burnchains/tests/db.rs
@@ -510,7 +510,7 @@ fn test_get_commit_at() {
 
     let mut burnchain = Burnchain::regtest(":memory");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -625,7 +625,7 @@ fn test_get_set_check_anchor_block() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -710,7 +710,7 @@ fn test_update_block_descendancy() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;
@@ -829,7 +829,7 @@ fn test_update_block_descendancy_with_fork() {
 
     let mut burnchain = Burnchain::regtest(":memory:");
     burnchain.pox_constants =
-        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::max_value());
+        PoxConstants::new(5, 3, 2, 3, 0, u64::MAX - 1, u64::MAX, u32::MAX);
     burnchain.first_block_height = first_height;
     burnchain.first_block_hash = first_bhh.clone();
     burnchain.first_block_timestamp = first_timestamp;

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -1767,7 +1767,7 @@ mod tests {
         ];
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::MAX),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -2300,7 +2300,7 @@ mod tests {
         ];
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::MAX),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),
@@ -2990,7 +2990,7 @@ mod tests {
         .unwrap();
 
         let burnchain = Burnchain {
-            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::max_value()),
+            pox_constants: PoxConstants::new(6, 2, 2, 25, 5, 5000, 10000, u32::MAX),
             peer_version: 0x012345678,
             network_id: 0x9abcdef0,
             chain_name: "bitcoin".to_string(),

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -530,18 +530,8 @@ fn make_reward_set_coordinator<'a>(
 
 pub fn get_burnchain(path: &str, pox_consts: Option<PoxConstants>) -> Burnchain {
     let mut b = Burnchain::regtest(&format!("{}/burnchain/db/", path));
-    b.pox_constants = pox_consts.unwrap_or_else(|| {
-        PoxConstants::new(
-            5,
-            3,
-            3,
-            25,
-            5,
-            u64::MAX,
-            u64::MAX,
-            u32::MAX,
-        )
-    });
+    b.pox_constants = pox_consts
+        .unwrap_or_else(|| PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX, u32::MAX));
     b
 }
 
@@ -976,16 +966,7 @@ fn missed_block_commits_2_05() {
     let _r = std::fs::remove_dir_all(path);
 
     let sunset_ht = 8000;
-    let pox_consts = Some(PoxConstants::new(
-        5,
-        3,
-        3,
-        25,
-        5,
-        7010,
-        sunset_ht,
-        u32::MAX,
-    ));
+    let pox_consts = Some(PoxConstants::new(5, 3, 3, 25, 5, 7010, sunset_ht, u32::MAX));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
@@ -1294,16 +1275,7 @@ fn missed_block_commits_2_1() {
     let _r = std::fs::remove_dir_all(path);
 
     let sunset_ht = 8000;
-    let pox_consts = Some(PoxConstants::new(
-        5,
-        3,
-        3,
-        25,
-        5,
-        7010,
-        sunset_ht,
-        u32::MAX,
-    ));
+    let pox_consts = Some(PoxConstants::new(5, 3, 3, 25, 5, 7010, sunset_ht, u32::MAX));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
@@ -3672,16 +3644,7 @@ fn test_initial_coinbase_reward_distributions() {
     let _r = std::fs::remove_dir_all(path);
 
     let sunset_ht = 8000;
-    let pox_consts = Some(PoxConstants::new(
-        5,
-        3,
-        3,
-        25,
-        5,
-        7010,
-        sunset_ht,
-        u32::MAX,
-    ));
+    let pox_consts = Some(PoxConstants::new(5, 3, 3, 25, 5, 7010, sunset_ht, u32::MAX));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..50).map(|_| VRFPrivateKey::new()).collect();
@@ -3909,16 +3872,7 @@ fn test_epoch_switch_cost_contract_instantiation() {
     let _r = std::fs::remove_dir_all(path);
 
     let sunset_ht = 8000;
-    let pox_consts = Some(PoxConstants::new(
-        6,
-        3,
-        3,
-        25,
-        5,
-        10,
-        sunset_ht,
-        u32::MAX,
-    ));
+    let pox_consts = Some(PoxConstants::new(6, 3, 3, 25, 5, 10, sunset_ht, u32::MAX));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let vrf_keys: Vec<_> = (0..10).map(|_| VRFPrivateKey::new()).collect();
@@ -4900,16 +4854,7 @@ fn test_sortition_with_sunset() {
     let _r = std::fs::remove_dir_all(path);
 
     let sunset_ht = 80;
-    let pox_consts = Some(PoxConstants::new(
-        6,
-        3,
-        3,
-        25,
-        5,
-        10,
-        sunset_ht,
-        u32::MAX,
-    ));
+    let pox_consts = Some(PoxConstants::new(6, 3, 3, 25, 5, 10, sunset_ht, u32::MAX));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
     let mut vrf_keys: Vec<_> = (0..200).map(|_| VRFPrivateKey::new()).collect();

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -537,9 +537,9 @@ pub fn get_burnchain(path: &str, pox_consts: Option<PoxConstants>) -> Burnchain 
             3,
             25,
             5,
-            u64::max_value(),
-            u64::max_value(),
-            u32::max_value(),
+            u64::MAX,
+            u64::MAX,
+            u32::MAX,
         )
     });
     b
@@ -984,7 +984,7 @@ fn missed_block_commits_2_05() {
         5,
         7010,
         sunset_ht,
-        u32::max_value(),
+        u32::MAX,
     ));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
@@ -1302,7 +1302,7 @@ fn missed_block_commits_2_1() {
         5,
         7010,
         sunset_ht,
-        u32::max_value(),
+        u32::MAX,
     ));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
@@ -1644,7 +1644,7 @@ fn late_block_commits_2_1() {
         5,
         7010,
         sunset_ht,
-        u32::max_value(),
+        u32::MAX,
     ));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
@@ -2700,7 +2700,7 @@ fn test_pox_btc_ops() {
     let _r = std::fs::remove_dir_all(path);
 
     let sunset_ht = 8000;
-    let pox_v1_unlock_ht = u32::max_value();
+    let pox_v1_unlock_ht = u32::MAX;
     let pox_consts = Some(PoxConstants::new(
         5,
         3,
@@ -2976,7 +2976,7 @@ fn test_stx_transfer_btc_ops() {
     let path = &test_path("stx_transfer-btc-ops");
     let _r = std::fs::remove_dir_all(path);
 
-    let pox_v1_unlock_ht = u32::max_value();
+    let pox_v1_unlock_ht = u32::MAX;
     let sunset_ht = 8000;
     let pox_consts = Some(PoxConstants::new(
         5,
@@ -3680,7 +3680,7 @@ fn test_initial_coinbase_reward_distributions() {
         5,
         7010,
         sunset_ht,
-        u32::max_value(),
+        u32::MAX,
     ));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
@@ -3917,7 +3917,7 @@ fn test_epoch_switch_cost_contract_instantiation() {
         5,
         10,
         sunset_ht,
-        u32::max_value(),
+        u32::MAX,
     ));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
@@ -4908,7 +4908,7 @@ fn test_sortition_with_sunset() {
         5,
         10,
         sunset_ht,
-        u32::max_value(),
+        u32::MAX,
     ));
     let burnchain_conf = get_burnchain(path, pox_consts.clone());
 
@@ -5562,7 +5562,7 @@ fn test_pox_processable_block_in_different_pox_forks() {
         5,
         u64::MAX - 1,
         u64::MAX,
-        u32::max_value(),
+        u32::MAX,
     ));
     let b = get_burnchain(path, pox_consts.clone());
     let b_blind = get_burnchain(path_blinded, pox_consts.clone());

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -149,7 +149,7 @@ impl ClarityTestSim {
             marf,
             height: 0,
             fork: 0,
-            epoch_bounds: vec![0, u64::max_value()],
+            epoch_bounds: vec![0, u64::MAX],
         }
     }
 
@@ -388,7 +388,7 @@ impl BurnStateDB for TestSimBurnStateDB {
                 .epoch_bounds
                 .get(epoch_begin_index + 1)
                 .cloned()
-                .unwrap_or(u64::max_value()),
+                .unwrap_or(u64::MAX),
             epoch_id,
             block_limit: ExecutionCost::max_value(),
             network_epoch: PEER_VERSION_EPOCH_1_0,
@@ -400,7 +400,7 @@ impl BurnStateDB for TestSimBurnStateDB {
     }
 
     fn get_v1_unlock_height(&self) -> u32 {
-        u32::max_value()
+        u32::MAX
     }
 
     fn get_pox_prepare_length(&self) -> u32 {

--- a/src/chainstate/stacks/boot/mod.rs
+++ b/src/chainstate/stacks/boot/mod.rs
@@ -970,7 +970,7 @@ pub mod test {
 
     #[test]
     fn get_reward_threshold_units() {
-        let test_pox_constants = PoxConstants::new(501, 1, 1, 1, 5, 5000, 10000, u32::max_value());
+        let test_pox_constants = PoxConstants::new(501, 1, 1, 1, 5, 5000, 10000, u32::MAX);
         // when the liquid amount = the threshold step,
         //   the threshold should always be the step size.
         let liquid = POX_THRESHOLD_STEPS_USTX;

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -177,7 +177,7 @@ pub struct BlockBuilderSettings {
 impl BlockBuilderSettings {
     pub fn limited() -> BlockBuilderSettings {
         BlockBuilderSettings {
-            max_miner_time_ms: u64::max_value(),
+            max_miner_time_ms: u64::MAX,
             mempool_settings: MemPoolWalkSettings::default(),
             miner_status: Arc::new(Mutex::new(MinerStatus::make_ready(0))),
         }
@@ -185,7 +185,7 @@ impl BlockBuilderSettings {
 
     pub fn max_value() -> BlockBuilderSettings {
         BlockBuilderSettings {
-            max_miner_time_ms: u64::max_value(),
+            max_miner_time_ms: u64::MAX,
             mempool_settings: MemPoolWalkSettings::zero(),
             miner_status: Arc::new(Mutex::new(MinerStatus::make_ready(0))),
         }

--- a/src/clarity_vm/clarity.rs
+++ b/src/clarity_vm/clarity.rs
@@ -2249,7 +2249,7 @@ mod tests {
                 self.get_stacks_epoch(0)
             }
             fn get_v1_unlock_height(&self) -> u32 {
-                u32::max_value()
+                u32::MAX
             }
 
             fn get_pox_prepare_length(&self) -> u32 {

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -314,7 +314,7 @@ impl MemPoolWalkSettings {
     pub fn default() -> MemPoolWalkSettings {
         MemPoolWalkSettings {
             min_tx_fee: 1,
-            max_walk_time_ms: u64::max_value(),
+            max_walk_time_ms: u64::MAX,
             consider_no_estimate_tx_prob: 5,
             nonce_cache_size: 1024 * 1024,
             candidate_retry_cache_size: 64 * 1024,
@@ -323,7 +323,7 @@ impl MemPoolWalkSettings {
     pub fn zero() -> MemPoolWalkSettings {
         MemPoolWalkSettings {
             min_tx_fee: 0,
-            max_walk_time_ms: u64::max_value(),
+            max_walk_time_ms: u64::MAX,
             consider_no_estimate_tx_prob: 5,
             nonce_cache_size: 1024 * 1024,
             candidate_retry_cache_size: 64 * 1024,

--- a/src/cost_estimates/pessimistic.rs
+++ b/src/cost_estimates/pessimistic.rs
@@ -148,7 +148,7 @@ impl Samples {
     fn flush_sqlite(&self, tx: &SqliteTransaction, identifier: &str) {
         let sql = "INSERT OR REPLACE INTO pessimistic_estimator
                      (estimate_key, current_value, samples) VALUES (?, ?, ?)";
-        let current_value = u64_to_sql(self.mean()).unwrap_or_else(|_| i64::max_value());
+        let current_value = u64_to_sql(self.mean()).unwrap_or_else(|_| i64::MAX);
         tx.execute(
             sql,
             rusqlite::params![identifier, current_value, self.to_json()],

--- a/src/deps/httparse/mod.rs
+++ b/src/deps/httparse/mod.rs
@@ -1269,7 +1269,7 @@ mod tests {
         assert_eq!(parse_chunk_size(b"567xf8a\r\n"), Err(Error::ChunkSize));
         assert_eq!(
             parse_chunk_size(b"ffffffffffffffff\r\n"),
-            Ok(Status::Complete((18, u64::max_value())))
+            Ok(Status::Complete((18, u64::MAX)))
         );
         assert_eq!(
             parse_chunk_size(b"1ffffffffffffffff\r\n"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1069,11 +1069,7 @@ simulating a miner.
         let burnchain = Burnchain::regtest(&burnchain_db_path);
         let first_burnchain_block_height = burnchain.first_block_height;
         let first_burnchain_block_hash = burnchain.first_block_hash;
-        let epochs = StacksEpoch::all(
-            first_burnchain_block_height,
-            u64::MAX,
-            u64::MAX,
-        );
+        let epochs = StacksEpoch::all(first_burnchain_block_height, u64::MAX, u64::MAX);
         let (mut new_sortition_db, _) = burnchain
             .connect_db(
                 true,
@@ -1158,11 +1154,7 @@ simulating a miner.
         let mut known_stacks_blocks = HashSet::new();
         let mut next_arrival = 0;
 
-        let epochs = StacksEpoch::all(
-            first_burnchain_block_height,
-            u64::MAX,
-            u64::MAX,
-        );
+        let epochs = StacksEpoch::all(first_burnchain_block_height, u64::MAX, u64::MAX);
 
         let (p2p_new_sortition_db, _) = burnchain
             .connect_db(

--- a/src/main.rs
+++ b/src/main.rs
@@ -734,8 +734,8 @@ simulating a miner.
         let sort_db_path = format!("{}/mainnet/burnchain/sortition", &argv[2]);
         let chain_state_path = format!("{}/mainnet/chainstate/", &argv[2]);
 
-        let mut min_fee = u64::max_value();
-        let mut max_time = u64::max_value();
+        let mut min_fee = u64::MAX;
+        let mut max_time = u64::MAX;
 
         if argv.len() >= 4 {
             min_fee = argv[3].parse().expect("Could not parse min_fee");
@@ -1071,8 +1071,8 @@ simulating a miner.
         let first_burnchain_block_hash = burnchain.first_block_hash;
         let epochs = StacksEpoch::all(
             first_burnchain_block_height,
-            u64::max_value(),
-            u64::max_value(),
+            u64::MAX,
+            u64::MAX,
         );
         let (mut new_sortition_db, _) = burnchain
             .connect_db(
@@ -1160,8 +1160,8 @@ simulating a miner.
 
         let epochs = StacksEpoch::all(
             first_burnchain_block_height,
-            u64::max_value(),
-            u64::max_value(),
+            u64::MAX,
+            u64::MAX,
         );
 
         let (p2p_new_sortition_db, _) = burnchain

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3115,9 +3115,9 @@ mod test {
             3,
             25,
             5,
-            u64::max_value(),
-            u64::max_value(),
-            u32::max_value(),
+            u64::MAX,
+            u64::MAX,
+            u32::MAX,
         );
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
@@ -3142,9 +3142,9 @@ mod test {
             3,
             25,
             5,
-            u64::max_value(),
-            u64::max_value(),
-            u32::max_value(),
+            u64::MAX,
+            u64::MAX,
+            u32::MAX,
         );
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);

--- a/src/net/inv.rs
+++ b/src/net/inv.rs
@@ -3109,16 +3109,7 @@ mod test {
     #[test]
     fn test_inv_merge_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants = PoxConstants::new(
-            5,
-            3,
-            3,
-            25,
-            5,
-            u64::MAX,
-            u64::MAX,
-            u32::MAX,
-        );
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX, u32::MAX);
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..32 {
@@ -3136,16 +3127,7 @@ mod test {
     #[test]
     fn test_inv_truncate_pox_inv() {
         let mut burnchain = Burnchain::regtest("unused");
-        burnchain.pox_constants = PoxConstants::new(
-            5,
-            3,
-            3,
-            25,
-            5,
-            u64::MAX,
-            u64::MAX,
-            u32::MAX,
-        );
+        burnchain.pox_constants = PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX, u32::MAX);
 
         let mut peer_inv = PeerBlocksInv::new(vec![0x01], vec![0x01], vec![0x01], 1, 1, 0);
         for i in 0..5 {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2481,9 +2481,9 @@ pub mod test {
                 3,
                 25,
                 5,
-                u64::max_value(),
-                u64::max_value(),
-                u32::max_value(),
+                u64::MAX,
+                u64::MAX,
+                u32::MAX,
             );
 
             let mut spending_account = TestMinerFactory::new().next_miner(

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2475,16 +2475,8 @@ pub mod test {
                 &BurnchainHeaderHash::from_hex(BITCOIN_GENESIS_BLOCK_HASH_REGTEST).unwrap(),
             );
 
-            burnchain.pox_constants = PoxConstants::new(
-                5,
-                3,
-                3,
-                25,
-                5,
-                u64::MAX,
-                u64::MAX,
-                u32::MAX,
-            );
+            burnchain.pox_constants =
+                PoxConstants::new(5, 3, 3, 25, 5, u64::MAX, u64::MAX, u32::MAX);
 
             let mut spending_account = TestMinerFactory::new().next_miner(
                 &burnchain,

--- a/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
+++ b/stacks-common/src/deps_common/bitcoin/blockdata/transaction.rs
@@ -57,7 +57,7 @@ impl OutPoint {
     pub fn null() -> OutPoint {
         OutPoint {
             txid: Default::default(),
-            vout: u32::max_value(),
+            vout: u32::MAX,
         }
     }
 


### PR DESCRIPTION
### Description
I changed all occurrences of deprecated `u32::max_value()`.
While I was at it, I changed the same deprecated method for `u64` and `i32` hiding there.

### Applicable issues
- fixes #3682 

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] Changelog is updated
