### PR TITLE
Enable signer tracing

### DIFF
--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^mongodb-.*'
           sudo apt-get remove -y '^mysql-.*'
-          #sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           sudo apt-get autoremove -y
           sudo apt-get clean
           docker system prune --force

--- a/.github/workflows/bitcoin-tests.yml
+++ b/.github/workflows/bitcoin-tests.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^mongodb-.*'
           sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          #sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           sudo apt-get autoremove -y
           sudo apt-get clean
           docker system prune --force

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2142,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2221,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
@@ -2650,6 +2675,15 @@ checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -3183,6 +3217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3389,8 @@ dependencies = [
  "stx-genesis",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "warp",
  "wsts",
 ]
@@ -3373,6 +3418,8 @@ dependencies = [
  "stacks-common",
  "thiserror",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "wsts",
 ]
 
@@ -3866,6 +3913,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4002,6 +4079,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
@@ -4416,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "4.0.0"
-source = "git+https://github.com/Trust-Machines/wsts?tag=4.0.0rc1#8167a32c123a4769ee2704fd64f7b0d753ca0f56"
+source = "git+https://github.com/Trust-Machines/wsts?tag=4.0.0rc2#e87f997781c0e9d9b2951d75059d673296311eec"
 dependencies = [
  "aes-gcm 0.10.2",
  "bs58 0.5.0",
@@ -4431,6 +4514,7 @@ dependencies = [
  "sha2 0.10.6",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -37,7 +37,9 @@ slog-term = "2.6.0"
 stacks-common = { path = "../stacks-common" }
 thiserror = "1.0"
 toml = "0.5.6"
-wsts = { git = "https://github.com/Trust-Machines/wsts", tag = "4.0.0rc1" }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+wsts = { git = "https://github.com/Trust-Machines/wsts", tag = "4.0.0rc2" }
 
 [dependencies.serde_json]
 version = "1.0"

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -56,6 +56,7 @@ use std::{
     sync::mpsc::{channel, Receiver, Sender},
     time::Duration,
 };
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use wsts::{
     state_machine::{coordinator::Coordinator as FrostCoordinator, OperationResult},
     v2,
@@ -298,6 +299,12 @@ fn handle_generate_files(args: GenerateFilesArgs) {
 
 fn main() {
     let cli = Cli::parse();
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
     match cli.command {
         Command::GetChunk(args) => {
             handle_get_chunk(args);

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -39,7 +39,9 @@ stacks-common = { path = "../../stacks-common", features = ["default", "testing"
 stacks = { package = "stackslib", path = "../../stackslib", features = ["default", "testing"] }
 stacks-signer = { path = "../../stacks-signer" }
 p256k1 = "5.4.1"
-wsts = { git = "https://github.com/Trust-Machines/wsts", tag = "4.0.0rc1" }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+wsts = { git = "https://github.com/Trust-Machines/wsts", tag = "4.0.0rc2" }
 
 [dev-dependencies.rusqlite]
 version = "=0.24.2"

--- a/testnet/stacks-node/src/tests/signer.rs
+++ b/testnet/stacks-node/src/tests/signer.rs
@@ -24,6 +24,7 @@ use stacks_signer::{
     runloop::RunLoopCommand,
     utils::{build_signer_config_tomls, build_stackerdb_contract},
 };
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use wsts::{
     state_machine::{coordinator::Coordinator as FrostCoordinator, OperationResult},
     v2,
@@ -156,9 +157,15 @@ fn test_stackerdb_dkg() {
     if env::var("BITCOIND_TEST") != Ok("1".into()) {
         return;
     }
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
     // Generate Signer Data
     let num_signers: u32 = 16;
-    let num_keys: u32 = 4000;
+    let num_keys: u32 = 40;
     let signer_stacks_private_keys = (0..num_signers)
         .map(|_| StacksPrivateKey::new())
         .collect::<Vec<StacksPrivateKey>>();


### PR DESCRIPTION
### Description
`wsts`, like many rust libraries, uses the `tracing` crate for logging.  This PR subscribes to the `tracing` logs using the default `RUST_LOG` environmental variable, which allows setting log levels on a per-module basis, in both the `stacks-signer` binary and the `signer::test_stackerdb_dkg` integration test.

### Applicable issues
- fixes #

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
