### PR TITLE
hardcode the dockerhub org

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.bitcoin-tests
@@ -1,4 +1,4 @@
-FROM stacks-node:integrations AS test
+FROM stacks-blockchain:integrations AS test
 
 ARG test_name
 ENV BITCOIND_TEST 1

--- a/.github/workflows/image-build-alpine-binary.yml
+++ b/.github/workflows/image-build-alpine-binary.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ github.repository }}
+            blockstack/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest,enable=${{ inputs.tag != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )}}
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}

--- a/.github/workflows/image-build-debian-binary.yml
+++ b/.github/workflows/image-build-debian-binary.yml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ github.repository }}
+            blockstack/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest-${{ inputs.linux_version }},enable=${{ inputs.tag != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )}}
             type=raw,value=${{ inputs.tag }}-${{ inputs.linux_version }},enable=${{ inputs.tag != '' }}

--- a/.github/workflows/image-build-debian-source.yml
+++ b/.github/workflows/image-build-debian-source.yml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ github.repository }}
+            blockstack/${{ github.event.repository.name }}
           tags: |
             type=raw,value=${{ env.BRANCH_NAME }}
             type=ref,event=pr


### PR DESCRIPTION
Resolves an issue with the dockerhub repo being named differently than the github org https://github.com/stacks-network/stacks-blockchain/actions/runs/5193175067

reverts the image name from the testing repo of `${{ github.repository }}` (i.e. `stacks-network/stacks-blockchain`) -> `blockstack/${{ github.event.repository.name }}` (`blockstack/stacks-blockchain`)

https://hub.docker.com/u/blockstack