### PR TITLE
Add txid to contract deploy logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the versioning scheme outlined in the [README.md](README.md).
 
+## [2.4.0.0.1]
+
+This is a minor change to add `txid` fields into the log messages from failing
+contract deploys. This will help tools (and users) more easily find the log
+messages to determine what went wrong.
+
 ## [2.4.0.0.0]
 This is a **consensus-breaking** release to revert consensus to PoX, and is the second fork proposed in SIP-022.
 

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -1133,6 +1133,7 @@ impl StacksChainState {
                                 warn!(
                                     "Runtime error in contract analysis for {}: {:?}",
                                     &contract_id, &other_error;
+                                    "txid" => %tx.txid(),
                                     "AST rules" => %format!("{:?}", &ast_rules)
                                 );
                                 let receipt = StacksTransactionReceipt::from_analysis_failure(
@@ -1187,6 +1188,7 @@ impl StacksChainState {
                     Err(e) => match handle_clarity_runtime_error(e) {
                         ClarityRuntimeTxError::Acceptable { error, err_type } => {
                             info!("Smart-contract processed with {}", err_type;
+                                      "txid" => %tx.txid(),
                                       "contract" => %contract_id,
                                       "code" => %contract_code_str,
                                       "error" => ?error);
@@ -1215,6 +1217,7 @@ impl StacksChainState {
                                 // in 2.1 and later, this is a permitted runtime error.  take the
                                 // fee from the payer and keep the tx.
                                 warn!("Smart-contract encountered an analysis error at runtime";
+                                      "txid" => %tx.txid(),
                                       "contract" => %contract_id,
                                       "code" => %contract_code_str,
                                       "error" => %check_error);
@@ -1230,6 +1233,7 @@ impl StacksChainState {
                             } else {
                                 // prior to 2.1, this is not permitted in a block.
                                 warn!("Unexpected analysis error invalidating transaction: if included, this will invalidate a block";
+                                      "txid" => %tx.txid(),
                                       "contract" => %contract_id,
                                       "code" => %contract_code_str,
                                       "error" => %check_error);
@@ -1240,6 +1244,7 @@ impl StacksChainState {
                         }
                         ClarityRuntimeTxError::Rejectable(e) => {
                             error!("Unexpected error invalidating transaction: if included, this will invalidate a block";
+                                       "txid" => %tx.txid(),
                                        "contract_name" => %contract_id,
                                        "code" => %contract_code_str,
                                        "error" => ?e);


### PR DESCRIPTION
### Description

Add `txid` to logs for errors during a contract deploy transaction. The transaction id is not currently included in these logs, and it makes finding the errors more difficult.

### Applicable issues
- none

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
