### PR TITLE
ci: Fix CI failing when we don't have DockerHub credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
   docker-alpine:
     if: ${{ inputs.tag != '' || (github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && !contains(github.ref, 'refs/pull')) }}
     name: Docker Alpine (Binary)
-    uses: stacks-network/stacks-blockchain/.github/workflows/image-build-alpine-binary.yml@master
+    uses: jbencin/stacks-blockchain/.github/workflows/image-build-alpine-binary.yml@ci/pass-without-dockerhub-credentials
     needs: github-release
     with:
       tag: ${{ inputs.tag }}
@@ -147,7 +147,7 @@ jobs:
   docker-debian:
     if: ${{ inputs.tag != '' || (github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && !contains(github.ref, 'refs/pull')) }}
     name: Docker Debian (Binary)
-    uses: stacks-network/stacks-blockchain/.github/workflows/image-build-debian-binary.yml@master
+    uses: jbencin/stacks-blockchain/.github/workflows/image-build-debian-binary.yml@ci/pass-without-dockerhub-credentials
     needs: github-release
     with:
       tag: ${{ inputs.tag }}
@@ -167,7 +167,7 @@ jobs:
   build-branch:
     if: ${{ inputs.tag == '' }}
     name: Docker Debian (Source)
-    uses: stacks-network/stacks-blockchain/.github/workflows/image-build-debian-source.yml@master
+    uses: jbencin/stacks-blockchain/.github/workflows/image-build-debian-source.yml@ci/pass-without-dockerhub-credentials
     needs:
       - rustfmt
       - leaked-cred-test

--- a/.github/workflows/image-build-alpine-binary.yml
+++ b/.github/workflows/image-build-alpine-binary.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
           echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "DOCKER_PUSH=${{ (secrets.DOCKERHUB_USERNAME != '') && (secrets.DOCKERHUB_PASSWORD != '') }}" >> $GITHUB_ENV
       - name: Set up QEMU
         id: docker_qemu
         uses: docker/setup-qemu-action@v2
@@ -62,6 +63,8 @@ jobs:
       - name: Login to DockerHub
         id: docker_login
         uses: docker/login-action@v2
+        # Only attempt login and push if we have credentials
+        if: env.DOCKER_PUSH == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -78,4 +81,4 @@ jobs:
             STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-          push: true
+          push: ${{ env.DOCKER_PUSH }}

--- a/.github/workflows/image-build-debian-binary.yml
+++ b/.github/workflows/image-build-debian-binary.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
           echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "DOCKER_PUSH=${{ (secrets.DOCKERHUB_USERNAME != '') && (secrets.DOCKERHUB_PASSWORD != '') }}" >> $GITHUB_ENV
       - name: Set up QEMU
         id: docker_qemu
         uses: docker/setup-qemu-action@v2
@@ -73,6 +74,8 @@ jobs:
       - name: Login to DockerHub
         id: docker_login
         uses: docker/login-action@v2
+        # Only attempt login and push if we have credentials
+        if: env.DOCKER_PUSH == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -89,4 +92,4 @@ jobs:
             STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-          push: true
+          push: ${{ env.DOCKER_PUSH }}

--- a/.github/workflows/image-build-debian-source.yml
+++ b/.github/workflows/image-build-debian-source.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           echo "GITHUB_SHA_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV
           echo "GITHUB_REF_SHORT=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "DOCKER_PUSH=${{ (secrets.DOCKERHUB_USERNAME != '') && (secrets.DOCKERHUB_PASSWORD != '') }}" >> $GITHUB_ENV
       - name: Set up QEMU
         id: docker_qemu
         uses: docker/setup-qemu-action@v2
@@ -72,6 +73,8 @@ jobs:
       - name: Login to DockerHub
         id: docker_login
         uses: docker/login-action@v2
+        # Only attempt login and push if we have credentials
+        if: env.DOCKER_PUSH == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -87,4 +90,4 @@ jobs:
             STACKS_NODE_VERSION=${{ env.GITHUB_SHA_SHORT }}
             GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
             GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-          push: true
+          push: ${{ env.DOCKER_PUSH }}


### PR DESCRIPTION
### Description

Currently, CI always fails when I commit to my personal fork of `stacks-blockchain`. The same behavior would also occur in any other fork of this repo. This is because in forks, the secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` are not accessible.

This PR fixes the failure by checking whether these credentials are empty. If they are, it will still attempt to build the Docker images, but will not attempt to login and push them to DockerHub.

### Additional Notes

**The changes to `.github/workflows/ci.yml` should not be merged.** Those only to enable running the tests without pushing to `master`

As an alternative, I could have modified `.github/workflows/ci.yml` to skip the Docker image builds all together. I don't know if building the image itself is a useful test, maybe not?