### PR TITLE
Clean unused imports

### DIFF
--- a/clarity/src/vm/costs/mod.rs
+++ b/clarity/src/vm/costs/mod.rs
@@ -18,9 +18,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 use std::{cmp, fmt};
 
-use regex::internal::Exec;
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use serde::{Deserialize, Serialize};
+use stacks_common::types::StacksEpochId;
 
 use crate::boot_util::boot_code_id;
 use crate::vm::ast::ContractAST;
@@ -36,7 +36,6 @@ use crate::vm::types::{
     TypeSignature, NONE,
 };
 use crate::vm::{ast, eval_all, ClarityName, SymbolicExpression, Value};
-use stacks_common::types::StacksEpochId;
 
 pub mod constants;
 pub mod cost_functions;


### PR DESCRIPTION
### Description

```
use regex::internal::Exec;
```
causes an error with newer versions of the `regex` crate, and it is not
used anyway, so remove it.

Also re-format using the recommended:
```
rustfmt clarity/src/vm/costs/mod.rs --config group_imports=StdExternalCrate
```