### PR TITLE
Fix developer mode issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ StackerDB replicas in their config files.
 
 ### Changed
 
-- `developer-mode` is not longer enabled in the default feature set. This is the correct default behavior, since the stacks-node should NOT build with developer-mode enabled by default. Tools that need to use developer-mode should enable it explicitly.
+- `developer-mode` is no longer enabled in the default feature set. This is the correct default behavior, since the stacks-node should NOT build with developer-mode enabled by default. Tools that need to use developer-mode should enable it explicitly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ StackerDB replicas in their config files.
   hosted by subscribed Stacks nodes and controlled by smart contracts
 - Added 3 new public and regionally diverse bootstrap nodes: est.stacksnodes.org, cet.stacksnodes.org, sgt.stacksnodes.org
 
+### Changed
+
+- `developer-mode` is not longer enabled in the default feature set. This is the correct default behavior, since the stacks-node should NOT build with developer-mode enabled by default. Tools that need to use developer-mode should enable it explicitly.
+
 ### Fixed
 
 - The transaction receipts for smart contract publish transactions now indicate

--- a/stackslib/Cargo.toml
+++ b/stackslib/Cargo.toml
@@ -100,7 +100,7 @@ rstest = "0.17.0"
 rstest_reuse = "0.5.0"
 
 [features]
-default = ["developer-mode"]
+default = []
 profile-sqlite = []
 disable-costs = []
 developer-mode = ["clarity/developer-mode"]


### PR DESCRIPTION
### Description
This is a follow up to #3955. I previously missed the fact that `stackslib` enabled `developer-mode` in the default feature set. This should not be the case.

### Applicable issues
- fixes #3945

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [x] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
