### PR TITLE
fix: lower warning about mempool nonce caching to `debug!`

### DIFF
--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -853,7 +853,7 @@ impl NonceCache {
                         let should_store_again = match db_set_nonce(mempool_db, address, nonce) {
                             Ok(_) => false,
                             Err(e) => {
-                                warn!("error caching nonce to sqlite: {}", e);
+                                debug!("error caching nonce to sqlite: {}", e);
                                 true
                             }
                         };


### PR DESCRIPTION
### Description

The warning about failing to cache mempool nonces shows up very often during normal execution of the node. It should not be a warning. This PR lowers it to a debug message.

```
error caching nonce to sqlite: database is locked
```

### Applicable issues
- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
