### PR TITLE
Bugfixes for signer when testing CLI through mainnet develop node

### DIFF
--- a/libsigner/src/runloop.rs
+++ b/libsigner/src/runloop.rs
@@ -133,6 +133,12 @@ impl<EV: EventReceiver, R> RunningSigner<EV, R> {
         // kill event receiver
         self.stop_signal.send();
 
+        self.join()
+    }
+
+    /// Wait for the signer to terminate, and get the final state.
+    /// WARNING: This will hang forever if the event receiver stop signal was never sent/no error occurs.
+    pub fn join(self) -> Option<R> {
         debug!("Try join event loop...");
         // wait for event receiver join
         let _ = self.event_join.join().map_err(|thread_panic| {

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -94,6 +94,8 @@ pub struct PutChunkArgs {
     pub slot_version: u32,
     /// The data to upload
     #[arg(required = false, value_parser = parse_data)]
+    // Note this weirdness is due to https://github.com/clap-rs/clap/discussions/4695
+    // Need to specify the long name here due to invalid parsing in Clap which looks at the NAME rather than the TYPE which causes issues in how it handles Vec's.
     pub data: alloc::vec::Vec<u8>,
 }
 
@@ -105,6 +107,8 @@ pub struct SignArgs {
     pub config: PathBuf,
     /// The data to sign
     #[arg(required = false, value_parser = parse_data)]
+    // Note this weirdness is due to https://github.com/clap-rs/clap/discussions/4695
+    // Need to specify the long name here due to invalid parsing in Clap which looks at the NAME rather than the TYPE which causes issues in how it handles Vec's.
     pub data: alloc::vec::Vec<u8>,
 }
 

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -135,7 +135,7 @@ pub struct GenerateFilesArgs {
     /// The total number of key ids to distribute among the signers
     pub num_keys: u32,
     #[arg(long, value_parser = parse_network)]
-    /// The network to use. One of "mainnet" or "testnet".
+    /// The network to use. One of "mainnet", "testnet", or "mocknet".
     pub network: Network,
     /// The directory to write the test data files to
     #[arg(long, default_value = ".")]
@@ -168,14 +168,15 @@ fn parse_data(data: &str) -> Result<String, String> {
     Ok(data)
 }
 
-/// Parse the network. Must be one of "mainnet" or "testnet".
+/// Parse the network. Must be one of "mainnet", "testnet", or "mocknet".
 fn parse_network(network: &str) -> Result<Network, String> {
     Ok(match network.to_lowercase().as_str() {
         "mainnet" => Network::Mainnet,
         "testnet" => Network::Testnet,
+        "mocknet" => Network::Mocknet,
         _ => {
             return Err(format!(
-                "Invalid network: {}. Must be one of \"mainnet\" or \"testnet\".",
+                "Invalid network: {}. Must be one of \"mainnet\", \"testnet\", or \"mocknet\".",
                 network
             ))
         }

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -93,7 +93,7 @@ pub struct PutChunkArgs {
     pub slot_version: u32,
     /// The data to upload
     #[arg(required = false, value_parser = parse_data)]
-    pub data: Vec<u8>,
+    pub data: String,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -104,7 +104,7 @@ pub struct SignArgs {
     pub config: PathBuf,
     /// The data to sign
     #[arg(required = false, value_parser = parse_data)]
-    pub data: Vec<u8>,
+    pub data: String,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -156,14 +156,14 @@ fn parse_private_key(private_key: &str) -> Result<StacksPrivateKey, String> {
 }
 
 /// Parse the input data
-fn parse_data(data: &str) -> Result<Vec<u8>, String> {
+fn parse_data(data: &str) -> Result<String, String> {
     let data = if data == "-" {
         // Parse the data from stdin
-        let mut buf = vec![];
-        io::stdin().read_to_end(&mut buf).unwrap();
-        buf
+        let mut data = String::new();
+        io::stdin().read_to_string(&mut data).unwrap();
+        data
     } else {
-        data.as_bytes().to_vec()
+        data.to_string()
     };
     Ok(data)
 }

--- a/stacks-signer/src/cli.rs
+++ b/stacks-signer/src/cli.rs
@@ -7,13 +7,7 @@ use clap::Parser;
 use clarity::vm::types::QualifiedContractIdentifier;
 use stacks_common::{address::b58, types::chainstate::StacksPrivateKey};
 
-/// Wrapper around b58 data to enable CLI parsing
-// Cannot pass Vec<u8> directly or it will expect a space seperated list of chars from the command line
-#[derive(Clone, Debug)]
-pub struct B58Data {
-    /// The data
-    pub data: Vec<u8>,
-}
+extern crate alloc;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -100,7 +94,7 @@ pub struct PutChunkArgs {
     pub slot_version: u32,
     /// The data to upload
     #[arg(required = false, value_parser = parse_data)]
-    pub data: B58Data,
+    pub data: alloc::vec::Vec<u8>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -111,7 +105,7 @@ pub struct SignArgs {
     pub config: PathBuf,
     /// The data to sign
     #[arg(required = false, value_parser = parse_data)]
-    pub data: B58Data,
+    pub data: alloc::vec::Vec<u8>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -163,7 +157,7 @@ fn parse_private_key(private_key: &str) -> Result<StacksPrivateKey, String> {
 }
 
 /// Parse the input data
-fn parse_data(data: &str) -> Result<B58Data, String> {
+fn parse_data(data: &str) -> Result<Vec<u8>, String> {
     let encoded_data = if data == "-" {
         // Parse the data from stdin
         let mut data = String::new();
@@ -174,7 +168,7 @@ fn parse_data(data: &str) -> Result<B58Data, String> {
     };
     let data =
         b58::from(&encoded_data).map_err(|e| format!("Failed to decode provided data: {}", e))?;
-    Ok(B58Data { data })
+    Ok(data)
 }
 
 /// Parse the network. Must be one of "mainnet", "testnet", or "mocknet".

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -76,7 +76,7 @@ impl Network {
     pub fn to_chain_id(&self) -> u32 {
         match self {
             Self::Mainnet => CHAIN_ID_MAINNET,
-            Self::Testnet => CHAIN_ID_TESTNET,
+            Self::Testnet | Self::Mocknet => CHAIN_ID_TESTNET,
         }
     }
 
@@ -84,7 +84,7 @@ impl Network {
     pub fn to_address_version(&self) -> u8 {
         match self {
             Self::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-            Self::Testnet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+            Self::Testnet | Self::Mocknet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
         }
     }
 
@@ -92,7 +92,7 @@ impl Network {
     pub fn to_transaction_version(&self) -> TransactionVersion {
         match self {
             Self::Mainnet => TransactionVersion::Mainnet,
-            Self::Testnet => TransactionVersion::Testnet,
+            Self::Testnet | Self::Mocknet => TransactionVersion::Testnet,
         }
     }
 }

--- a/stacks-signer/src/config.rs
+++ b/stacks-signer/src/config.rs
@@ -67,6 +67,8 @@ pub enum Network {
     Mainnet,
     /// The testnet network
     Testnet,
+    /// The mocknet network
+    Mocknet,
 }
 
 impl Network {

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -174,7 +174,7 @@ fn handle_list_chunks(args: StackerDBArgs) {
 fn handle_put_chunk(args: PutChunkArgs) {
     debug!("Putting chunk...");
     let mut session = stackerdb_session(args.db_args.host, args.db_args.contract);
-    let mut chunk = StackerDBChunkData::new(args.slot_id, args.slot_version, args.data.data);
+    let mut chunk = StackerDBChunkData::new(args.slot_id, args.slot_version, args.data);
     chunk.sign(&args.private_key).unwrap();
     let chunk_ack = session.put_chunk(chunk).unwrap();
     println!("{}", serde_json::to_string(&chunk_ack).unwrap());
@@ -195,7 +195,7 @@ fn handle_sign(args: SignArgs) {
     spawned_signer
         .cmd_send
         .send(RunLoopCommand::Sign {
-            message: args.data.data,
+            message: args.data,
             is_taproot: false,
             merkle_root: None,
         })
@@ -213,7 +213,7 @@ fn handle_dkg_sign(args: SignArgs) {
     spawned_signer
         .cmd_send
         .send(RunLoopCommand::Sign {
-            message: args.data.data,
+            message: args.data,
             is_taproot: false,
             merkle_root: None,
         })

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -95,7 +95,7 @@ fn spawn_running_signer(path: &PathBuf) -> SpawnedSigner {
         RunLoop<FrostCoordinator<v2::Aggregator>>,
         StackerDBEventReceiver,
     > = Signer::new(runloop, ev, cmd_recv, res_send);
-    let endpoint = config.node_host;
+    let endpoint = config.endpoint;
     let running_signer = signer.spawn(endpoint).unwrap();
     SpawnedSigner {
         running_signer,
@@ -228,7 +228,11 @@ fn handle_dkg_sign(args: SignArgs) {
 fn handle_run(args: RunDkgArgs) {
     debug!("Running signer...");
     let _spawned_signer = spawn_running_signer(&args.config);
-    println!("Signer spawned successfully. Waiting for messages to process.");
+    println!("Signer spawned successfully. Waiting for messages to process...");
+    loop {
+        std::thread::sleep(Duration::from_secs(20));
+        debug!("Signer still running...");
+    }
 }
 
 fn handle_generate_files(args: GenerateFilesArgs) {

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -174,7 +174,7 @@ fn handle_list_chunks(args: StackerDBArgs) {
 fn handle_put_chunk(args: PutChunkArgs) {
     debug!("Putting chunk...");
     let mut session = stackerdb_session(args.db_args.host, args.db_args.contract);
-    let mut chunk = StackerDBChunkData::new(args.slot_id, args.slot_version, args.data.into());
+    let mut chunk = StackerDBChunkData::new(args.slot_id, args.slot_version, args.data.data);
     chunk.sign(&args.private_key).unwrap();
     let chunk_ack = session.put_chunk(chunk).unwrap();
     println!("{}", serde_json::to_string(&chunk_ack).unwrap());
@@ -195,7 +195,7 @@ fn handle_sign(args: SignArgs) {
     spawned_signer
         .cmd_send
         .send(RunLoopCommand::Sign {
-            message: args.data.into(),
+            message: args.data.data,
             is_taproot: false,
             merkle_root: None,
         })
@@ -213,7 +213,7 @@ fn handle_dkg_sign(args: SignArgs) {
     spawned_signer
         .cmd_send
         .send(RunLoopCommand::Sign {
-            message: args.data.into(),
+            message: args.data.data,
             is_taproot: false,
             merkle_root: None,
         })

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -174,7 +174,7 @@ fn handle_list_chunks(args: StackerDBArgs) {
 fn handle_put_chunk(args: PutChunkArgs) {
     debug!("Putting chunk...");
     let mut session = stackerdb_session(args.db_args.host, args.db_args.contract);
-    let mut chunk = StackerDBChunkData::new(args.slot_id, args.slot_version, args.data.clone());
+    let mut chunk = StackerDBChunkData::new(args.slot_id, args.slot_version, args.data.into());
     chunk.sign(&args.private_key).unwrap();
     let chunk_ack = session.put_chunk(chunk).unwrap();
     println!("{}", serde_json::to_string(&chunk_ack).unwrap());
@@ -195,7 +195,7 @@ fn handle_sign(args: SignArgs) {
     spawned_signer
         .cmd_send
         .send(RunLoopCommand::Sign {
-            message: args.data,
+            message: args.data.into(),
             is_taproot: false,
             merkle_root: None,
         })
@@ -213,7 +213,7 @@ fn handle_dkg_sign(args: SignArgs) {
     spawned_signer
         .cmd_send
         .send(RunLoopCommand::Sign {
-            message: args.data,
+            message: args.data.into(),
             is_taproot: false,
             merkle_root: None,
         })
@@ -229,7 +229,9 @@ fn handle_run(args: RunDkgArgs) {
     debug!("Running signer...");
     let _spawned_signer = spawn_running_signer(&args.config);
     println!("Signer spawned successfully. Waiting for messages to process...");
-    loop {}
+    loop {
+        std::thread::sleep(Duration::from_secs(10));
+    }
 }
 
 fn handle_generate_files(args: GenerateFilesArgs) {

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -227,11 +227,10 @@ fn handle_dkg_sign(args: SignArgs) {
 
 fn handle_run(args: RunDkgArgs) {
     debug!("Running signer...");
-    let _spawned_signer = spawn_running_signer(&args.config);
+    let spawned_signer = spawn_running_signer(&args.config);
     println!("Signer spawned successfully. Waiting for messages to process...");
-    loop {
-        std::thread::sleep(Duration::from_secs(10));
-    }
+    // Wait for the spawned signer to stop (will only occur if an error occurs)
+    let _ = spawned_signer.running_signer.join();
 }
 
 fn handle_generate_files(args: GenerateFilesArgs) {

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -186,7 +186,7 @@ fn handle_dkg(args: RunDkgArgs) {
     spawned_signer.cmd_send.send(RunLoopCommand::Dkg).unwrap();
     let dkg_res = spawned_signer.res_recv.recv().unwrap();
     process_dkg_result(&dkg_res);
-    spawned_signer.running_signer.stop().unwrap();
+    spawned_signer.running_signer.stop();
 }
 
 fn handle_sign(args: SignArgs) {
@@ -202,7 +202,7 @@ fn handle_sign(args: SignArgs) {
         .unwrap();
     let sign_res = spawned_signer.res_recv.recv().unwrap();
     process_sign_result(&sign_res);
-    spawned_signer.running_signer.stop().unwrap();
+    spawned_signer.running_signer.stop();
 }
 
 fn handle_dkg_sign(args: SignArgs) {
@@ -222,17 +222,14 @@ fn handle_dkg_sign(args: SignArgs) {
     process_dkg_result(&dkg_res);
     let sign_res = spawned_signer.res_recv.recv().unwrap();
     process_sign_result(&sign_res);
-    spawned_signer.running_signer.stop().unwrap();
+    spawned_signer.running_signer.stop();
 }
 
 fn handle_run(args: RunDkgArgs) {
     debug!("Running signer...");
     let _spawned_signer = spawn_running_signer(&args.config);
     println!("Signer spawned successfully. Waiting for messages to process...");
-    loop {
-        std::thread::sleep(Duration::from_secs(20));
-        debug!("Signer still running...");
-    }
+    loop {}
 }
 
 fn handle_generate_files(args: GenerateFilesArgs) {

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -336,7 +336,7 @@ fn main() {
 fn to_addr(stacks_private_key: &StacksPrivateKey, network: &Network) -> StacksAddress {
     let version = match network {
         Network::Mainnet => C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
-        Network::Testnet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
+        Network::Testnet | Network::Mocknet => C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
     };
     StacksAddress::from_public_keys(
         version,


### PR DESCRIPTION
This PR is ongoing, fixing bugs are required (found through testing stacker db on mainnet)
- [x] Fix spawn_running_signer to use endpoint not node_host for creating the event listeners.
- [x] Loop the run thread forever so that we always wait for messages
- [x] Do not unwrap the results of the stop() in main as we expect these to return None. Nothing to actually unwrap.
- [x] Fixed clap to use String instead of Vec<u8>. This may need to be updated to take a hex string explicitly and dehexify that string to a vec<u8>? EDIT: updated to use stacks_common's copy of b58 decoder