### PR TITLE
Chore: add profile definitions back into top-level workspace definiton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,14 @@ members = [
     "clarity",
     "stx-genesis",
     "testnet/stacks-node"]
+
+# Use a bit more than default optimization for
+#  dev builds to speed up test execution
+[profile.dev]
+opt-level = 1
+
+# Use release-level optimization for dependencies
+# This slows down "first" builds on development environments,
+#  but won't impact subsequent builds.
+[profile.dev.package."*"]
+opt-level = 3


### PR DESCRIPTION
Unit test run times more than doubled after merging #3814, this corrects that by putting the prior profile definitions back into the workspace Cargo.toml.