### PR TITLE
workaround to failing actions for "no space left"

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           tool-cache: true
 
+      - name: docker prune
+        run: |
+          docker system prune --force
+
       - name: Post clean diskfree
         run: | 
           df -h

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout the latest code
         id: git_checkout
         uses: actions/checkout@v3
+
+      # Could run a `docker system prune here to clean up a little extra space, ~4-5GB
+
       - name: Build bitcoin integration testing image
         id: build_docker_image
         env:
@@ -35,23 +38,12 @@ jobs:
         run: |
           rm .dockerignore
           docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-blockchain:integrations .
-      - name: Pre clean diskfree
-        run: |
-          df -h
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
           docker-images: false
-
-      - name: Post clean diskfree
-        run: |
-          df -h
-
-      - name: Docker image sizes
-        run: |
-          docker images
 
       - name: Export docker image as tarball
         id: export_docker_image

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -44,10 +44,6 @@ jobs:
         with:
           tool-cache: true
 
-      - name: docker prune
-        run: |
-          docker system prune --force
-
       - name: Post clean diskfree
         run: | 
           df -h
@@ -56,13 +52,10 @@ jobs:
         run: |
           docker images
 
-      - name: pwd
-        run: |
-          pwd
-        
       - name: Export docker image as tarball
         id: export_docker_image
         run: docker save -o integration-image.tar stacks-blockchain:integrations
+
       - name: Upload built docker image
         id: upload_docker_image
         uses: actions/upload-artifact@v3

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -28,7 +28,18 @@ jobs:
         id: git_checkout
         uses: actions/checkout@v3
 
-      # Could run a `docker system prune --force`` here to clean up a little extra space, ~4-5GB
+      - name: Reclaim disk space
+        id: cleanup
+        run: |
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^mongodb-.*'
+          sudo apt-get remove -y '^mysql-.*'
+          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          docker system prune --force
 
       - name: Build bitcoin integration testing image
         id: build_docker_image
@@ -38,12 +49,6 @@ jobs:
         run: |
           rm .dockerignore
           docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-blockchain:integrations .
-
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          docker-images: false
 
       - name: Export docker image as tarball
         id: export_docker_image

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -48,6 +48,14 @@ jobs:
         run: | 
           df -h
 
+      - name: Docker image sizes
+        run: |
+          docker images
+
+      - name: pwd
+        run: |
+          pwd
+        
       - name: Export docker image as tarball
         id: export_docker_image
         run: docker save -o integration-image.tar stacks-blockchain:integrations

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Export docker image as tarball
         id: export_docker_image
-        # run: docker save -o integration-image.tar stacks-blockchain:integrations
         run: docker save stacks-blockchain:integrations | gzip > integration-image.tar.gz
 
       - name: Upload built docker image

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -28,7 +28,7 @@ jobs:
         id: git_checkout
         uses: actions/checkout@v3
 
-      # Could run a `docker system prune here to clean up a little extra space, ~4-5GB
+      # Could run a `docker system prune --force`` here to clean up a little extra space, ~4-5GB
 
       - name: Build bitcoin integration testing image
         id: build_docker_image
@@ -47,14 +47,15 @@ jobs:
 
       - name: Export docker image as tarball
         id: export_docker_image
-        run: docker save -o integration-image.tar stacks-blockchain:integrations
+        # run: docker save -o integration-image.tar stacks-blockchain:integrations
+        run: docker save stacks-blockchain:integrations | gzip > integration-image.tar.gz
 
       - name: Upload built docker image
         id: upload_docker_image
         uses: actions/upload-artifact@v3
         with:
-          name: integration-image.tar
-          path: integration-image.tar
+          name: integration-image.tar.gz
+          path: integration-image.tar.gz
 
   # Run integration tests using sampled genesis block
   sampled-genesis:
@@ -141,10 +142,10 @@ jobs:
         id: download_docker_image
         uses: actions/download-artifact@v3
         with:
-          name: integration-image.tar
+          name: integration-image.tar.gz
       - name: Load docker image
         id: load_docker_image
-        run: docker load -i integration-image.tar && rm integration-image.tar
+        run: docker load -i integration-image.tar.gz && rm integration-image.tar.gz
       - name: All integration tests with sampled genesis
         id: bitcoin_integration_tests
         timeout-minutes: 30
@@ -180,10 +181,10 @@ jobs:
         id: download_docker_image
         uses: actions/download-artifact@v3
         with:
-          name: integration-image.tar
+          name: integration-image.tar.gz
       - name: Load docker image
         id: load_docker_image
-        run: docker load -i integration-image.tar && rm integration-image.tar
+        run: docker load -i integration-image.tar.gz && rm integration-image.tar.gz
       - name: Atlas integration tests
         id: atlas_integration_tests
         timeout-minutes: 40

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           rm .dockerignore
           docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-blockchain:integrations .
-      - name: Pre clean diskfree 
+      - name: Pre clean diskfree
         run: |
           df -h
 
@@ -43,9 +43,10 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
+          docker-images: false
 
       - name: Post clean diskfree
-        run: | 
+        run: |
           df -h
 
       - name: Docker image sizes

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -35,6 +35,19 @@ jobs:
         run: |
           rm .dockerignore
           docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-blockchain:integrations .
+      - name: Pre clean diskfree 
+        run: |
+          df -h
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+
+      - name: Post clean diskfree
+        run: | 
+          df -h
+
       - name: Export docker image as tarball
         id: export_docker_image
         run: docker save -o integration-image.tar stacks-blockchain:integrations


### PR DESCRIPTION
ex: https://github.com/stacks-network/stacks-blockchain/actions/runs/5510601197

not sure of the root cause here, but the last i had checked this docker image was around 8GB in size. 
there *should* be plenty of space available on the runner (historically this has been true) - so either the free space is less now for some reason, or we're using more space than we have in the past. 

this is a test workaround that does 3 things:
1. prints`dh -f` output
2. runs [this action](https://github.com/jlumbroso/free-disk-space/releases/tag/v1.1.0) to reclaim space
2. prints `df -h` output again