### PR TITLE
Feat/stackerdb config

### DIFF
--- a/stackslib/src/chainstate/stacks/db/mod.rs
+++ b/stackslib/src/chainstate/stacks/db/mod.rs
@@ -1827,6 +1827,24 @@ impl StacksChainState {
         result.unwrap()
     }
 
+    /// Checked eval-read-only
+    pub fn eval_read_only(
+        &mut self,
+        burn_dbconn: &dyn BurnStateDB,
+        parent_id_bhh: &StacksBlockId,
+        contract: &QualifiedContractIdentifier,
+        code: &str,
+    ) -> Result<Value, clarity_error> {
+        self.clarity_state.eval_read_only(
+            parent_id_bhh,
+            &HeadersDBConn(self.state_index.sqlite_conn()),
+            burn_dbconn,
+            contract,
+            code,
+            ASTRules::PrecheckSize,
+        )
+    }
+
     pub fn db(&self) -> &DBConn {
         self.state_index.sqlite_conn()
     }

--- a/stackslib/src/net/codec.rs
+++ b/stackslib/src/net/codec.rs
@@ -37,6 +37,7 @@ use crate::chainstate::stacks::StacksTransaction;
 use crate::chainstate::stacks::MAX_BLOCK_LEN;
 use crate::core::PEER_VERSION_TESTNET;
 use crate::net::db::LocalPeer;
+use crate::net::stackerdb::STACKERDB_MAX_CHUNK_SIZE;
 use crate::net::Error as net_error;
 use crate::net::*;
 use stacks_common::codec::{read_next_at_most, read_next_exact, MAX_MESSAGE_LEN};
@@ -885,7 +886,7 @@ impl StacksMessageCodec for StackerDBChunkData {
         let slot_id: u32 = read_next(fd)?;
         let slot_version: u32 = read_next(fd)?;
         let sig: MessageSignature = read_next(fd)?;
-        let data: Vec<u8> = read_next(fd)?;
+        let data: Vec<u8> = read_next_at_most(fd, STACKERDB_MAX_CHUNK_SIZE.into())?;
         Ok(StackerDBChunkData {
             slot_id,
             slot_version,

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -277,6 +277,8 @@ pub enum Error {
     InvalidStackerDBContract(ContractId),
     /// state machine step took too long
     StepTimeout,
+    /// stacker DB chunk is too big
+    StackerDBChunkTooBig(usize),
 }
 
 impl From<codec_error> for Error {
@@ -407,6 +409,9 @@ impl fmt::Display for Error {
                 )
             }
             Error::StepTimeout => write!(f, "State-machine step took too long"),
+            Error::StackerDBChunkTooBig(ref sz) => {
+                write!(f, "StackerDB chunk size is too big ({})", sz)
+            }
         }
     }
 }
@@ -477,6 +482,7 @@ impl error::Error for Error {
             Error::TooFrequentSlotWrites(..) => None,
             Error::InvalidStackerDBContract(..) => None,
             Error::StepTimeout => None,
+            Error::StackerDBChunkTooBig(..) => None,
         }
     }
 }

--- a/stackslib/src/net/mod.rs
+++ b/stackslib/src/net/mod.rs
@@ -273,6 +273,8 @@ pub enum Error {
     TooManySlotWrites(u32, u32),
     /// too frequent writes to a slot
     TooFrequentSlotWrites(u64),
+    /// Invalid control smart contract for a Stacker DB
+    InvalidStackerDBContract(ContractId),
     /// state machine step took too long
     StepTimeout,
 }
@@ -397,6 +399,13 @@ impl fmt::Display for Error {
             Error::TooFrequentSlotWrites(ref deadline) => {
                 write!(f, "Too frequent slot writes (deadline={})", deadline)
             }
+            Error::InvalidStackerDBContract(ref contract_id) => {
+                write!(
+                    f,
+                    "Invalid StackerDB control smart contract {}",
+                    contract_id
+                )
+            }
             Error::StepTimeout => write!(f, "State-machine step took too long"),
         }
     }
@@ -466,6 +475,7 @@ impl error::Error for Error {
             Error::BadSlotSigner(..) => None,
             Error::TooManySlotWrites(..) => None,
             Error::TooFrequentSlotWrites(..) => None,
+            Error::InvalidStackerDBContract(..) => None,
             Error::StepTimeout => None,
         }
     }
@@ -512,6 +522,12 @@ impl From<rusqlite::Error> for Error {
 impl From<burnchain_error> for Error {
     fn from(e: burnchain_error) -> Self {
         Error::BurnchainError(e)
+    }
+}
+
+impl From<clarity_error> for Error {
+    fn from(e: clarity_error) -> Self {
+        Error::ClarityError(e)
     }
 }
 
@@ -2918,7 +2934,7 @@ pub mod test {
                 .map(|neighbor| NeighborAddress::from_neighbor(&neighbor))
                 .collect();
 
-                db_config.hint_peers = initial_peers;
+                db_config.hint_replicas = initial_peers;
                 let stacker_dbs = StackerDBs::connect(&stackerdb_path, true).unwrap();
                 let stacker_db_sync = StackerDBSync::new(
                     contract_id.clone(),

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -1,0 +1,449 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/// This file implements the interface to the StackerDB smart contract for loading the DB's config.
+/// The smart contract must conform to this trait:
+///
+/// ;; Any StackerDB smart contract must conform to this trait.
+/// (define-trait stackerdb-trait
+///
+///     ;; Get the list of (signer, num-slots) that make up this DB
+///     (define-public (stackerdb-get-signer-slots) (response (list 4096 { signer: principal, num-slots: uint }) uint))
+///
+///     ;; Get the control metadata for this DB
+///     (define-public (stackerdb-get-config)
+///         (response {
+///             chunk-size: uint,
+///             write-freq: uint,
+///             max-writes: uint,
+///             max-neighbors: uint,
+///             hint-replicas: (list 128 { addr: (list 16 uint), port: uint, public-key-hash: (buff 20) })
+///         },
+///         uint))
+/// )
+use std::collections::{HashMap, HashSet};
+use std::mem;
+
+use crate::net::stackerdb::{StackerDBConfig, StackerDBs, STACKERDB_INV_MAX};
+
+use crate::net::ContractId;
+use crate::net::Error as net_error;
+use crate::net::NeighborAddress;
+use crate::net::PeerAddress;
+
+use crate::chainstate::burn::db::sortdb::SortitionDB;
+use crate::chainstate::stacks::db::StacksChainState;
+use crate::chainstate::stacks::Error as chainstate_error;
+
+use crate::clarity_vm::clarity::{ClarityReadOnlyConnection, Error as clarity_error};
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::clarity::ClarityConnection;
+use clarity::vm::database::BurnStateDB;
+use clarity::vm::types::StandardPrincipalData;
+use clarity::vm::types::{
+    BufferLength, FixedFunction, FunctionType, ListTypeData, PrincipalData, SequenceSubtype,
+    TupleTypeSignature, TypeSignature,
+};
+use clarity::vm::ClarityName;
+
+use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
+use stacks_common::types::StacksEpochId;
+use stacks_common::util::hash::Hash160;
+
+const MAX_HINT_REPLICAS: u32 = 128;
+
+lazy_static! {
+    pub static ref REQUIRED_FUNCTIONS: [(ClarityName, TypeSignature); 2] = [
+        (
+            "stackerdb-get-signer-slots".into(),
+            TypeSignature::new_response(
+                ListTypeData::new_list(
+                    TupleTypeSignature::try_from(vec![
+                        ("signer".into(), TypeSignature::PrincipalType),
+                        ("num-slots".into(), TypeSignature::UIntType)
+                    ])
+                    .expect("FATAL: failed to construct signer list type")
+                    .into(),
+                    MAX_HINT_REPLICAS
+                )
+                .expect("FATAL: could not construct signer list type")
+                .into(),
+                TypeSignature::UIntType
+            ).expect("FATAL: failed to construct response with signer slots"),
+        ),
+        (
+            "stackerdb-get-config".into(),
+            TypeSignature::new_response(
+                TypeSignature::TupleType(
+                    TupleTypeSignature::try_from(vec![
+                        ("chunk-size".into(), TypeSignature::UIntType),
+                        ("write-freq".into(), TypeSignature::UIntType),
+                        ("max-writes".into(), TypeSignature::UIntType),
+                        ("max-neighbors".into(), TypeSignature::UIntType),
+                        ("hint-replicas".into(), ListTypeData::new_list(
+                            TypeSignature::TupleType(
+                                TupleTypeSignature::try_from(vec![
+                                    ("addr".into(), ListTypeData::new_list(TypeSignature::UIntType, 16)
+                                        .expect("FATAL: invalid IP address list")
+                                        .into()),
+                                    ("port".into(), TypeSignature::UIntType),
+                                    ("public-key-hash".into(),
+                                        // can't use BUFF_20 here because it's also in a
+                                        // lazy_static! block
+                                        TypeSignature::SequenceType(SequenceSubtype::BufferType(BufferLength::try_from(20u32).expect("FATAL: could not create (buff 20)"))))
+                                ])
+                                .expect("FATAL: unable to construct hint-replicas type")
+                                .into()),
+                            MAX_HINT_REPLICAS)
+                            .expect("FATAL: failed to construct hint-replicas list type")
+                            .into())
+                    ]).expect("FATAL: unable to construct config type")).into(),
+                TypeSignature::UIntType
+            ).expect("FATAL: unable to construct config response type")
+        )
+    ];
+}
+
+impl StackerDBConfig {
+    /// Check that a smart contract is consistent with being a StackerDB controller
+    fn is_contract_valid(epoch: &StacksEpochId, analysis: ContractAnalysis) -> bool {
+        for (name, func_return_type) in REQUIRED_FUNCTIONS.iter() {
+            let func = if let Some(f) = analysis.read_only_function_types.get(name) {
+                f
+            } else if let Some(f) = analysis.public_function_types.get(name) {
+                f
+            } else {
+                test_debug!("Contract is missing function '{}'", name);
+                return false;
+            };
+
+            match func {
+                FunctionType::Fixed(FixedFunction { args, returns }) => {
+                    if args.len() != 0 {
+                        return false;
+                    }
+                    if !func_return_type
+                        .admits_type(epoch, &returns)
+                        .unwrap_or(false)
+                    {
+                        test_debug!("Contract function '{}' has an invalid return type: expected {:?}, got {:?}", name, func_return_type, returns);
+                        return false;
+                    }
+                }
+                _ => {
+                    test_debug!("Contract function '{}' is not a fixed function", name);
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Evaluate the contract to get its signer slots
+    fn eval_signer_slots(
+        chainstate: &mut StacksChainState,
+        burn_dbconn: &dyn BurnStateDB,
+        contract_id: &ContractId,
+        tip: &StacksBlockId,
+    ) -> Result<Vec<(StacksAddress, u64)>, net_error> {
+        let value = chainstate.eval_read_only(
+            burn_dbconn,
+            tip,
+            contract_id,
+            "(stackerdb-get-signer-slots)",
+        )?;
+
+        let result = value.expect_result();
+        let slot_list = match result {
+            Err(err_val) => {
+                let err_code = err_val.expect_u128();
+                debug!(
+                    "Contract {} failed to run `stackerdb-get-signer-slots`: error u{}",
+                    contract_id, &err_code
+                );
+                return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+            }
+            Ok(ok_val) => ok_val.expect_list(),
+        };
+
+        let mut total_num_slots = 0u64;
+        let mut ret = vec![];
+        for slot_value in slot_list.into_iter() {
+            let slot_data = slot_value.expect_tuple();
+            let signer_principal = slot_data
+                .get("signer")
+                .expect("FATAL: no 'signer'")
+                .clone()
+                .expect_principal();
+            let num_slots_uint = slot_data
+                .get("num-slots")
+                .expect("FATAL: no 'num-slots'")
+                .clone()
+                .expect_u128();
+
+            if num_slots_uint > (STACKERDB_INV_MAX as u128) {
+                debug!(
+                    "Contract {} stipulated more than maximum number of slots for one signer ({})",
+                    contract_id, STACKERDB_INV_MAX
+                );
+                return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+            }
+            let num_slots = num_slots_uint as u64;
+            total_num_slots = total_num_slots.saturating_add(num_slots);
+
+            if total_num_slots > STACKERDB_INV_MAX.into() {
+                debug!(
+                    "Contract {} stipulated more than the maximum number of slots",
+                    contract_id
+                );
+                return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+            }
+
+            // standard principals only
+            let addr = match signer_principal {
+                PrincipalData::Contract(..) => {
+                    debug!("Contract {} stipulated a contract principal as a writer, which is not supported", contract_id);
+                    return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+                }
+                PrincipalData::Standard(StandardPrincipalData(version, bytes)) => StacksAddress {
+                    version,
+                    bytes: Hash160(bytes),
+                },
+            };
+
+            ret.push((addr, num_slots));
+        }
+        Ok(ret)
+    }
+
+    /// Evaluate the contract to get its config
+    fn eval_config(
+        chainstate: &mut StacksChainState,
+        burn_dbconn: &dyn BurnStateDB,
+        contract_id: &ContractId,
+        tip: &StacksBlockId,
+        signers: Vec<(StacksAddress, u64)>,
+    ) -> Result<StackerDBConfig, net_error> {
+        let value =
+            chainstate.eval_read_only(burn_dbconn, tip, contract_id, "(stackerdb-get-config)")?;
+
+        let result = value.expect_result();
+        let config_tuple = match result {
+            Err(err_val) => {
+                let err_code = err_val.expect_u128();
+                debug!(
+                    "Contract {} failed to run `stackerdb-get-config`: err u{}",
+                    contract_id, &err_code
+                );
+                return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+            }
+            Ok(ok_val) => ok_val.expect_tuple(),
+        };
+
+        let chunk_size = config_tuple
+            .get("chunk-size")
+            .expect("FATAL: missing 'chunk-size'")
+            .clone()
+            .expect_u128();
+        if chunk_size > u64::MAX as u128 {
+            debug!(
+                "Contract {} stipulates a chunk size beyond u64::MAX",
+                contract_id
+            );
+            return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+        }
+
+        let write_freq = config_tuple
+            .get("write-freq")
+            .expect("FATAL: missing 'write-freq'")
+            .clone()
+            .expect_u128();
+        if write_freq > u64::MAX as u128 {
+            debug!(
+                "Contract {} stipulates a write frequency beyond u64::MAX",
+                contract_id
+            );
+            return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+        }
+
+        let max_writes = config_tuple
+            .get("max-writes")
+            .expect("FATAL: missing 'max-writes'")
+            .clone()
+            .expect_u128();
+        if max_writes > u32::MAX as u128 {
+            debug!(
+                "Contract {} stipulates a max-write bound beyond u32::MAX",
+                contract_id
+            );
+            return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+        }
+
+        let max_neighbors = config_tuple
+            .get("max-neighbors")
+            .expect("FATAL: missing 'max-neighbors'")
+            .clone()
+            .expect_u128();
+        if max_neighbors > usize::MAX as u128 {
+            debug!(
+                "Contract {} stipulates a maximum number of neighbors beyond usize::MAX",
+                contract_id
+            );
+            return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+        }
+
+        let hint_replicas_list = config_tuple
+            .get("hint-replicas")
+            .expect("FATAL: missing 'hint-replicas'")
+            .clone()
+            .expect_list();
+        let mut hint_replicas = vec![];
+        for hint_replica_value in hint_replicas_list.into_iter() {
+            let hint_replica_data = hint_replica_value.expect_tuple();
+
+            let addr_byte_list = hint_replica_data
+                .get("addr")
+                .expect("FATAL: missing 'addr'")
+                .clone()
+                .expect_list();
+            let port = hint_replica_data
+                .get("port")
+                .expect("FATAL: missing 'port'")
+                .clone()
+                .expect_u128();
+            let pubkey_hash_bytes = hint_replica_data
+                .get("public-key-hash")
+                .expect("FATAL: missing 'public-key-hash")
+                .clone()
+                .expect_buff_padded(20, 0);
+
+            let mut addr_bytes = vec![];
+            for byte_val in addr_byte_list.into_iter() {
+                let byte = byte_val.expect_u128();
+                if byte > (u8::MAX as u128) {
+                    debug!(
+                        "Contract {} stipulates an addr byte above u8::MAX",
+                        contract_id
+                    );
+                    return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+                }
+                addr_bytes.push(byte as u8);
+            }
+            if addr_bytes.len() != 16 {
+                debug!(
+                    "Contract {} did not stipulate a full 16-octet IP address",
+                    contract_id
+                );
+                return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+            }
+
+            if port < 1024 || port > ((u16::MAX - 1) as u128) {
+                debug!(
+                    "Contract {} stipulates a port lower than 1024 or above u16::MAX - 1",
+                    contract_id
+                );
+                return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+            }
+
+            let mut pubkey_hash_slice = [0u8; 20];
+            pubkey_hash_slice.copy_from_slice(&pubkey_hash_bytes[0..20]);
+
+            let peer_addr = PeerAddress::from_slice(&addr_bytes).expect("FATAL: not 16 bytes");
+            let naddr = NeighborAddress {
+                addrbytes: peer_addr,
+                port: port as u16,
+                public_key_hash: Hash160(pubkey_hash_slice),
+            };
+            hint_replicas.push(naddr);
+        }
+
+        Ok(StackerDBConfig {
+            chunk_size: chunk_size as u64,
+            signers,
+            write_freq: write_freq as u64,
+            max_writes: max_writes as u32,
+            hint_replicas,
+            max_neighbors: max_neighbors as usize,
+        })
+    }
+
+    /// Load up the DB config from the controlling smart contract as of the current Stacks chain
+    /// tip
+    pub fn from_smart_contract(
+        chainstate: &mut StacksChainState,
+        sortition_db: &SortitionDB,
+        contract_id: &ContractId,
+    ) -> Result<StackerDBConfig, net_error> {
+        let chain_tip = chainstate
+            .get_stacks_chain_tip(sortition_db)?
+            .ok_or(net_error::NoSuchStackerDB(contract_id.clone()))?;
+
+        let burn_tip = SortitionDB::get_block_snapshot_consensus(
+            sortition_db.conn(),
+            &chain_tip.consensus_hash,
+        )?
+        .expect("FATAL: missing snapshot for Stacks block");
+
+        let chain_tip_hash =
+            StacksBlockId::new(&chain_tip.consensus_hash, &chain_tip.anchored_block_hash);
+        let cur_epoch = SortitionDB::get_stacks_epoch(sortition_db.conn(), burn_tip.block_height)?
+            .expect("FATAL: no epoch defined");
+
+        let dbconn = sortition_db.index_conn();
+
+        // check the target contract
+        let res =
+            chainstate.maybe_read_only_clarity_tx(&dbconn, &chain_tip_hash, |clarity_tx| {
+                // determine if this contract exists and conforms to this trait
+                clarity_tx.with_clarity_db_readonly(|db| {
+                    // contract must exist or this errors out
+                    let analysis = db
+                        .load_contract_analysis(contract_id)
+                        .ok_or(net_error::NoSuchStackerDB(contract_id.clone()))?;
+
+                    // contract must be consistent with StackerDB control interface
+                    if !Self::is_contract_valid(&cur_epoch.epoch_id, analysis) {
+                        debug!(
+                            "Contract {} does not conform to StackerDB trait",
+                            contract_id
+                        );
+                        return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+                    }
+
+                    Ok(())
+                })
+            })?;
+
+        if res.is_none() {
+            info!(
+                "Could not evaluate contract {} at {}",
+                contract_id, &chain_tip_hash
+            );
+            return Err(net_error::InvalidStackerDBContract(contract_id.clone()));
+        } else if let Some(Err(e)) = res {
+            info!(
+                "Could not use contract {} for StackerDB: {:?}",
+                contract_id, &e
+            );
+            return Err(e);
+        }
+
+        // evaluate the contract for these two functions
+        let signers = Self::eval_signer_slots(chainstate, &dbconn, contract_id, &chain_tip_hash)?;
+        let config = Self::eval_config(chainstate, &dbconn, contract_id, &chain_tip_hash, signers)?;
+        Ok(config)
+    }
+}

--- a/stackslib/src/net/stackerdb/config.rs
+++ b/stackslib/src/net/stackerdb/config.rs
@@ -37,7 +37,9 @@
 use std::collections::{HashMap, HashSet};
 use std::mem;
 
-use crate::net::stackerdb::{StackerDBConfig, StackerDBs, STACKERDB_INV_MAX};
+use crate::net::stackerdb::{
+    StackerDBConfig, StackerDBs, STACKERDB_INV_MAX, STACKERDB_MAX_CHUNK_SIZE,
+};
 
 use crate::net::ContractId;
 use crate::net::Error as net_error;
@@ -258,9 +260,9 @@ impl StackerDBConfig {
             .expect("FATAL: missing 'chunk-size'")
             .clone()
             .expect_u128();
-        if chunk_size > u64::MAX as u128 {
+        if chunk_size > STACKERDB_MAX_CHUNK_SIZE as u128 {
             debug!(
-                "Contract {} stipulates a chunk size beyond u64::MAX",
+                "Contract {} stipulates a chunk size beyond STACKERDB_MAX_CHUNK_SIZE",
                 contract_id
             );
             return Err(net_error::InvalidStackerDBContract(contract_id.clone()));

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -24,6 +24,7 @@ use std::path::Path;
 use crate::chainstate::stacks::address::PoxAddress;
 use crate::net::stackerdb::{
     SlotMetadata, StackerDBConfig, StackerDBTx, StackerDBs, STACKERDB_INV_MAX,
+    STACKERDB_MAX_CHUNK_SIZE,
 };
 use crate::net::Error as net_error;
 use crate::net::{ContractId, StackerDBChunkData, StackerDBHandshakeData};
@@ -379,6 +380,10 @@ impl<'a> StackerDBTx<'a> {
         slot_desc: &SlotMetadata,
         chunk: &[u8],
     ) -> Result<(), net_error> {
+        if chunk.len() > STACKERDB_MAX_CHUNK_SIZE as usize {
+            return Err(net_error::StackerDBChunkTooBig(chunk.len()));
+        }
+
         let slot_validation = self
             .get_slot_validation(smart_contract, slot_desc.slot_id)?
             .ok_or(net_error::NoSuchSlot(

--- a/stackslib/src/net/stackerdb/db.rs
+++ b/stackslib/src/net/stackerdb/db.rs
@@ -228,7 +228,7 @@ impl<'a> StackerDBTx<'a> {
     pub fn create_stackerdb(
         &self,
         smart_contract: &ContractId,
-        slots: &[(StacksAddress, u64)],
+        slots: &[(StacksAddress, u32)],
     ) -> Result<(), net_error> {
         if slots.len() > (STACKERDB_INV_MAX as usize) {
             return Err(net_error::ArrayTooLong);
@@ -289,19 +289,26 @@ impl<'a> StackerDBTx<'a> {
     pub fn reconfigure_stackerdb(
         &self,
         smart_contract: &ContractId,
-        slots: &[(StacksAddress, u64)],
+        slots: &[(StacksAddress, u32)],
     ) -> Result<(), net_error> {
         let stackerdb_id = self.get_stackerdb_id(smart_contract)?;
-        let mut slot_id = 0u32;
+        let mut total_slots_read = 0u32;
         for (principal, slot_count) in slots.iter() {
-            for _ in 0..*slot_count {
+            total_slots_read =
+                total_slots_read
+                    .checked_add(*slot_count)
+                    .ok_or(net_error::OverflowError(
+                        "Slot count exceeeds u32::MAX".to_string(),
+                    ))?;
+            let slots_before_principal = total_slots_read - slot_count;
+            for cur_principal_slot in 0..*slot_count {
+                let slot_id = slots_before_principal + cur_principal_slot;
                 if let Some(existing_validation) =
                     self.get_slot_validation(smart_contract, slot_id)?
                 {
                     // this slot already exists.
                     if existing_validation.signer == *principal {
                         // no change
-                        slot_id += 1;
                         continue;
                     }
                 }
@@ -321,7 +328,6 @@ impl<'a> StackerDBTx<'a> {
                 ];
 
                 stmt.execute(args)?;
-                slot_id += 1;
             }
         }
         Ok(())

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -115,6 +115,7 @@
 pub mod tests;
 
 pub mod bits;
+pub mod config;
 pub mod db;
 pub mod sync;
 
@@ -143,6 +144,7 @@ use crate::net::neighbors::NeighborComms;
 
 use crate::net::p2p::PeerNetwork;
 
+use stacks_common::types::chainstate::StacksAddress;
 use stacks_common::util::get_epoch_time_secs;
 
 /// maximum chunk inventory size
@@ -167,16 +169,16 @@ pub struct StackerDBSyncResult {
 pub struct StackerDBConfig {
     /// maximum chunk size
     pub chunk_size: u64,
-    /// number of chunks in this DB.  Cannot be bigger than STACERDB_INV_MAX.
-    pub num_slots: u64,
+    /// list of who writes and how many slots they have
+    pub signers: Vec<(StacksAddress, u64)>,
     /// minimum wall-clock time between writes to the same slot.
     pub write_freq: u64,
     /// maximum number of times a slot may be written to during a reward cycle.
     pub max_writes: u32,
     /// hint for some initial peers that have replicas of this DB
-    pub hint_peers: Vec<NeighborAddress>,
+    pub hint_replicas: Vec<NeighborAddress>,
     /// hint for how many neighbors to connect to
-    pub num_neighbors: usize,
+    pub max_neighbors: usize,
 }
 
 impl StackerDBConfig {
@@ -186,10 +188,15 @@ impl StackerDBConfig {
             chunk_size: u64::MAX,
             write_freq: 0,
             max_writes: u32::MAX,
-            hint_peers: vec![],
-            num_neighbors: 8,
-            num_slots: STACKERDB_INV_MAX.into(),
+            hint_replicas: vec![],
+            max_neighbors: 8,
+            signers: vec![],
         }
+    }
+
+    /// How many slots are in this DB total?
+    pub fn num_slots(&self) -> u64 {
+        self.signers.iter().fold(0, |acc, s| acc + s.1)
     }
 }
 
@@ -241,7 +248,7 @@ pub struct StackerDBSync<NC: NeighborComms> {
     pub smart_contract_id: ContractId,
     /// number of chunks in this DB
     pub num_slots: usize,
-    /// how frequently we accept chunk writes
+    /// how frequently we accept chunk writes, in seconds
     pub write_freq: u64,
     /// What versions of each chunk does each neighbor have?
     pub chunk_invs: HashMap<NeighborAddress, StackerDBChunkInvData>,
@@ -260,9 +267,9 @@ pub struct StackerDBSync<NC: NeighborComms> {
     /// Downloaded chunks
     pub downloaded_chunks: HashMap<NeighborAddress, Vec<StackerDBChunkData>>,
     /// Replicas to contact
-    pub(crate) replicas: Vec<NeighborAddress>,
+    pub(crate) replicas: HashSet<NeighborAddress>,
     /// Replicas that have connected
-    pub(crate) connected_replicas: Vec<NeighborAddress>,
+    pub(crate) connected_replicas: HashSet<NeighborAddress>,
     /// Comms with neigbors
     pub(crate) comms: NC,
     /// Handle to StackerDBs
@@ -275,6 +282,8 @@ pub struct StackerDBSync<NC: NeighborComms> {
     pub total_stored: u64,
     /// total chunks pushed
     pub total_pushed: u64,
+    /// last time the state-transition function ran to completion
+    last_run_ts: u64,
 }
 
 impl StackerDBSyncResult {
@@ -323,7 +332,12 @@ impl PeerNetwork {
                             "Failed to run StackerDB state machine for {}: {:?}",
                             &sc, &e
                         );
-                        stacker_db_sync.reset(Some(self), config)?;
+                        if let Err(e) = stacker_db_sync.reset(Some(self), config) {
+                            info!(
+                                "Failed to reset StackerDB state machine for {}: {:?}",
+                                &sc, &e
+                            );
+                        }
                     }
                 }
             } else {
@@ -424,6 +438,10 @@ impl PeerNetwork {
     /// Handle unsolicited StackerDBPushChunk messages.
     /// Generate a reply handle for a StackerDBChunksInv to be sent to the remote peer, in which
     /// the inventory vector is updated with this chunk's data.
+    ///
+    /// Note that this can happen *during* a StackerDB sync's execution, so be very careful about
+    /// modifying a state machine's contents!
+    ///
     /// Return Ok(true) if we should store the chunk
     /// Return Ok(false) if we should drop it.
     pub fn handle_unsolicited_StackerDBPushChunk(
@@ -489,6 +507,13 @@ impl PeerNetwork {
                 // patch inventory -- we'll accept this chunk
                 data.slot_versions[chunk_data.chunk_data.slot_id as usize] =
                     chunk_data.chunk_data.slot_version;
+
+                // wake up the state machine -- force it to begin a new sync if it's asleep
+                if let Some(stackerdb_syncs) = self.stacker_db_syncs.as_mut() {
+                    if let Some(stackerdb_sync) = stackerdb_syncs.get_mut(&chunk_data.contract_id) {
+                        stackerdb_sync.wakeup();
+                    }
+                }
             }
             _ => {}
         }

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -173,7 +173,7 @@ pub struct StackerDBConfig {
     /// maximum chunk size
     pub chunk_size: u64,
     /// list of who writes and how many slots they have
-    pub signers: Vec<(StacksAddress, u64)>,
+    pub signers: Vec<(StacksAddress, u32)>,
     /// minimum wall-clock time between writes to the same slot.
     pub write_freq: u64,
     /// maximum number of times a slot may be written to during a reward cycle.
@@ -198,7 +198,7 @@ impl StackerDBConfig {
     }
 
     /// How many slots are in this DB total?
-    pub fn num_slots(&self) -> u64 {
+    pub fn num_slots(&self) -> u32 {
         self.signers.iter().fold(0, |acc, s| acc + s.1)
     }
 }

--- a/stackslib/src/net/stackerdb/mod.rs
+++ b/stackslib/src/net/stackerdb/mod.rs
@@ -150,6 +150,9 @@ use stacks_common::util::get_epoch_time_secs;
 /// maximum chunk inventory size
 pub const STACKERDB_INV_MAX: u32 = 4096;
 
+/// maximum chunk size (1 MB)
+pub const STACKERDB_MAX_CHUNK_SIZE: u32 = 1024 * 1024;
+
 /// Final result of synchronizing state with a remote set of DB replicas
 pub struct StackerDBSyncResult {
     /// which contract this is a replica for

--- a/stackslib/src/net/stackerdb/tests/config.rs
+++ b/stackslib/src/net/stackerdb/tests/config.rs
@@ -1,0 +1,526 @@
+// Copyright (C) 2013-2020 Blockstack PBC, a public benefit corporation
+// Copyright (C) 2020-2023 Stacks Open Internet Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::burnchains::Burnchain;
+use crate::core::StacksEpochExtension;
+use crate::core::BITCOIN_REGTEST_FIRST_BLOCK_HASH;
+
+use crate::chainstate::stacks::boot::test::{
+    instantiate_pox_peer, instantiate_pox_peer_with_epoch,
+};
+use crate::chainstate::stacks::StacksTransaction;
+use crate::chainstate::stacks::StacksTransactionSigner;
+use crate::chainstate::stacks::TransactionAuth;
+use crate::chainstate::stacks::TransactionPayload;
+use crate::chainstate::stacks::TransactionVersion;
+
+use crate::net::test::TestEventObserver;
+use crate::net::ContractId;
+use crate::net::ContractIdExtension;
+use crate::net::Error as net_error;
+use crate::net::NeighborAddress;
+use crate::net::PeerAddress;
+use crate::net::StackerDBConfig;
+
+use clarity::vm::ClarityVersion;
+use clarity::vm::ContractName;
+
+use stacks_common::address::AddressHashMode;
+use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::chainstate::StacksAddress;
+use stacks_common::types::chainstate::StacksPrivateKey;
+use stacks_common::types::chainstate::StacksPublicKey;
+use stacks_common::types::StacksEpoch;
+use stacks_common::util::hash::Hash160;
+
+fn make_smart_contract(
+    name: &str,
+    code_body: &str,
+    pk: &StacksPrivateKey,
+    nonce: u64,
+    fee: u64,
+) -> StacksTransaction {
+    let mut tx_contract = StacksTransaction::new(
+        TransactionVersion::Testnet,
+        TransactionAuth::from_p2pkh(pk).unwrap(),
+        TransactionPayload::new_smart_contract(name, code_body, None).unwrap(),
+    );
+
+    tx_contract.chain_id = 0x80000000;
+    tx_contract.auth.set_origin_nonce(nonce);
+    tx_contract.set_tx_fee(fee);
+
+    let mut tx_signer = StacksTransactionSigner::new(&tx_contract);
+    tx_signer.sign_origin(&pk).unwrap();
+    let tx_contract_signed = tx_signer.get_tx().unwrap();
+
+    tx_contract_signed
+}
+/// ;; Any StackerDB smart contract must conform to this trait.
+/// (define-trait stackerdb-trait
+///
+///     ;; Get the list of (signer, num-slots) that make up this DB
+///     (define-public (stackerdb-get-signer-slots) (response (list 4096 { signer: principal, num-slots: uint }) uint))
+///
+///     ;; Get the control metadata for this DB
+///     (define-public (stackerdb-get-config)
+///         (response {
+///             chunk-size: uint,
+///             write-freq: uint,
+///             max-writes: uint,
+///             max-neighbors: uint,
+///             hint-replicas: (list 128 { addr: (list 16 uint), port: uint, public-key-hash: (buff 20) })
+///         },
+///         uint))
+/// )
+
+#[test]
+fn test_valid_and_invalid_stackerdb_configs() {
+    let AUTO_UNLOCK_HEIGHT = 12;
+    let EXPECTED_FIRST_V2_CYCLE = 8;
+    // the sim environment produces 25 empty sortitions before
+    //  tenures start being tracked.
+    let EMPTY_SORTITIONS = 25;
+
+    let mut burnchain = Burnchain::default_unittest(
+        0,
+        &BurnchainHeaderHash::from_hex(BITCOIN_REGTEST_FIRST_BLOCK_HASH).unwrap(),
+    );
+    burnchain.pox_constants.reward_cycle_length = 5;
+    burnchain.pox_constants.prepare_length = 2;
+    burnchain.pox_constants.anchor_threshold = 1;
+    burnchain.pox_constants.v1_unlock_height = AUTO_UNLOCK_HEIGHT + EMPTY_SORTITIONS;
+
+    let first_v2_cycle = burnchain
+        .block_height_to_reward_cycle(burnchain.pox_constants.v1_unlock_height as u64)
+        .unwrap()
+        + 1;
+
+    assert_eq!(first_v2_cycle, EXPECTED_FIRST_V2_CYCLE);
+
+    let epochs = StacksEpoch::all(0, 0, EMPTY_SORTITIONS as u64 + 10);
+
+    let observer = TestEventObserver::new();
+
+    let (mut peer, mut keys) = instantiate_pox_peer_with_epoch(
+        &burnchain,
+        "test_valid_and_invalid_stackerdb_configs",
+        62104,
+        Some(epochs.clone()),
+        Some(&observer),
+    );
+
+    peer.config.check_pox_invariants =
+        Some((EXPECTED_FIRST_V2_CYCLE, EXPECTED_FIRST_V2_CYCLE + 10));
+
+    let contract_owner = keys.pop().unwrap();
+    let mut coinbase_nonce = 0;
+    let mut txs = vec![];
+
+    let testcases = vec![
+        (
+            // valid
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            Some(StackerDBConfig {
+                chunk_size: 123,
+                signers: vec![(
+                    StacksAddress {
+                        version: 26,
+                        bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b")
+                            .unwrap(),
+                    },
+                    3,
+                )],
+                write_freq: 4,
+                max_writes: 56,
+                hint_replicas: vec![NeighborAddress {
+                    addrbytes: PeerAddress::from_ipv4(127, 0, 0, 1),
+                    port: 8901,
+                    public_key_hash: Hash160::from_hex("0123456789abcdef0123456789abcdef01234567")
+                        .unwrap(),
+                }],
+                max_neighbors: 7,
+            }),
+        ),
+        (
+            // valid
+            r#"
+            (define-read-only (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-read-only (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            Some(StackerDBConfig {
+                chunk_size: 123,
+                signers: vec![(
+                    StacksAddress {
+                        version: 26,
+                        bytes: Hash160::from_hex("b4fdae98b64b9cd6c9436f3b965558966afe890b")
+                            .unwrap(),
+                    },
+                    3,
+                )],
+                write_freq: 4,
+                max_writes: 56,
+                hint_replicas: vec![NeighborAddress {
+                    addrbytes: PeerAddress::from_ipv4(127, 0, 0, 1),
+                    port: 8901,
+                    public_key_hash: Hash160::from_hex("0123456789abcdef0123456789abcdef01234567")
+                        .unwrap(),
+                }],
+                max_neighbors: 7,
+            }),
+        ),
+        (
+            // invalid -- missing function
+            r#"
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- bad function signature (argument)
+            r#"
+            (define-public (stackerdb-get-signer-slots (bad-arg uint))
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- bad return type
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok true))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- bad signer (can't be a contract)
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B.nope, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- num-slots too big
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u30000 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- chunk-size too big
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u18446744073709551617,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- write-freq too big
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u18446744073709551617,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- max-writes too big
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u4294967297,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- max-neighbors too big
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u18446744073709551617,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- bad hint-replicas address
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (unwrap-panic (as-max-len? (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0) u16)),
+                            port: u8901,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- bad port (too small)
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u1,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+        (
+            // invalid -- bad port (too big)
+            r#"
+            (define-public (stackerdb-get-signer-slots)
+                (ok (list { signer: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B, num-slots: u3 })))
+
+            (define-public (stackerdb-get-config)
+                (ok {
+                    chunk-size: u123,
+                    write-freq: u4,
+                    max-writes: u56,
+                    max-neighbors: u7,
+                    hint-replicas: (list
+                        {
+                            addr: (list u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u255 u255 u127 u0 u0 u1),
+                            port: u65537,
+                            public-key-hash: 0x0123456789abcdef0123456789abcdef01234567
+                        })
+                }))
+            "#,
+            None,
+        ),
+    ];
+
+    for (i, (code, _result)) in testcases.iter().enumerate() {
+        let tx = make_smart_contract(
+            &format!("test-{}", i),
+            code,
+            &contract_owner,
+            i as u64,
+            10000,
+        );
+        txs.push(tx);
+    }
+
+    peer.tenure_with_txs(&txs, &mut coinbase_nonce);
+
+    for (i, (code, result)) in testcases.iter().enumerate() {
+        let contract_id = ContractId::from_parts(
+            StacksAddress::from_public_keys(
+                26,
+                &AddressHashMode::SerializeP2PKH,
+                1,
+                &vec![StacksPublicKey::from_private(&contract_owner)],
+            )
+            .unwrap(),
+            ContractName::try_from(format!("test-{}", i)).unwrap(),
+        );
+        peer.with_db_state(|sortdb, chainstate, _, _| {
+            match StackerDBConfig::from_smart_contract(chainstate, sortdb, &contract_id) {
+                Ok(config) => {
+                    let expected = result
+                        .clone()
+                        .expect(&format!("FATAL: parsed a bad contract\n{}", code));
+                    assert_eq!(config, expected);
+                }
+                Err(net_error::InvalidStackerDBContract(..)) => {
+                    assert!(
+                        result.is_none(),
+                        "FATAL: valid contract treated as invalid\n{}",
+                        code
+                    );
+                }
+                Err(e) => {
+                    panic!("Unexpected error: {:?}", &e);
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+}

--- a/stackslib/src/net/stackerdb/tests/config.rs
+++ b/stackslib/src/net/stackerdb/tests/config.rs
@@ -328,7 +328,7 @@ fn test_valid_and_invalid_stackerdb_configs() {
 
             (define-public (stackerdb-get-config)
                 (ok {
-                    chunk-size: u18446744073709551617,
+                    chunk-size: u1048577,
                     write-freq: u4,
                     max-writes: u56,
                     max-neighbors: u7,

--- a/stackslib/src/net/stackerdb/tests/db.rs
+++ b/stackslib/src/net/stackerdb/tests/db.rs
@@ -714,3 +714,5 @@ fn test_reconfigure_stackerdb() {
         }
     }
 }
+
+// TODO: max chunk size

--- a/stackslib/src/net/stackerdb/tests/db.rs
+++ b/stackslib/src/net/stackerdb/tests/db.rs
@@ -348,7 +348,7 @@ fn test_stackerdb_prepare_clear_slots() {
         if slot_id < 2 {
             // belongs to 0x02
             assert_eq!(
-                slot_validation.stacker,
+                slot_validation.signer,
                 StacksAddress {
                     version: 0x02,
                     bytes: Hash160([0x02; 20])
@@ -357,7 +357,7 @@ fn test_stackerdb_prepare_clear_slots() {
         } else if slot_id >= 2 && slot_id < 2 + 3 {
             // belongs to 0x03
             assert_eq!(
-                slot_validation.stacker,
+                slot_validation.signer,
                 StacksAddress {
                     version: 0x03,
                     bytes: Hash160([0x03; 20])
@@ -366,7 +366,7 @@ fn test_stackerdb_prepare_clear_slots() {
         } else if slot_id >= 2 + 3 && slot_id < 2 + 3 + 4 {
             // belongs to 0x03
             assert_eq!(
-                slot_validation.stacker,
+                slot_validation.signer,
                 StacksAddress {
                     version: 0x04,
                     bytes: Hash160([0x04; 20])
@@ -560,5 +560,157 @@ fn test_stackerdb_insert_query_chunks() {
     let timestamps = db.get_slot_write_timestamps(&sc).unwrap();
     for ts in timestamps {
         assert!(ts > 0);
+    }
+}
+
+/// Verify that we can reconfigure the database by changing its slots
+#[test]
+fn test_reconfigure_stackerdb() {
+    let path = "/tmp/test_stackerdb_reconfigure.sqlite";
+    setup_test_path(path);
+
+    let sc = ContractId::from_parts(
+        StacksAddress {
+            version: 0x01,
+            bytes: Hash160([0x01; 20]),
+        },
+        ContractName::try_from("db1").unwrap(),
+    );
+
+    let mut db = StackerDBs::connect(path, true).unwrap();
+
+    let mut db_config = StackerDBConfig::noop();
+    db_config.max_writes = 3;
+    db_config.write_freq = 120;
+
+    let tx = db.tx_begin(db_config.clone()).unwrap();
+
+    let pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let addrs: Vec<_> = pks
+        .iter()
+        .map(|pk| {
+            StacksAddress::from_public_keys(
+                C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+                &AddressHashMode::SerializeP2PKH,
+                1,
+                &vec![StacksPublicKey::from_private(&pk)],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    tx.create_stackerdb(
+        &sc,
+        &addrs
+            .clone()
+            .into_iter()
+            .map(|addr| (addr, 1))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    // store some data
+    let mut initial_metadata = vec![];
+    for (i, pk) in pks.iter().enumerate() {
+        let mut chunk_data = StackerDBChunkData {
+            slot_id: i as u32,
+            slot_version: 1,
+            sig: MessageSignature::empty(),
+            data: vec![i as u8; 128],
+        };
+
+        chunk_data.sign(&pk).unwrap();
+
+        let slot_metadata = tx.get_slot_metadata(&sc, i as u32).unwrap().unwrap();
+        assert_eq!(slot_metadata.slot_id, i as u32);
+        assert_eq!(slot_metadata.slot_version, 0);
+        assert_eq!(slot_metadata.data_hash, Sha512Trunc256Sum([0x00; 32]));
+        assert_eq!(slot_metadata.signature, MessageSignature::empty());
+
+        // should succeed
+        tx.try_replace_chunk(&sc, &chunk_data.get_slot_metadata(), &chunk_data.data)
+            .unwrap();
+
+        let slot_metadata = tx.get_slot_metadata(&sc, i as u32).unwrap().unwrap();
+        assert_eq!(slot_metadata.slot_id, i as u32);
+        assert_eq!(slot_metadata.slot_version, chunk_data.slot_version);
+        assert_eq!(slot_metadata.data_hash, chunk_data.data_hash());
+        assert_eq!(slot_metadata.signature, chunk_data.sig);
+
+        initial_metadata.push((slot_metadata, chunk_data));
+    }
+
+    let new_pks: Vec<_> = (0..10).map(|_| StacksPrivateKey::new()).collect();
+    let reconfigured_pks = vec![
+        // first five slots are unchanged
+        pks[0], pks[1], pks[2], pks[3], pks[4],
+        // next five slots are different, so their contents will be dropped and versions and write
+        // timestamps reset
+        new_pks[0], new_pks[1], new_pks[2], new_pks[3], new_pks[4],
+        // next five slots are now, so they'll be uninitialized
+        new_pks[5], new_pks[6], new_pks[7], new_pks[8], new_pks[9],
+    ];
+    let reconfigured_addrs: Vec<_> = reconfigured_pks
+        .iter()
+        .map(|pk| {
+            StacksAddress::from_public_keys(
+                C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
+                &AddressHashMode::SerializeP2PKH,
+                1,
+                &vec![StacksPublicKey::from_private(&pk)],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    // reconfigure
+    tx.reconfigure_stackerdb(
+        &sc,
+        &reconfigured_addrs
+            .clone()
+            .into_iter()
+            .map(|addr| (addr, 1))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    tx.commit().unwrap();
+
+    for (i, pk) in new_pks.iter().enumerate() {
+        if i < 5 {
+            // first five are unchanged
+            let chunk_data = StackerDBChunkData {
+                slot_id: i as u32,
+                slot_version: 1,
+                sig: MessageSignature::empty(),
+                data: vec![i as u8; 128],
+            };
+
+            let slot_metadata = db.get_slot_metadata(&sc, i as u32).unwrap().unwrap();
+            let chunk = db.get_latest_chunk(&sc, i as u32).unwrap().unwrap();
+
+            assert_eq!(initial_metadata[i].0, slot_metadata);
+            assert_eq!(initial_metadata[i].1.data, chunk);
+        } else if i < 10 {
+            // next five are wiped
+            let slot_metadata = db.get_slot_metadata(&sc, i as u32).unwrap().unwrap();
+            assert_eq!(slot_metadata.slot_id, i as u32);
+            assert_eq!(slot_metadata.slot_version, 0);
+            assert_eq!(slot_metadata.data_hash, Sha512Trunc256Sum([0x00; 32]));
+            assert_eq!(slot_metadata.signature, MessageSignature::empty());
+
+            let chunk = db.get_latest_chunk(&sc, i as u32).unwrap().unwrap();
+            assert_eq!(chunk.len(), 0);
+        } else {
+            // final five are new
+            let slot_metadata = db.get_slot_metadata(&sc, i as u32).unwrap().unwrap();
+            assert_eq!(slot_metadata.slot_id, i as u32);
+            assert_eq!(slot_metadata.slot_version, 0);
+            assert_eq!(slot_metadata.data_hash, Sha512Trunc256Sum([0x00; 32]));
+            assert_eq!(slot_metadata.signature, MessageSignature::empty());
+
+            let chunk = db.get_latest_chunk(&sc, i as u32).unwrap().unwrap();
+            assert_eq!(chunk.len(), 0);
+        }
     }
 }

--- a/stackslib/src/net/stackerdb/tests/mod.rs
+++ b/stackslib/src/net/stackerdb/tests/mod.rs
@@ -15,5 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod bits;
+pub mod config;
 pub mod db;
 pub mod sync;

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -122,7 +122,7 @@ fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool, num_slots: usize
         };
 
         pks.push(pk);
-        slots.push((addr, 1));
+        slots.push((addr, 1u32));
     }
 
     stackerdb_config.signers = slots.clone();

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -60,26 +60,14 @@ const NUM_NEIGHBORS: usize = 8;
 /// Some testable configurations for stacker DB configs
 impl StackerDBConfig {
     #[cfg(test)]
-    pub fn one_chunk() -> StackerDBConfig {
+    pub fn template() -> StackerDBConfig {
         StackerDBConfig {
             chunk_size: CHUNK_SIZE,
             write_freq: 0,
             max_writes: u32::MAX,
-            hint_peers: vec![],
-            num_neighbors: NUM_NEIGHBORS,
-            num_slots: 1,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn ten_chunks() -> StackerDBConfig {
-        StackerDBConfig {
-            chunk_size: CHUNK_SIZE,
-            write_freq: 0,
-            max_writes: u32::MAX,
-            hint_peers: vec![],
-            num_neighbors: NUM_NEIGHBORS,
-            num_slots: 10,
+            hint_replicas: vec![],
+            max_neighbors: NUM_NEIGHBORS,
+            signers: vec![], // to be filled in
         }
     }
 }
@@ -104,15 +92,14 @@ fn add_stackerdb(config: &mut TestPeerConfig, stackerdb_config: Option<StackerDB
 
 /// Set up a stacker DB and optionally fill it with random data.
 /// `idx` refers to the `idx`th stacker DB in the node config struct.
-fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool) {
+fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool, num_slots: usize) {
     let contract_id = &peer.config.stacker_dbs[idx];
     let rc_consensus_hash = &peer.network.get_chain_view().rc_consensus_hash;
 
-    let noop = StackerDBConfig::noop();
+    let mut noop = StackerDBConfig::noop();
     let stackerdb_config = peer.config.stacker_db_configs[idx]
-        .as_ref()
-        .unwrap_or(&noop);
-    let num_slots = stackerdb_config.num_slots;
+        .as_mut()
+        .unwrap_or(&mut noop);
     let chunk_size = stackerdb_config.chunk_size;
 
     let mut k: u64 = 0;
@@ -138,6 +125,7 @@ fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool) {
         slots.push((addr, 1));
     }
 
+    stackerdb_config.signers = slots.clone();
     let tx = peer
         .network
         .stackerdbs
@@ -162,6 +150,16 @@ fn setup_stackerdb(peer: &mut TestPeer, idx: usize, fill: bool) {
     }
 
     tx.commit().unwrap();
+
+    // load the new slot data into the sync state machine
+    peer.network
+        .stacker_db_syncs
+        .as_mut()
+        .unwrap()
+        .get_mut(contract_id)
+        .unwrap()
+        .reset(None, stackerdb_config)
+        .unwrap();
 }
 
 /// Load up the entire stacker DB, including its metadata
@@ -169,7 +167,7 @@ fn load_stackerdb(peer: &TestPeer, idx: usize) -> Vec<(SlotMetadata, Vec<u8>)> {
     let num_slots = peer.config.stacker_db_configs[idx]
         .as_ref()
         .unwrap_or(&StackerDBConfig::noop())
-        .num_slots;
+        .num_slots();
     let rc_consensus_hash = &peer.network.get_chain_view().rc_consensus_hash;
     let mut ret = vec![];
     for i in 0..num_slots {
@@ -209,15 +207,15 @@ fn test_stackerdb_replica_2_neighbors_1_chunk() {
         peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
         // set up stacker DBs for both peers
-        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::one_chunk()));
-        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::one_chunk()));
+        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::template()));
+        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::template()));
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
 
         // peer 1 gets the DB
-        setup_stackerdb(&mut peer_1, idx_1, true);
-        setup_stackerdb(&mut peer_2, idx_2, false);
+        setup_stackerdb(&mut peer_1, idx_1, true, 1);
+        setup_stackerdb(&mut peer_2, idx_2, false, 1);
 
         // verify that peer 1 got the data
         let peer_1_db_chunks = load_stackerdb(&peer_1, idx_1);
@@ -318,15 +316,15 @@ fn inner_test_stackerdb_replica_2_neighbors_10_chunks(push_only: bool) {
         peer_2_config.add_neighbor(&peer_1_config.to_neighbor());
 
         // set up stacker DBs for both peers
-        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::ten_chunks()));
-        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::ten_chunks()));
+        let idx_1 = add_stackerdb(&mut peer_1_config, Some(StackerDBConfig::template()));
+        let idx_2 = add_stackerdb(&mut peer_2_config, Some(StackerDBConfig::template()));
 
         let mut peer_1 = TestPeer::new(peer_1_config);
         let mut peer_2 = TestPeer::new(peer_2_config);
 
         // peer 1 gets the DB
-        setup_stackerdb(&mut peer_1, idx_1, true);
-        setup_stackerdb(&mut peer_2, idx_2, false);
+        setup_stackerdb(&mut peer_1, idx_1, true, 10);
+        setup_stackerdb(&mut peer_2, idx_2, false, 10);
 
         // verify that peer 1 got the data
         let peer_1_db_chunks = load_stackerdb(&peer_1, idx_1);
@@ -430,7 +428,7 @@ fn inner_test_stackerdb_replica_10_neighbors_line_10_chunks(push_only: bool) {
 
             // short-lived walks...
             peer_config.connection_opts.walk_max_duration = 10;
-            let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::ten_chunks()));
+            let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::template()));
 
             peer_configs.push(peer_config);
             peer_db_idxs.push(idx);
@@ -449,7 +447,7 @@ fn inner_test_stackerdb_replica_10_neighbors_line_10_chunks(push_only: bool) {
 
             if i == 0 {
                 // peer 0 -- at one end of the line -- gets the initial DB
-                setup_stackerdb(&mut peer, peer_db_idxs[i], true);
+                setup_stackerdb(&mut peer, peer_db_idxs[i], true, 10);
 
                 // verify instantiation
                 let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i]);
@@ -461,7 +459,7 @@ fn inner_test_stackerdb_replica_10_neighbors_line_10_chunks(push_only: bool) {
                 }
             } else {
                 // everyone else gets nothing
-                setup_stackerdb(&mut peer, peer_db_idxs[i], false);
+                setup_stackerdb(&mut peer, peer_db_idxs[i], false, 10);
 
                 // verify instantiation
                 let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i]);
@@ -552,7 +550,7 @@ fn test_stackerdb_10_replicas_10_neighbors_line_10_chunks() {
 
             let mut idxs = vec![];
             for j in 0..10 {
-                let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::ten_chunks()));
+                let idx = add_stackerdb(&mut peer_config, Some(StackerDBConfig::template()));
                 idxs.push(idx);
             }
 
@@ -574,7 +572,7 @@ fn test_stackerdb_10_replicas_10_neighbors_line_10_chunks() {
             if i == 0 {
                 for j in 0..peer_db_idxs[i].len() {
                     // peer 0 -- at one end of the line -- gets the initial DBs
-                    setup_stackerdb(&mut peer, peer_db_idxs[i][j], true);
+                    setup_stackerdb(&mut peer, peer_db_idxs[i][j], true, 10);
 
                     // verify instantiation
                     let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i][j]);
@@ -588,7 +586,7 @@ fn test_stackerdb_10_replicas_10_neighbors_line_10_chunks() {
             } else {
                 for j in 0..peer_db_idxs[i].len() {
                     // everyone else gets nothing
-                    setup_stackerdb(&mut peer, peer_db_idxs[i][j], false);
+                    setup_stackerdb(&mut peer, peer_db_idxs[i][j], false, 10);
 
                     // verify instantiation
                     let peer_db_chunks = load_stackerdb(&peer, peer_db_idxs[i][j]);

--- a/stackslib/src/net/stackerdb/tests/sync.rs
+++ b/stackslib/src/net/stackerdb/tests/sync.rs
@@ -401,11 +401,13 @@ fn inner_test_stackerdb_replica_2_neighbors_10_chunks(push_only: bool, base_port
 }
 
 #[test]
+#[ignore]
 fn test_stackerdb_10_replicas_10_neighbors_line_10_chunks() {
     inner_test_stackerdb_10_replicas_10_neighbors_line_10_chunks(false, BASE_PORT + 28);
 }
 
 #[test]
+#[ignore]
 fn test_stackerdb_10_replicas_10_neighbors_line_push_10_chunks() {
     inner_test_stackerdb_10_replicas_10_neighbors_line_10_chunks(true, BASE_PORT + 68);
 }


### PR DESCRIPTION
This PR adds the ability to load a StackerDB configuration from a smart contract.  This allows the smart contract to reconfigure the following data:

* Who gets to write to it, and how much data (in terms of number of signer slots)
* How big each slot it
* How often the slot can be written
* How many times per reward cycle the slot can be written
* A list of initial peers to connect to
* A hint as to how many replicas to connect to at once