### PR TITLE
docs: use `rustfmt` instead of `cargo fmt` in pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ you push your code. Follow these instruction to set it up:
 #!/bin/sh
 HAS_ISSUES=0
 for file in $(git diff --name-only --staged); do
-    FMT_RESULT="$(cargo fmt -- $file --check --config group_imports=StdExternalCrate 2>/dev/null || true)"
+    FMT_RESULT="$(rustfmt $file --check --config group_imports=StdExternalCrate 2>/dev/null || true)"
     if [ "$FMT_RESULT" != "" ]; then
         HAS_ISSUES=1
     fi


### PR DESCRIPTION
The `cargo fmt` command recommended to include in the `pre-commit` hook will run on all files, instead of just the changed files as intended. This change uses `rustfmt` to just run on one file at a time as intended.