### PR TITLE
Update docs-pr base image

### DIFF
--- a/.github/actions/docsgen/Dockerfile.docsgen
+++ b/.github/actions/docsgen/Dockerfile.docsgen
@@ -1,4 +1,4 @@
-FROM rust:stretch as build
+FROM rust:bullseye as build
 
 WORKDIR /src
 


### PR DESCRIPTION
updates `.github/actions/docsgen/Dockerfile.docsgen` to use bullseye rather than stretch for the base image. 
This action has not been completing successfully in a while, some of the package repos are 404'ing during the build phase. 

Example failures: https://github.com/stacks-network/stacks-blockchain/actions/runs/5052004488/jobs/9064421170

