### PR TITLE
ci: use nextest for unit tests, disable grcov collation and codecov o…

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -27,6 +27,20 @@ jobs:
       - name: Checkout the latest code
         id: git_checkout
         uses: actions/checkout@v3
+
+      - name: Reclaim disk space
+        id: cleanup
+        run: |
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^mongodb-.*'
+          sudo apt-get remove -y '^mysql-.*'
+          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          docker system prune --force
+
       - name: Build bitcoin integration testing image
         id: build_docker_image
         env:
@@ -35,15 +49,17 @@ jobs:
         run: |
           rm .dockerignore
           docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.generic.bitcoin-tests -t stacks-blockchain:integrations .
+
       - name: Export docker image as tarball
         id: export_docker_image
-        run: docker save -o integration-image.tar stacks-blockchain:integrations
+        run: docker save stacks-blockchain:integrations | gzip > integration-image.tar.gz
+
       - name: Upload built docker image
         id: upload_docker_image
         uses: actions/upload-artifact@v3
         with:
-          name: integration-image.tar
-          path: integration-image.tar
+          name: integration-image.tar.gz
+          path: integration-image.tar.gz
 
   # Run integration tests using sampled genesis block
   sampled-genesis:
@@ -130,10 +146,10 @@ jobs:
         id: download_docker_image
         uses: actions/download-artifact@v3
         with:
-          name: integration-image.tar
+          name: integration-image.tar.gz
       - name: Load docker image
         id: load_docker_image
-        run: docker load -i integration-image.tar && rm integration-image.tar
+        run: docker load -i integration-image.tar.gz && rm integration-image.tar.gz
       - name: All integration tests with sampled genesis
         id: bitcoin_integration_tests
         timeout-minutes: 30
@@ -169,10 +185,10 @@ jobs:
         id: download_docker_image
         uses: actions/download-artifact@v3
         with:
-          name: integration-image.tar
+          name: integration-image.tar.gz
       - name: Load docker image
         id: load_docker_image
-        run: docker load -i integration-image.tar && rm integration-image.tar
+        run: docker load -i integration-image.tar.gz && rm integration-image.tar.gz
       - name: Atlas integration tests
         id: atlas_integration_tests
         timeout-minutes: 40

--- a/.github/workflows/stacks-blockchain-tests.yml
+++ b/.github/workflows/stacks-blockchain-tests.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           rustup component add llvm-tools-preview
           cargo install grcov
+      - name: Add nextest
+        run: |
+          cargo install cargo-nextest
       - name: Checkout the latest code
         id: git_checkout
         uses: actions/checkout@v3
@@ -53,9 +56,23 @@ jobs:
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: stacks-blockchain-%p-%m.profraw
         run: |
-          cargo test --workspace
+          cargo nextest run --workspace
+      - name: Collate grcov
+        # grcov doesn't work with cargo nextest currently, getting
+        #  that to work again will have to happen separately. Getting unit
+        #  test run times below 2 hours is more important for now.
+        if: ${{ false }}
+        id: unit_tests_grcov
+        env:
+          RUSTFLAGS: -Cinstrument-coverage
+          LLVM_PROFILE_FILE: stacks-blockchain-%p-%m.profraw
+        run: |
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
       - name: Upload codecov results
+        # grcov doesn't work with cargo nextest currently, getting
+        #  that to work again will have to happen separately. Getting unit
+        #  test run times below 2 hours is more important for now.
+        if: ${{ false }}
         uses: codecov/codecov-action@v3
         id: codedov
         with:

--- a/.github/workflows/stacks-blockchain-tests.yml
+++ b/.github/workflows/stacks-blockchain-tests.yml
@@ -52,9 +52,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Run units tests (with coverage)
         id: unit_tests_codecov
-        env:
-          RUSTFLAGS: -Cinstrument-coverage
-          LLVM_PROFILE_FILE: stacks-blockchain-%p-%m.profraw
+        # unset the coverage instrumentation flags.
+        # these slow tests down a lot locally (5-10x), and since
+        # grcov cannot collect this coverage data right now anyways,
+        # this is a speed win.
+        #env:
+        #  RUSTFLAGS: -Cinstrument-coverage
+        #  LLVM_PROFILE_FILE: stacks-blockchain-%p-%m.profraw
         run: |
           cargo nextest run --workspace
       - name: Collate grcov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,19 +2814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if 1.0.0",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
### Description

Units tests are currently taking ~5 hours to run. This PR alters the execution of the unit tests CI task to use `cargo nextest` instead of `cargo test`. This should speed things up pretty significantly (from 5 hours down to 1.5). I can't get grcov to work quite right with this yet, but since pretty much all PRs are stalled due to the unit test run time, getting this change out seems important enough to disable unit test coverage for now.

### Applicable issues
- #3808 

