### PR TITLE
Add prom metrics for last mined block

### DIFF
--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -63,6 +63,9 @@ use crate::chainstate::stacks::db::blocks::SetupBlockResult;
 use crate::chainstate::stacks::StacksBlockHeader;
 use crate::chainstate::stacks::StacksMicroblockHeader;
 use crate::codec::{read_next, write_next, StacksMessageCodec};
+use crate::monitoring::{
+    set_last_mined_block_transaction_count, set_last_mined_execution_cost_observed,
+};
 use crate::types::chainstate::BurnchainHeaderHash;
 use crate::types::chainstate::StacksBlockId;
 use crate::types::chainstate::TrieHash;
@@ -73,7 +76,6 @@ use clarity::vm::ast::ASTRules;
 use clarity::vm::clarity::TransactionConnection;
 use clarity::vm::errors::Error as InterpreterError;
 use clarity::vm::types::TypeSignature;
-use crate::monitoring::{set_last_mined_block_transaction_count, set_last_mined_execution_cost_observed};
 
 /// System status for mining.
 /// The miner can be Ready, in which case a miner is allowed to run

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -73,6 +73,7 @@ use clarity::vm::ast::ASTRules;
 use clarity::vm::clarity::TransactionConnection;
 use clarity::vm::errors::Error as InterpreterError;
 use clarity::vm::types::TypeSignature;
+use crate::monitoring::{set_last_mined_block_transaction_count, set_last_mined_execution_cost_observed};
 
 /// System status for mining.
 /// The miner can be Ready, in which case a miner is allowed to run
@@ -2646,6 +2647,9 @@ impl StacksBlockBuilder {
                 tx_events,
             );
         }
+
+        set_last_mined_block_transaction_count(block.txs.len() as u64);
+        set_last_mined_execution_cost_observed(&consumed, &block_limit);
 
         info!(
             "Miner: mined anchored block";

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -164,7 +164,6 @@ pub fn set_last_mined_block_transaction_count(transactions_in_block: u64) {
         .set(i64::try_from(transactions_in_block).unwrap_or_else(|_| i64::MAX));
 }
 
-
 pub fn increment_btc_ops_sent_counter() {
     #[cfg(feature = "monitoring_prom")]
     prometheus::BTC_OPS_SENT_COUNTER.inc();

--- a/src/monitoring/mod.rs
+++ b/src/monitoring/mod.rs
@@ -134,6 +134,37 @@ pub fn set_last_block_transaction_count(transactions_in_block: u64) {
         .set(i64::try_from(transactions_in_block).unwrap_or_else(|_| i64::MAX));
 }
 
+/// Log `execution_cost` as a ratio of `block_limit`.
+#[allow(unused_variables)]
+pub fn set_last_mined_execution_cost_observed(
+    execution_cost: &ExecutionCost,
+    block_limit: &ExecutionCost,
+) {
+    #[cfg(feature = "monitoring_prom")]
+    {
+        prometheus::LAST_MINED_BLOCK_READ_COUNT
+            .set(execution_cost.read_count as f64 / block_limit.read_count as f64);
+        prometheus::LAST_MINED_BLOCK_WRITE_COUNT
+            .set(execution_cost.write_count as f64 / block_limit.read_count as f64);
+        prometheus::LAST_MINED_BLOCK_READ_LENGTH
+            .set(execution_cost.read_length as f64 / block_limit.read_length as f64);
+        prometheus::LAST_MINED_BLOCK_WRITE_LENGTH
+            .set(execution_cost.write_length as f64 / block_limit.write_length as f64);
+        prometheus::LAST_MINED_BLOCK_RUNTIME
+            .set(execution_cost.runtime as f64 / block_limit.runtime as f64);
+    }
+}
+
+/// Log the number of transactions in the latest block.
+#[allow(unused_variables)]
+pub fn set_last_mined_block_transaction_count(transactions_in_block: u64) {
+    // Saturating cast from u64 to i64
+    #[cfg(feature = "monitoring_prom")]
+    prometheus::LAST_MINED_BLOCK_TRANSACTION_COUNT
+        .set(i64::try_from(transactions_in_block).unwrap_or_else(|_| i64::MAX));
+}
+
+
 pub fn increment_btc_ops_sent_counter() {
     #[cfg(feature = "monitoring_prom")]
     prometheus::BTC_OPS_SENT_COUNTER.inc();

--- a/src/monitoring/prometheus.rs
+++ b/src/monitoring/prometheus.rs
@@ -121,6 +121,37 @@ lazy_static! {
         "Number of transactions in the last block."
     )).unwrap();
 
+    pub static ref LAST_MINED_BLOCK_READ_COUNT: Gauge = register_gauge!(opts!(
+        "stacks_node_last_mined_block_read_count",
+        "`execution_cost_read_count` for the last mined block produced."
+    )).unwrap();
+
+    pub static ref LAST_MINED_BLOCK_WRITE_COUNT: Gauge = register_gauge!(opts!(
+        "stacks_node_last_mined_block_write_count",
+        "`execution_cost_write_count` for the last mined block produced."
+    )).unwrap();
+
+    pub static ref LAST_MINED_BLOCK_READ_LENGTH: Gauge = register_gauge!(opts!(
+        "stacks_node_last_mined_block_read_length",
+        "`execution_cost_read_length` for the last mined block produced."
+    )).unwrap();
+
+    pub static ref LAST_MINED_BLOCK_WRITE_LENGTH: Gauge = register_gauge!(opts!(
+        "stacks_node_last_mined_block_write_length",
+        "`execution_cost_write_length` for the last mined block produced."
+    )).unwrap();
+
+    pub static ref LAST_MINED_BLOCK_RUNTIME: Gauge = register_gauge!(opts!(
+        "stacks_node_last_mined_block_runtime",
+        "`execution_cost_runtime` for the last mined block produced."
+    )).unwrap();
+
+    pub static ref LAST_MINED_BLOCK_TRANSACTION_COUNT: IntGauge = register_int_gauge!(opts!(
+        "stacks_node_last_mined_block_transaction_count",
+        "Number of transactions in the last mined block."
+    )).unwrap();
+
+
     pub static ref ACTIVE_MINERS_COUNT_GAUGE: IntGauge = register_int_gauge!(opts!(
         "stacks_node_active_miners_total",
         "Total number of active miners"

--- a/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
+++ b/testnet/stacks-node/src/burnchains/bitcoin_regtest_controller.rs
@@ -1390,7 +1390,7 @@ impl BitcoinRegtestController {
         res
     }
 
-    fn get_miner_address(
+    pub(crate) fn get_miner_address(
         &self,
         epoch_id: StacksEpochId,
         public_key: &Secp256k1PublicKey,

--- a/testnet/stacks-node/src/keychain.rs
+++ b/testnet/stacks-node/src/keychain.rs
@@ -12,6 +12,7 @@ use super::operations::BurnchainOpSigner;
 use stacks_common::address::{
     C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
+use stacks_common::util::secp256k1::Secp256k1PublicKey;
 
 /// A wrapper around a node's seed, coupled with operations for using it
 #[derive(Clone)]
@@ -124,6 +125,11 @@ impl Keychain {
                "pubkey_hash" => %Hash160::from_node_public_key(&StacksPublicKey::from_private(&sk)).to_string()
         );
         sk
+    }
+
+    pub fn get_pub_key(&self) -> Secp256k1PublicKey {
+        let sk = self.get_secret_key();
+        StacksPublicKey::from_private(&sk)
     }
 
     /// Get the Stacks address for the inner secret state

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -149,7 +149,9 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc, Mutex};
 use std::time::Duration;
 use std::{thread, thread::JoinHandle};
 
-use stacks::burnchains::{db::BurnchainHeaderReader, Burnchain, BurnchainParameters, Txid, BurnchainSigner};
+use stacks::burnchains::{
+    db::BurnchainHeaderReader, Burnchain, BurnchainParameters, BurnchainSigner, Txid,
+};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::{
     leader_block_commit::{RewardSetInfo, BURN_BLOCK_MINED_AT_MODULUS},
@@ -205,8 +207,8 @@ use stacks::util::vrf::VRFPublicKey;
 use stacks::util_lib::strings::{UrlString, VecDisplay};
 use stacks::vm::costs::ExecutionCost;
 
-use crate::burnchains::bitcoin_regtest_controller::{addr2str, BitcoinRegtestController};
 use crate::burnchains::bitcoin_regtest_controller::OngoingBlockCommit;
+use crate::burnchains::bitcoin_regtest_controller::{addr2str, BitcoinRegtestController};
 use crate::burnchains::make_bitcoin_indexer;
 use crate::run_loop::neon::Counters;
 use crate::run_loop::neon::RunLoop;
@@ -4176,14 +4178,14 @@ impl StacksNode {
         let relayer_thread = RelayerThread::new(runloop, local_peer.clone(), relayer);
 
         let public_key = keychain.get_pub_key();
-        let miner_addr = relayer_thread.bitcoin_controller.get_miner_address(StacksEpochId::Epoch21, &public_key);
+        let miner_addr = relayer_thread
+            .bitcoin_controller
+            .get_miner_address(StacksEpochId::Epoch21, &public_key);
         let miner_addr_str = addr2str(&miner_addr);
-        match monitoring::set_burnchain_signer(BurnchainSigner(miner_addr_str)) {
-            Err(e) => {
-                warn!("Failed to set global burnchain signer: {:?}", &e);
-            }
-            _ => {}
-        }
+        let _ = monitoring::set_burnchain_signer(BurnchainSigner(miner_addr_str)).map_err(|e| {
+            warn!("Failed to set global burnchain signer: {:?}", &e);
+            e
+        });
 
         let relayer_thread_handle = thread::Builder::new()
             .name(format!("relayer-{}", &local_peer.data_url))

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -4131,9 +4131,16 @@ impl StacksNode {
     }
 
     /// This function sets the global var `GLOBAL_BURNCHAIN_SIGNER`.
-    /// This variable is used for prometheus monitoring (which only runs when the feature flag
-    /// `monitoring_prom` is activated
-    pub fn set_monitoring_miner_address(keychain: &Keychain, relayer_thread: &RelayerThread) {
+    ///
+    /// This variable is used for prometheus monitoring (which only
+    /// runs when the feature flag `monitoring_prom` is activated).
+    /// The address is set using the single-signature BTC address
+    /// associated with `keychain`'s public key. This address always
+    /// assumes Epoch-2.1 rules for the miner address: if the
+    /// node is configured for segwit, then the miner address generated
+    /// is a segwit address, otherwise it is a p2pkh.
+    ///
+    fn set_monitoring_miner_address(keychain: &Keychain, relayer_thread: &RelayerThread) {
         let public_key = keychain.get_pub_key();
         let miner_addr = relayer_thread
             .bitcoin_controller


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Adds prom metrics for last mined block. 

This PR also includes a fix to a bug introduced in Epoch 2.1, related to segwit addresses. Essentially, there was a mismatch between the representation of the miner address stored for prometheus and the representation of the miner address within the decoded LeaderBlockCommitOp. 
To fix this, it was necessary to update the representation of the miner address within the prometheus related code. 

### Applicable issues
- fixes #3263 
