### PR TITLE
Adding more default bootstrap nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to the versioning scheme outlined in the [README.md](RE
 - New RPC endpoint at /v2/constant_val to fetch a constant from a contract.
 - Message definitions and codecs for Stacker DB, a replicated off-chain DB
   hosted by subscribed Stacks nodes and controlled by smart contracts
+- Added 3 new public and regionally diverse bootstrap nodes: est.stacksnodes.org, cet.stacksnodes.org, sgt.stacksnodes.org
 
 ### Fixed
 

--- a/testnet/stacks-node/conf/mainnet-follower-conf.toml
+++ b/testnet/stacks-node/conf/mainnet-follower-conf.toml
@@ -2,7 +2,7 @@
 # working_dir = "/dir/to/save/chainstate"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444"
+bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444,02539449ad94e6e6392d8c1deb2b4e61f80ae2a18964349bc14336d8b903c46a8c@cet.stacksnodes.org:20444,02ececc8ce79b8adf813f13a0255f8ae58d4357309ba0cedd523d9f1a306fcfb79@sgt.stacksnodes.org:20444,0303144ba518fe7a0fb56a8a7d488f950307a4330f146e1e1458fc63fb33defe96@est.stacksnodes.org:20444"
 
 [burnchain]
 chain = "bitcoin"

--- a/testnet/stacks-node/conf/mainnet-miner-conf.toml
+++ b/testnet/stacks-node/conf/mainnet-miner-conf.toml
@@ -5,7 +5,7 @@ p2p_bind = "0.0.0.0:20444"
 seed = "<YOUR_SEED>"
 local_peer_seed = "<YOUR_SEED>"
 miner = true
-bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444"
+bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444,02539449ad94e6e6392d8c1deb2b4e61f80ae2a18964349bc14336d8b903c46a8c@cet.stacksnodes.org:20444,02ececc8ce79b8adf813f13a0255f8ae58d4357309ba0cedd523d9f1a306fcfb79@sgt.stacksnodes.org:20444,0303144ba518fe7a0fb56a8a7d488f950307a4330f146e1e1458fc63fb33defe96@est.stacksnodes.org:20444"
 
 [burnchain]
 chain = "bitcoin"

--- a/testnet/stacks-node/conf/mainnet-mockminer-conf.toml
+++ b/testnet/stacks-node/conf/mainnet-mockminer-conf.toml
@@ -4,7 +4,7 @@ rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 miner = true
 mock_mining = true
-bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444"
+bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444,02539449ad94e6e6392d8c1deb2b4e61f80ae2a18964349bc14336d8b903c46a8c@cet.stacksnodes.org:20444,02ececc8ce79b8adf813f13a0255f8ae58d4357309ba0cedd523d9f1a306fcfb79@sgt.stacksnodes.org:20444,0303144ba518fe7a0fb56a8a7d488f950307a4330f146e1e1458fc63fb33defe96@est.stacksnodes.org:20444"
 
 [burnchain]
 chain = "bitcoin"

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -208,7 +208,7 @@ impl ConfigFile {
         };
 
         let node = NodeConfigFile {
-            bootstrap_node: Some("029266faff4c8e0ca4f934f34996a96af481df94a89b0c9bd515f3536a95682ddc@seed.testnet.hiro.so:20444".to_string()),
+            bootstrap_node: Some("02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444,02539449ad94e6e6392d8c1deb2b4e61f80ae2a18964349bc14336d8b903c46a8c@cet.stacksnodes.org:20444,02ececc8ce79b8adf813f13a0255f8ae58d4357309ba0cedd523d9f1a306fcfb79@sgt.stacksnodes.org:20444,0303144ba518fe7a0fb56a8a7d488f950307a4330f146e1e1458fc63fb33defe96@est.stacksnodes.org:20444".to_string()),
             miner: Some(false),
             ..NodeConfigFile::default()
         };
@@ -253,7 +253,7 @@ impl ConfigFile {
         };
 
         let node = NodeConfigFile {
-            bootstrap_node: Some("02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444".to_string()),
+            bootstrap_node: Some("02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a605923893@seed.mainnet.hiro.so:20444,02539449ad94e6e6392d8c1deb2b4e61f80ae2a18964349bc14336d8b903c46a8c@cet.stacksnodes.org:20444,02ececc8ce79b8adf813f13a0255f8ae58d4357309ba0cedd523d9f1a306fcfb79@sgt.stacksnodes.org:20444,0303144ba518fe7a0fb56a8a7d488f950307a4330f146e1e1458fc63fb33defe96@est.stacksnodes.org:20444".to_string()),
             miner: Some(false),
             ..NodeConfigFile::default()
         };


### PR DESCRIPTION
This PR adds 3 new bootstrap nodes to the default list alongside the existing `seed.mainnet.hiro.so` node. 
Sample configs are also adjusted to add these 3 extra nodes. 

the three regionally diverse nodes:
- est.stacsknodes.org @`54.91.222.127` (EST timezone)
- cet.stacksnodes.org @`3.122.176.89` (CET timezone)
- sgt.stacksnodes.org @`52.77.118.154`  (SGT timezone)

Simple test to ensure they're being loaded at runtime (via `stacks-node mainnet` on this branch):
```
➭ curl -sL localhost:20443/v2/neighbors | jq -r
{
  "bootstrap": [
    {
      "network_id": 1,
      "peer_version": 402653193,
      "ip": "35.194.79.91",
      "port": 20444,
      "public_key_hash": "6d6ce48c436ecd4bb0f7549f944c1a5321c2339c",
      "authenticated": true,
      "stackerdbs": []
    },
    {
      "network_id": 1,
      "peer_version": 402653193,
      "ip": "52.77.118.154",
      "port": 20444,
      "public_key_hash": "cae272d47b8d13f15f4b9c4311682caa2486a90d",
      "authenticated": true,
      "stackerdbs": []
    },
    {
      "network_id": 1,
      "peer_version": 402653193,
      "ip": "54.91.222.127",
      "port": 20444,
      "public_key_hash": "a21a8b69c9ece5b00110323e51cad0c4b4d4ec85",
      "authenticated": true,
      "stackerdbs": []
    },
    {
      "network_id": 1,
      "peer_version": 402653193,
      "ip": "3.122.176.89",
      "port": 20444,
      "public_key_hash": "6090e1600d9c86f05bdb97caedc6294f5b5134f1",
      "authenticated": true,
      "stackerdbs": []
    }
  ...
  ```