### PR TITLE
Feat: ignore logging errors rather than panicking

### DIFF
--- a/stacks-common/src/util/log.rs
+++ b/stacks-common/src/util/log.rs
@@ -205,8 +205,8 @@ fn make_json_logger() -> Logger {
                       }),
     );
 
-    let drain = Mutex::new(slog_json::Json::default(std::io::stderr())).map(slog::Fuse);
-    let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).fuse();
+    let drain = Mutex::new(slog_json::Json::default(std::io::stderr()));
+    let filtered_drain = slog::LevelFilter::new(drain, get_loglevel()).ignore_res();
     slog::Logger::root(filtered_drain, def_keys)
 }
 
@@ -225,7 +225,7 @@ fn make_logger() -> Logger {
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stderr());
         let atty = isatty(Stream::Stderr);
         let drain = TermFormat::new(decorator, pretty_print, debug, atty);
-        let logger = Logger::root(drain.fuse(), o!());
+        let logger = Logger::root(drain.ignore_res(), o!());
         logger
     }
 }
@@ -239,7 +239,7 @@ fn make_logger() -> Logger {
         let plain = slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter);
         let isatty = isatty(Stream::Stdout);
         let drain = TermFormat::new(plain, false, debug, isatty);
-        let logger = Logger::root(drain.fuse(), o!());
+        let logger = Logger::root(drain.ignore_res(), o!());
         logger
     }
 }


### PR DESCRIPTION
### Description

The log macros in the `stacks-blockchain` use a [`Fuse`](https://docs.rs/slog/latest/slog/struct.Fuse.html) drain. This panics if there's a drain error -- like the logging FS is busy and would block.

This patch uses an `IgnoreResult` drain instead.
