### PR TITLE
chore: added burnchain sync percentage

### DIFF
--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -1082,7 +1082,7 @@ impl RunLoop {
             let ibd = match self.get_pox_watchdog().pox_sync_wait(
                 &burnchain_config,
                 &burnchain_tip,
-                Some(remote_chain_height),
+                remote_chain_height,
                 num_sortitions_in_last_cycle,
             ) {
                 Ok(ibd) => ibd,
@@ -1091,6 +1091,16 @@ impl RunLoop {
                     continue;
                 }
             };
+
+            // print burnchain sync percentage
+            if ibd {
+                let percent: f64 =
+                    burnchain_tip.block_snapshot.block_height as f64 / remote_chain_height as f64;
+                debug!("Burnchain sync percentage";
+                       "percent" => %percent,
+                       "local_tip_height" => %burnchain_tip.block_snapshot.block_height,
+                       "remote_tip_height" => %remote_chain_height);
+            }
 
             // will recalculate this in the following loop
             num_sortitions_in_last_cycle = 0;

--- a/testnet/stacks-node/src/syncctl.rs
+++ b/testnet/stacks-node/src/syncctl.rs
@@ -432,21 +432,9 @@ impl PoxSyncWatchdog {
         &mut self,
         burnchain: &Burnchain,
         burnchain_tip: &BurnchainTip, // this is the highest burnchain snapshot we've sync'ed to
-        burnchain_height_opt: Option<u64>, // this is the absolute burnchain block height, if known
+        burnchain_height: u64,        // this is the absolute burnchain block height
         num_sortitions_in_last_cycle: u64,
     ) -> Result<bool, burnchain_error> {
-        let burnchain_height = match burnchain_height_opt {
-            Some(bh) => bh,
-            None => {
-                // not known yet, so assume IBD
-                debug!("Pox watchdog: burnchain height not known yet, so assume IBD");
-                self.relayer_comms.set_ibd(true);
-
-                sleep_ms(self.steady_state_burnchain_sync_interval);
-                return Ok(true);
-            }
-        };
-
         if self.watch_start_ts == 0 {
             self.watch_start_ts = get_epoch_time_secs();
         }


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
When the node is in initial block download, the percentage of the burnchain sync will now print. 

### Applicable issues
- fixes #3557
