### PR TITLE
Update rusqlite to 0.29.0 [NEXT]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ version = "0.24.2"
 features = ["serde", "recovery"]
 
 [dependencies.rusqlite]
-version = "=0.24.2"
+version = "0.29.0"
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [dependencies.ed25519-dalek]


### PR DESCRIPTION
In order for this repo to be usable by other up to date repos, we must update rusqlite