### PR TITLE
Do not enable `developer-mode` by default in `clarity`

### DIFF
--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -50,7 +50,7 @@ assert-json-diff = "1.0.0"
 # criterion = "0.3"
 
 [features]
-default = ["developer-mode"]
+default = []
 developer-mode = []
 slog_json = ["stacks_common/slog_json"]
 testing = []


### PR DESCRIPTION
### Description
This mode should only be enabled explicitly by users of the clarity crate. This fixes a problem where this mode was enabled accidentally, causing incompatibility with saved chain state.

### Applicable issues
- fixes #3945

### Additional info (benefits, drawbacks, caveats)
Users of the clarity crate that require `developer-mode` will now need to explicitly enable it.

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
